### PR TITLE
Fix assemble project to include dependencies.

### DIFF
--- a/assembly/components/zms.xml
+++ b/assembly/components/zms.xml
@@ -36,10 +36,6 @@
       </includes>
     </fileSet>
     <fileSet>
-      <directory>${basedir}/../servers/zms/target/dependency</directory>
-      <outputDirectory>lib/jars</outputDirectory>
-    </fileSet>
-    <fileSet>
       <directory>${basedir}/../utils/zms_cli/target</directory>
       <outputDirectory>bin</outputDirectory>
     </fileSet>
@@ -81,15 +77,23 @@
       <fileMode>644</fileMode>
     </file>
   </files>
-  <dependencySets>
-    <dependencySet>
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>false</useAllReactorProjects>
       <includes>
         <include>com.yahoo.athenz:zms_server</include>
       </includes>
-      <outputDirectory>lib/jars</outputDirectory>
-      <unpack>false</unpack>
-      <scope>runtime</scope>
-      <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
-  </dependencySets>
+      <binaries>
+        <outputDirectory>lib/jars</outputDirectory>
+        <unpack>false</unpack>
+        <includeDependencies>true</includeDependencies>
+        <dependencySets>
+          <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+          </dependencySet>
+        </dependencySets>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
 </assembly>

--- a/assembly/components/zpu.xml
+++ b/assembly/components/zpu.xml
@@ -80,15 +80,23 @@
       <fileMode>644</fileMode>
     </file>
   </files>
-  <dependencySets>
-    <dependencySet>
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>false</useAllReactorProjects>
       <includes>
         <include>com.yahoo.athenz:zpe_policy_updater</include>
       </includes>
-      <outputDirectory>lib/jars</outputDirectory>
-      <unpack>false</unpack>
-      <scope>runtime</scope>
-      <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
-  </dependencySets>
+      <binaries>
+        <outputDirectory>lib/jars</outputDirectory>
+        <unpack>false</unpack>
+        <includeDependencies>true</includeDependencies>
+        <dependencySets>
+          <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+          </dependencySet>
+        </dependencySets>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
 </assembly>

--- a/assembly/components/zts.xml
+++ b/assembly/components/zts.xml
@@ -81,15 +81,23 @@
       <fileMode>644</fileMode>
     </file>
   </files>
-  <dependencySets>
-    <dependencySet>
+  <moduleSets>
+    <moduleSet>
+      <useAllReactorProjects>false</useAllReactorProjects>
       <includes>
         <include>com.yahoo.athenz:zts_server</include>
       </includes>
-      <outputDirectory>lib/jars</outputDirectory>
-      <unpack>false</unpack>
-      <scope>runtime</scope>
-      <useProjectArtifact>false</useProjectArtifact>
-    </dependencySet>
-  </dependencySets>
+      <binaries>
+        <outputDirectory>lib/jars</outputDirectory>
+        <unpack>false</unpack>
+        <includeDependencies>true</includeDependencies>
+        <dependencySets>
+          <dependencySet>
+            <scope>runtime</scope>
+            <useProjectArtifact>false</useProjectArtifact>
+          </dependencySet>
+        </dependencySets>
+      </binaries>
+    </moduleSet>
+  </moduleSets>
 </assembly>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -26,26 +26,25 @@
   <name>assembly</name>
   <packaging>pom</packaging>
 
-  <dependencies>
-    <dependency>
-      <groupId>com.yahoo.athenz</groupId>
-      <artifactId>zms_server</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.athenz</groupId>
-      <artifactId>zts_server</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.yahoo.athenz</groupId>
-      <artifactId>zpe_policy_updater</artifactId>
-      <version>${project.parent.version}</version>
-    </dependency>
-  </dependencies>
+  <properties>
+    <maven.test.skip>true</maven.test.skip>
+  </properties>
 
+  <modules>
+    <module>../servers/zms</module>
+    <module>../servers/zts</module>
+    <module>../utils/zpe_policy_updater</module>
+  </modules>
+    
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.12.4</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <version>2.6</version>

--- a/docs/dev_environment.md
+++ b/docs/dev_environment.md
@@ -79,5 +79,5 @@ successfully:
 
 ```shell
 $ cd assembly
-$ mvn clean package
+$ mvn clean package -Dmaven.test.skip=true
 ```


### PR DESCRIPTION
Because v1.0 release packages doesn't have depending jar files, I couldn't setup athenz with released binary packages according to documents.
I fixed some assemble definitions to include dependencies.