### PR TITLE
Retrieving signed domains from ZMS one at a time

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
@@ -254,7 +254,7 @@ public class DataStore implements DataCacheProvider {
         }
         
         if (!result) {
-            LOGGER.error("Invalid local domain: " + domainName + ". Full refresh from ZMS required.");
+            LOGGER.error("Invalid local domain: " + domainName + ". Refresh from ZMS required.");
         }
         
         return result;


### PR DESCRIPTION
Originally ZMS change log class would pick up the initial changes (e.g. new installation) all at once in one call. However, in production, where we might have 5-10K domains, the data size becomes too big to collect, sign and quite often the client times out waiting for data. So instead, the implementation has been changed to get the domain list first, and iterate through the list and request one domain at a time.