### PR TITLE
Use latest AWS java sdk and simply get object class

### DIFF
--- a/servers/zts/pom.xml
+++ b/servers/zts/pom.xml
@@ -32,7 +32,7 @@
       <dependency>
         <groupId>com.amazonaws</groupId>
         <artifactId>aws-java-sdk-bom</artifactId>
-        <version>1.10.67</version>
+        <version>1.11.135</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreConnectionTest.java
@@ -26,11 +26,11 @@ import java.sql.Statement;
 import java.sql.Timestamp;
 import java.util.Date;
 
-import org.junit.Before;
 import org.mockito.Matchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.yahoo.athenz.common.server.db.PoolableDataSource;
@@ -50,7 +50,7 @@ public class JDBCCertRecordStoreConnectionTest extends TestCase {
     
     JDBCCertRecordStore strStore;
     
-    @Before
+    @BeforeMethod
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         Mockito.doReturn(mockConn).when(mockDataSrc).getConnection();

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/S3ChangeLogStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/S3ChangeLogStoreTest.java
@@ -351,7 +351,7 @@ public class S3ChangeLogStoreTest {
         S3Object object = mock(S3Object.class);
         when(object.getObjectContent()).thenReturn(s3Is);
 
-        when(store.s3.getObject(any(GetObjectRequest.class))).thenReturn(object);
+        when(store.s3.getObject("athenz-domain-sys.auth", "iaas")).thenReturn(object);
         
         SignedDomain signedDomain = store.getSignedDomain(store.s3, "iaas");
         assertNotNull(signedDomain);
@@ -371,7 +371,7 @@ public class S3ChangeLogStoreTest {
         S3Object object = mock(S3Object.class);
         when(object.getObjectContent()).thenReturn(s3Is);
 
-        when(store.s3.getObject(any(GetObjectRequest.class))).thenReturn(object);
+        when(store.s3.getObject("athenz-domain-sys.auth", "iaas")).thenReturn(object);
         
         SignedDomain signedDomain = store.getSignedDomain("iaas");
         assertNotNull(signedDomain);
@@ -436,7 +436,8 @@ public class S3ChangeLogStoreTest {
         S3Object object = mock(S3Object.class);
         when(object.getObjectContent()).thenReturn(s3Is);
 
-        when(store.s3.getObject(any(GetObjectRequest.class))).thenReturn(object);
+        when(store.s3.getObject("athenz-domain-sys.auth", "iaas")).thenReturn(object);
+        when(store.s3.getObject("athenz-domain-sys.auth", "iaas.athenz")).thenReturn(object);
         
         // set the last modification time to return one of the domains
         store.lastModTime = (new Date(150)).getTime();


### PR DESCRIPTION
Update to the latest AWS java sdk 1.11.135

When getting an object from S3, use the guava ByteStreams class to get the data from S3ObjectInputStream instance. Also use try-with-resources so the S3ObjectInputStream is automatically closed when the data is retrieved.