### PR TITLE
use idiomatic full import paths, goimports ordering

### DIFF
--- a/clients/go/zms/Makefile
+++ b/clients/go/zms/Makefile
@@ -12,7 +12,6 @@ RDL_LIB=github.com/ardielle/ardielle-go/rdl
 
 # check to see if go utility is installed
 GO := $(shell command -v go 2> /dev/null)
-export GOPATH=$(PWD)
 
 ifdef GO
 

--- a/clients/go/zms/auth.go
+++ b/clients/go/zms/auth.go
@@ -5,9 +5,10 @@ package zms
 
 import (
 	"fmt"
-	"github.com/ardielle/ardielle-go/rdl"
 	"log"
 	"strings"
+
+	"github.com/ardielle/ardielle-go/rdl"
 )
 
 //

--- a/clients/go/zms/client.go
+++ b/clients/go/zms/client.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	rdl "github.com/ardielle/ardielle-go/rdl"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -16,6 +15,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	rdl "github.com/ardielle/ardielle-go/rdl"
 )
 
 var _ = json.Marshal
@@ -72,7 +73,7 @@ func (client ZMSClient) httpGet(url string, headers map[string]string) (*http.Re
 		return nil, err
 	}
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -87,7 +88,7 @@ func (client ZMSClient) httpDelete(url string, headers map[string]string) (*http
 		return nil, err
 	}
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -107,7 +108,7 @@ func (client ZMSClient) httpPut(url string, headers map[string]string, body []by
 	}
 	req.Header.Add("Content-type", "application/json")
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -127,7 +128,7 @@ func (client ZMSClient) httpPost(url string, headers map[string]string, body []b
 	}
 	req.Header.Add("Content-type", "application/json")
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -147,7 +148,7 @@ func (client ZMSClient) httpPatch(url string, headers map[string]string, body []
 	}
 	req.Header.Add("Content-type", "application/json")
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -169,7 +170,7 @@ func (client ZMSClient) httpOptions(url string, headers map[string]string, body 
 		req.Header.Add("Content-type", "application/json")
 	}
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}

--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -7,6 +7,7 @@ package zms
 import (
 	"encoding/json"
 	"fmt"
+
 	rdl "github.com/ardielle/ardielle-go/rdl"
 )
 

--- a/clients/go/zts/Makefile
+++ b/clients/go/zts/Makefile
@@ -12,7 +12,6 @@ RDL_LIB=github.com/ardielle/ardielle-go/rdl
 
 # check to see if go utility is installed
 GO := $(shell command -v go 2> /dev/null)
-export GOPATH=$(PWD)
 
 ifdef GO
 

--- a/clients/go/zts/client.go
+++ b/clients/go/zts/client.go
@@ -72,7 +72,7 @@ func (client ZTSClient) httpGet(url string, headers map[string]string) (*http.Re
 		return nil, err
 	}
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -87,7 +87,7 @@ func (client ZTSClient) httpDelete(url string, headers map[string]string) (*http
 		return nil, err
 	}
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -107,7 +107,7 @@ func (client ZTSClient) httpPut(url string, headers map[string]string, body []by
 	}
 	req.Header.Add("Content-type", "application/json")
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -127,7 +127,7 @@ func (client ZTSClient) httpPost(url string, headers map[string]string, body []b
 	}
 	req.Header.Add("Content-type", "application/json")
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -147,7 +147,7 @@ func (client ZTSClient) httpPatch(url string, headers map[string]string, body []
 	}
 	req.Header.Add("Content-type", "application/json")
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}
@@ -169,7 +169,7 @@ func (client ZTSClient) httpOptions(url string, headers map[string]string, body 
 		req.Header.Add("Content-type", "application/json")
 	}
 	client.addAuthHeader(req)
-    if headers != nil {
+	if headers != nil {
 		for k, v := range headers {
 			req.Header.Add(k, v)
 		}

--- a/libs/go/zmscli/access.go
+++ b/libs/go/zmscli/access.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"strings"
 
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func (cli Zms) ShowAccess(dn string, action string, resource string, altIdent *string, altDomain *string) (*string, error) {

--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 type Zms struct {

--- a/libs/go/zmscli/domain.go
+++ b/libs/go/zmscli/domain.go
@@ -11,7 +11,7 @@ import (
 	"strconv"
 	"strings"
 
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 	"gopkg.in/yaml.v2"
 )
 

--- a/libs/go/zmscli/dump.go
+++ b/libs/go/zmscli/dump.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 var (

--- a/libs/go/zmscli/entity.go
+++ b/libs/go/zmscli/entity.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/ardielle/ardielle-go/rdl"
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func (cli Zms) ShowEntity(dn string, en string) (*string, error) {

--- a/libs/go/zmscli/import.go
+++ b/libs/go/zmscli/import.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func (cli Zms) importRoles(dn string, lstRoles []interface{}, validatedAdmins []string, skipErrors bool) error {

--- a/libs/go/zmscli/policy.go
+++ b/libs/go/zmscli/policy.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/ardielle/ardielle-go/rdl"
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func (cli Zms) policyNames(dn string) ([]string, error) {

--- a/libs/go/zmscli/policy_test.go
+++ b/libs/go/zmscli/policy_test.go
@@ -6,7 +6,7 @@ package zmscli
 import (
 	"testing"
 
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func TestAssertionMatchTrue(t *testing.T) {

--- a/libs/go/zmscli/profile.go
+++ b/libs/go/zmscli/profile.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/ardielle/ardielle-go/rdl"
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 type Assertion []string

--- a/libs/go/zmscli/role.go
+++ b/libs/go/zmscli/role.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/ardielle/ardielle-go/rdl"
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func providerRoleName(provider, group, action string) string {

--- a/libs/go/zmscli/service.go
+++ b/libs/go/zmscli/service.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/ardielle/ardielle-go/rdl"
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func shortname(dn string, sn string) string {

--- a/libs/go/zmscli/template.go
+++ b/libs/go/zmscli/template.go
@@ -6,7 +6,7 @@ package zmscli
 import (
 	"bytes"
 
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func (cli Zms) ListServerTemplates() (*string, error) {

--- a/libs/go/zmscli/tenant.go
+++ b/libs/go/zmscli/tenant.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"strings"
 
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func (cli Zms) DeleteTenancy(dn string, provider string) (*string, error) {

--- a/libs/go/zmscli/utils.go
+++ b/libs/go/zmscli/utils.go
@@ -7,7 +7,7 @@ import (
 	"bufio"
 	"strings"
 
-	"../../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
 )
 
 func split(data []byte, atEOF bool) (advance int, token []byte, err error) {

--- a/utils/athenz_conf/Makefile
+++ b/utils/athenz_conf/Makefile
@@ -12,7 +12,6 @@ SRC=athenz-conf.go
 
 # check to see if go utility is installed
 GO := $(shell command -v go 2> /dev/null)
-export GOPATH=$(PWD)
 
 ifdef GO
 

--- a/utils/athenz_conf/athenz-conf.go
+++ b/utils/athenz_conf/athenz-conf.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"golang.org/x/crypto/ssh/terminal"
-	"golang.org/x/net/proxy"
 	"io/ioutil"
 	"log"
 	"net"
@@ -19,7 +17,9 @@ import (
 	"syscall"
 	"time"
 
-	"../../clients/go/zms"
+	"github.com/yahoo/athenz/clients/go/zms"
+	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/net/proxy"
 )
 
 //these get set by the build script via the LDFLAGS

--- a/utils/zms_cli/Makefile
+++ b/utils/zms_cli/Makefile
@@ -12,7 +12,6 @@ SRC=zms-cli.go
 
 # check to see if go utility is installed
 GO := $(shell command -v go 2> /dev/null)
-export GOPATH=$(PWD)
 
 ifdef GO
 

--- a/utils/zms_cli/zms-cli.go
+++ b/utils/zms_cli/zms-cli.go
@@ -8,8 +8,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"golang.org/x/crypto/ssh/terminal"
-	"golang.org/x/net/proxy"
 	"io/ioutil"
 	"log"
 	"net"
@@ -19,8 +17,10 @@ import (
 	"syscall"
 	"time"
 
-	"../../clients/go/zms"
-	"../../libs/go/zmscli"
+	"github.com/yahoo/athenz/clients/go/zms"
+	"github.com/yahoo/athenz/libs/go/zmscli"
+	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/net/proxy"
 )
 
 //these get set by the build script via the LDFLAGS


### PR DESCRIPTION
I would suggest to use the absolute import paths - I think it would be more Go-idiomatic and would allow to do `go get github.com/yahoo/athenz/...` at once without having to resort to running `make`.  It would also allow to browse the API docs in godoc.org and avoid the current error on https://godoc.org/github.com/yahoo/athenz/utils/zms_cli:
```
The go get command cannot install this package because of the following issues:

Unrecognized import path "../../clients/go/zms" (zms-cli.go:22:2)
Unrecognized import path "../../libs/go/zmscli" (zms-cli.go:23:2)
```

I also propose to switch to the goimports [1] convention of ordering the imports (in blocks, first stdlib, then third-party ones) to avoid spurious diffs when someone who uses goimports (which is quite popular) would save the source code.

[1] https://godoc.org/golang.org/x/tools/cmd/goimports