### PR TITLE
Verify we got proper certs back from HttpCertSigner

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/HttpCertSigner.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/HttpCertSigner.java
@@ -280,9 +280,11 @@ public class HttpCertSigner implements CertSigner {
             return null;
         }
         
-        for (SSHCertificate sshCert : sshCerts.getCerts()) {
-            if (sshCert.getType().equals(type)) {
-                return sshCert.toString();
+        if (sshCerts != null && sshCerts.getCerts() != null) {
+            for (SSHCertificate sshCert : sshCerts.getCerts()) {
+                if (sshCert.getType().equals(type)) {
+                    return sshCert.toString();
+                }
             }
         }
         


### PR DESCRIPTION
Possible that HttpCertSigner does not support ssh certificates thus it will return null so we need to make sure to handle that case correctly.