### PR TITLE
Load pubkeys before initializing ZPE client to avoid null exception

### DIFF
--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/AuthZpeClient.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/AuthZpeClient.java
@@ -114,6 +114,20 @@ public class AuthZpeClient {
     
     static {
 
+        // load public keys
+
+        String pkeyFactoryClass = System.getProperty(ZpeConsts.ZPE_PROP_PUBLIC_KEY_CLASS, ZPE_PKEY_CLASS);
+
+        PublicKeyStoreFactory publicKeyStoreFactory = null;
+        try {
+            publicKeyStoreFactory = (PublicKeyStoreFactory) Class.forName(pkeyFactoryClass).newInstance();
+        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException ex) {
+            LOG.error("Invalid PublicKeyStore class: " + pkeyFactoryClass
+                    + ", error: " + ex.getMessage());
+            throw new RuntimeException(ex);
+        }
+        publicKeyStore = publicKeyStoreFactory.create();
+
         // instantiate implementation classes
         
         zpeClientImplName = System.getProperty(ZpeConsts.ZPE_PROP_CLIENT_IMPL, ZPE_UPDATER_CLASS);
@@ -133,18 +147,6 @@ public class AuthZpeClient {
         if (allowedOffset < 0) {
             allowedOffset = 300;
         }
-        
-        String pkeyFactoryClass = System.getProperty(ZpeConsts.ZPE_PROP_PUBLIC_KEY_CLASS, ZPE_PKEY_CLASS);
-
-        PublicKeyStoreFactory publicKeyStoreFactory = null;
-        try {
-            publicKeyStoreFactory = (PublicKeyStoreFactory) Class.forName(pkeyFactoryClass).newInstance();
-        } catch (InstantiationException | IllegalAccessException | ClassNotFoundException ex) {
-            LOG.error("Invalid PublicKeyStore class: " + pkeyFactoryClass
-                    + ", error: " + ex.getMessage());
-            throw new RuntimeException(ex);
-        }
-        publicKeyStore = publicKeyStoreFactory.create();
     }
     
     public static void init() {


### PR DESCRIPTION
■Issue
```
ERROR com.yahoo.athenz.zpe.ZpeUpdPolLoader - loadDb Failed, exc: null
```
is outputted at the initialization of `AuthZpeClient`.
It's not critical (authentication / authorization process after the initialization works) but annoying.

■Detail
1. In the initialization of `AuthZpeClient`, `ZpeUpdater` is [initialized](https://github.com/yahoo/athenz/blob/master/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/AuthZpeClient.java#L121).
2. In the initialization of `ZpeUpdater`, `ZpeUpdPolLoader` is [initialized](https://github.com/yahoo/athenz/blob/master/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdater.java#L53).
3. In the initialization of `ZpeUpdPolLoader`, `loadDb` is [called](https://github.com/yahoo/athenz/blob/master/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdPolLoader.java#L138)
4. `loadDb` [calls](https://github.com/yahoo/athenz/blob/master/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdPolLoader.java#L308) `loadFile`.
5. `loadFile` [calls](https://github.com/yahoo/athenz/blob/master/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdPolLoader.java#L368) `AuthZpeClient#getZtsPublicKey`. However, since the public keys have not been loaded yet, null exception is thrown and caught [here](https://github.com/yahoo/athenz/blob/master/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdPolLoader.java#L139-L141). As a result, the error log described above is outputted.

■Modification
I just reordered the statements to load the public keys before initializing ZPE client.