### PR TITLE
Remove complete flag component from role token

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -1186,7 +1186,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
                 new com.yahoo.athenz.auth.token.RoleToken.Builder(ZTS_ROLE_TOKEN_VERSION, domainName, roles)
                     .expirationWindow(tokenTimeout).host(serverHostName).keyId(privateKeyId)
                     .principal(principal).ip(ServletRequestUtil.getRemoteAddress(ctx.request()))
-                    .proxyUser(proxyUser).domainCompleteRoleSet(roleName == null).build();
+                    .proxyUser(proxyUser).build();
         token.sign(privateKey);
 
         RoleToken roleToken = new RoleToken();

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -1543,7 +1543,6 @@ public class ZTSImplTest {
         assertTrue(roleToken.getToken().contains(";i=10.11.12.13"));
         assertTrue(roleToken.getToken().contains(";p=user_domain.joe;"));
         assertTrue(roleToken.getToken().contains(";proxy=user_domain.proxy-user1;"));
-        assertTrue(roleToken.getToken().contains(";c=1;"));
         assertEquals(roleToken.getExpiryTime(), token.getExpiryTime());
 
         principal = SimplePrincipal.create("user_domain", "proxy-user2",
@@ -1559,7 +1558,6 @@ public class ZTSImplTest {
         assertTrue(roleToken.getToken().contains(";i=10.11.12.13"));
         assertTrue(roleToken.getToken().contains(";p=user_domain.jane;"));
         assertTrue(roleToken.getToken().contains(";proxy=user_domain.proxy-user2;"));
-        assertTrue(roleToken.getToken().contains(";c=1;"));
         assertEquals(roleToken.getExpiryTime(), token.getExpiryTime());
     }
     


### PR DESCRIPTION
We're not using the complete role set component yet, so for now we're going to remove it from the token list and we'll consider re-adding it later when it becomes necessary.