### PR TITLE
Call athenz instead of athens

### DIFF
--- a/docs/setup_ui.md
+++ b/docs/setup_ui.md
@@ -50,7 +50,7 @@ operation. From the `athenz-ui-X.Y` directory execute the following
 commands:
 
 ```shell
-$ cd var/athens_ui/keys
+$ cd var/athenz_ui/keys
 $ openssl genrsa -out ui_private.pem 2048
 $ openssl rsa -in ui_private.pem -pubout > ui_public.pem
 ```

--- a/docs/setup_ui_prod.md
+++ b/docs/setup_ui_prod.md
@@ -50,7 +50,7 @@ operation. From the `athenz-ui-X.Y` directory execute the following
 commands:
 
 ```shell
-$ cd var/athens_ui/keys
+$ cd var/athenz_ui/keys
 $ openssl genrsa -out ui_private.pem 2048
 $ openssl rsa -in ui_private.pem -pubout > ui_public.pem
 ```


### PR DESCRIPTION
Athenz UI seems not to be yet, but it's should be called athenz on docs probably.