### PR TITLE
Initialize variables in Authority initialize() method

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/PrincipalAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/PrincipalAuthority.java
@@ -53,7 +53,7 @@ public class PrincipalAuthority implements Authority, AuthorityKeyStore {
     private int allowedOffset = 300;
     IpCheckMode ipCheckMode = IpCheckMode.OPS_WRITE;
     String userDomain = USER_DOMAIN;
-    final String headerName = System.getProperty(ATHENZ_PROP_PRINCIPAL_HEADER, HTTP_HEADER);
+    String headerName = HTTP_HEADER;
     
     @Override
     public void initialize() {
@@ -61,6 +61,7 @@ public class PrincipalAuthority implements Authority, AuthorityKeyStore {
         allowedOffset = Integer.parseInt(System.getProperty(ATHENZ_PROP_TOKEN_OFFSET, "300"));
         ipCheckMode = IpCheckMode.valueOf(System.getProperty(ATHENZ_PROP_IP_CHECK_MODE, IpCheckMode.OPS_WRITE.toString()));
         userDomain = System.getProperty(ATHENZ_PROP_USER_DOMAIN, USER_DOMAIN);
+        headerName = System.getProperty(ATHENZ_PROP_PRINCIPAL_HEADER, HTTP_HEADER);
         
         // case of invalid value, we'll default back to 5 minutes
         

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/RoleAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/RoleAuthority.java
@@ -43,14 +43,15 @@ public class RoleAuthority implements Authority, AuthorityKeyStore {
 
     KeyStore keyStore = null;
     String userDomain = "user";
-    final String headerName = System.getProperty(ATHENZ_PROP_ROLE_HEADER, HTTP_HEADER);
+    String headerName = HTTP_HEADER;
     
     @Override
     public void initialize() {
         
         allowedOffset = Integer.parseInt(System.getProperty(ATHENZ_PROP_TOKEN_OFFSET, "300"));
         userDomain = System.getProperty(ATHENZ_PROP_USER_DOMAIN, USER_DOMAIN);
-        
+        headerName = System.getProperty(ATHENZ_PROP_ROLE_HEADER, HTTP_HEADER);
+
         // case of invalid value, we'll default back to 5 minutes
         
         if (allowedOffset < 0) {

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/UserAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/UserAuthority.java
@@ -36,7 +36,7 @@ public class UserAuthority implements Authority {
     private static final Logger LOG = LoggerFactory.getLogger(UserAuthority.class);
     static final String ATHENZ_PROP_PAM_SERVICE_NAME = "athenz.auth.user.pam_service_name";
 
-    final String serviceName = System.getProperty(ATHENZ_PROP_PAM_SERVICE_NAME, "login");
+    String serviceName = "login";
     private PAM pam = null;
     
     public UserAuthority() {
@@ -44,6 +44,7 @@ public class UserAuthority implements Authority {
 
     @Override
     public void initialize() {
+        serviceName = System.getProperty(ATHENZ_PROP_PAM_SERVICE_NAME, "login");
     }
 
     @Override


### PR DESCRIPTION
Since properties are set when the server is running, we want to initialize our variables within the initialize calls to make sure the properties has been set.