### PR TITLE
Support _domain_ in template role members

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -2005,7 +2005,12 @@ public class DBService {
         List<RoleMember> roleMembers = role.getRoleMembers();
         List<RoleMember> newMembers = new ArrayList<>();
         if (roleMembers != null && !roleMembers.isEmpty()) {
-            newMembers.addAll(roleMembers);
+            for (RoleMember roleMember : roleMembers) {
+                RoleMember newRoleMember = new RoleMember();
+                newRoleMember.setMemberName(roleMember.getMemberName().replace(TEMPLATE_DOMAIN_NAME, domainName));
+                newRoleMember.setExpiration(roleMember.getExpiration());
+                newMembers.add(newRoleMember);
+            }
         }
         templateRole.setRoleMembers(newMembers);
         return templateRole;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -484,16 +484,18 @@ public class DBServiceTest extends TestCase {
         List<RoleMember> members = new ArrayList<>();
         members.add(new RoleMember().setMemberName("user.user1"));
         members.add(new RoleMember().setMemberName("user.user2"));
+        members.add(new RoleMember().setMemberName("_domain_.user3"));
         role.setRoleMembers(members);
         
         Role newRole = zms.dbService.updateTemplateRole(role, "athenz", "readers");
         assertEquals("athenz:role.readers", newRole.getName());
         List<RoleMember> newMembers = newRole.getRoleMembers();
-        assertEquals(2, newMembers.size());
+        assertEquals(3, newMembers.size());
         
         List<String> checkList = new ArrayList<String>();
         checkList.add("user.user1");
         checkList.add("user.user2");
+        checkList.add("athenz.user3");
         checkRoleMember(checkList, newMembers);
     }
     


### PR DESCRIPTION
When defining templates, this change would allow support for _domain_ in template role members as well. E.g. with domain name sports and template including a member _domain_.reader would end up creating sports.reader as a member in the specified role.