### PR TITLE
Setting and timout/retry handling for x509 certs

### DIFF
--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -74,9 +74,28 @@ athenz.zts.self_signer_private_key_fname=${ROOT}/var/zts_server/keys/zts_private
 #athenz.zts.self_signer_cert_dn=cn=Self Signed Athenz CA,o=Athenz,c=US
 
 # HttpCertSignerFactory implementation - if this factory class is used
-# for the for the CertSigner implementation (athenz.zts.cert_signer_factory_class
+# for the CertSigner implementation (athenz.zts.cert_signer_factory_class
 # property), this setting specifies the base uri for the Certificate Signer Service
 #athenz.zts.certsign_base_uri=
+
+# HttpCertSignerFactory implementation - if this factory class is used
+# for the CertSigner implementation (athenz.zts.cert_signer_factory_class
+# property), this setting specifies in seconds the connect timeout
+#athenz.zts.certsign_connect_timeout=10
+
+# HttpCertSignerFactory implementation - if this factory class is used
+# for the CertSigner implementation (athenz.zts.cert_signer_factory_class
+# property), this setting specifies in seconds the request timeout.
+# We're setting the initial value to a small on so we know right away
+# if our idle connection has been been closed by cert signer and we'll
+# use our retry setting to retry with a max timout of 30 seconds.
+#athenz.zts.certsign_request_timeout=5
+
+# HttpCertSignerFactory implementation - if this factory class is used
+# for the CertSigner implementation (athenz.zts.cert_signer_factory_class
+# property), this setting specifies the number of times the request
+# should be retried if it's not completed with the requested timeout value
+#athenz.zts.certsign_retry_count=3
 
 # Specifies the factory class that implements the Metrics interface
 # used by the ZTS Server to report stats


### PR DESCRIPTION
1. Expose cert signer timeout settings in zts.properties files
2. Set connection timeout for the http cert signer client and use request timeout/request retry logic when generating x509 certificates.