### PR TITLE
Support role member with partial wildcards e.g. athenz.service*

### DIFF
--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -74,7 +74,7 @@ type YEncoded string
 
 //
 // AuthorityName - Used as the prefix in a signed assertion. This uniquely
-// identifies a signing authority. i.e. "user"
+// identifies a signing authority.
 //
 type AuthorityName string
 
@@ -89,8 +89,8 @@ type AuthorityName string
 type SignedToken string
 
 //
-// MemberName - Role Member name - could be one of three values, either *,
-// DomainName.* or ResourceName
+// MemberName - Role Member name - could be one of three values: *,
+// DomainName.* or ResourceName[*]
 //
 type MemberName string
 

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -67,7 +67,7 @@ func init() {
 	sb.AddType(tYEncoded.Build())
 
 	tAuthorityName := rdl.NewStringTypeBuilder("AuthorityName")
-	tAuthorityName.Comment("Used as the prefix in a signed assertion. This uniquely identifies a signing authority. i.e. \"user\"")
+	tAuthorityName.Comment("Used as the prefix in a signed assertion. This uniquely identifies a signing authority.")
 	tAuthorityName.Pattern("([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*")
 	sb.AddType(tAuthorityName.Build())
 
@@ -77,8 +77,8 @@ func init() {
 	sb.AddType(tSignedToken.Build())
 
 	tMemberName := rdl.NewStringTypeBuilder("MemberName")
-	tMemberName.Comment("Role Member name - could be one of three values, either *, DomainName.* or ResourceName")
-	tMemberName.Pattern("\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*(:([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*)?")
+	tMemberName.Comment("Role Member name - could be one of three values: *, DomainName.* or ResourceName[*]")
+	tMemberName.Pattern("\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*(:([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*)?(\\*)?")
 	sb.AddType(tMemberName.Build())
 
 	tDomain := rdl.NewStructTypeBuilder("Struct", "Domain")

--- a/core/zms/src/main/java/com/yahoo/athenz/provider/ProviderSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/provider/ProviderSchema.java
@@ -59,7 +59,7 @@ public class ProviderSchema {
             .pattern("[a-zA-Z0-9\\._%=-]*");
 
         sb.stringType("AuthorityName")
-            .comment("Used as the prefix in a signed assertion. This uniquely identifies a signing authority. i.e. \"user\"")
+            .comment("Used as the prefix in a signed assertion. This uniquely identifies a signing authority.")
             .pattern("([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*");
 
         sb.stringType("SignedToken")
@@ -67,8 +67,8 @@ public class ProviderSchema {
             .pattern("[a-zA-Z0-9\\._%=:;,-]*");
 
         sb.stringType("MemberName")
-            .comment("Role Member name - could be one of three values, either *, DomainName.* or ResourceName")
-            .pattern("\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*(:([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*)?");
+            .comment("Role Member name - could be one of three values: *, DomainName.* or ResourceName[*]")
+            .pattern("\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*(:([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*)?(\\*)?");
 
         sb.enumType("TenantState")
             .element("INACTIVE")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -59,7 +59,7 @@ public class ZMSSchema {
             .pattern("[a-zA-Z0-9\\._%=-]*");
 
         sb.stringType("AuthorityName")
-            .comment("Used as the prefix in a signed assertion. This uniquely identifies a signing authority. i.e. \"user\"")
+            .comment("Used as the prefix in a signed assertion. This uniquely identifies a signing authority.")
             .pattern("([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*");
 
         sb.stringType("SignedToken")
@@ -67,8 +67,8 @@ public class ZMSSchema {
             .pattern("[a-zA-Z0-9\\._%=:;,-]*");
 
         sb.stringType("MemberName")
-            .comment("Role Member name - could be one of three values, either *, DomainName.* or ResourceName")
-            .pattern("\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*(:([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*)?");
+            .comment("Role Member name - could be one of three values: *, DomainName.* or ResourceName[*]")
+            .pattern("\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*\\.\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*(:([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*)?(\\*)?");
 
         sb.structType("Domain")
             .comment("A domain is an independent partition of users, roles, and resources. Its name represents the definition of a namespace; the only way a new namespace can be created, from the top, is by creating Domains. Administration of a domain is governed by the parent domain (using reverse-DNS namespaces). The top level domains are governed by the special \"sys.auth\" domain.")

--- a/core/zms/src/main/rdl/Names.tdl
+++ b/core/zms/src/main/rdl/Names.tdl
@@ -53,6 +53,6 @@ type AuthorityName String (pattern="{CompoundName}"); //i.e. "user"
 //and , to separate roles and : for IPv6 addresses
 type SignedToken String (pattern="[a-zA-Z0-9\\._%=:;,-]*");
 
-//Role Member name - could be one of three values, either *,
-//DomainName.* or ResourceName
-type MemberName String (pattern="\\*|{DomainName}\\.\\*|{ResourceName}");
+//Role Member name - could be one of three values: *,
+//DomainName.* or ResourceName[*]
+type MemberName String (pattern="\\*|{DomainName}\\.\\*|{ResourceName}(\\*)?");

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
@@ -1429,6 +1429,8 @@ public class ZMSCoreTest {
                 "athenz.storage.test-test",
                 "user.3sets",
                 "athenz.great-service",
+                "athenz.great-service*",
+                "test.joe*",
                 "*"
         };
 
@@ -1443,8 +1445,8 @@ public class ZMSCoreTest {
         String[] badMemberNames = {
                 "user.*joe",
                 "*test",
-                "test.joe*",
-                "user.joe*test"
+                "user.joe*test",
+                "test.joe**"
         };
 
         for (String s : badMemberNames) {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -2367,10 +2367,10 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
     boolean memberNameMatch(String memberName, String matchName) {
         // we are supporting 3 formats for role members
-        // *, <domain>.* and <domain>.<user>
+        // *, <domain>.* and <domain>.<user>*
         if (memberName.equals("*")) {
             return true;
-        } else if (memberName.endsWith(".*")) {
+        } else if (memberName.endsWith("*")) {
             return matchName.startsWith(memberName.substring(0, memberName.length() - 1));
         } else {
             return memberName.equals(matchName);

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -14286,10 +14286,15 @@ public class ZMSImplTest extends TestCase {
         assertTrue(zms.memberNameMatch("*", "athenz.service.storage"));
         assertTrue(zms.memberNameMatch("user.*", "user.joe"));
         assertTrue(zms.memberNameMatch("athenz.*", "athenz.service.storage"));
+        assertTrue(zms.memberNameMatch("athenz.service*", "athenz.service.storage"));
+        assertTrue(zms.memberNameMatch("athenz.service*", "athenz.service-storage"));
+        assertTrue(zms.memberNameMatch("athenz.service*", "athenz.service"));
         assertTrue(zms.memberNameMatch("user.joe", "user.joe"));
         
         assertFalse(zms.memberNameMatch("user.*", "athenz.joe"));
         assertFalse(zms.memberNameMatch("athenz.*", "athenztest.joe"));
+        assertFalse(zms.memberNameMatch("athenz.service*", "athenz.servic"));
+        assertFalse(zms.memberNameMatch("athenz.service*", "athenz.servictag"));
         assertFalse(zms.memberNameMatch("user.joe", "user.joel"));
     }
 }


### PR DESCRIPTION
for role members, zms supports * and domain.* formats for wildcard support. however, it would also be useful to support domain.service* formats in case you have domain.service-one, domain.service-two, etc that you may dynamically create and manage and you don't have to keep updating the role membership. this PR addresses this request.