### PR TITLE
Add support for user (disable/enable/list) support in zms-cli

### DIFF
--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -230,6 +230,22 @@ func (cli *Zms) EvalCommand(params []string) (*string, error) {
 			if argc == 2 {
 				return cli.ShowResourceAccess(args[0], args[1])
 			}
+		case "list-user":
+			return cli.ListUsers()
+		case "delete-user":
+			if argc == 1 {
+				return cli.DeleteUser(args[0])
+			}
+		case "enable-user":
+			state := true
+			if argc == 1 {
+				return cli.UpdateUserState(args[0], &state)
+			}
+		case "disable-user":
+			state := false
+			if argc == 1 {
+				return cli.UpdateUserState(args[0], &state)
+			}
 		case "help":
 			return cli.helpCommand(args)
 		default:
@@ -1436,6 +1452,32 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   template   : name of the template to be deleted from the domain\n")
 		buf.WriteString(" examples:\n")
 		buf.WriteString("   " + domain_example + " delete-domain-template vipng\n")
+	case "list-user":
+		buf.WriteString(" syntax:\n")
+		buf.WriteString("   list-user\n")
+		buf.WriteString(" examples:\n")
+		buf.WriteString("   list-user\n")
+	case "delete-user":
+		buf.WriteString(" syntax:\n")
+		buf.WriteString("   delete-user user\n")
+		buf.WriteString(" parameters:\n")
+		buf.WriteString("   user   : id of the user to be deleted\n")
+		buf.WriteString(" examples:\n")
+		buf.WriteString("   delete-user jdoe\n")
+	case "enable-user":
+		buf.WriteString(" syntax:\n")
+		buf.WriteString("   enable-user user\n")
+		buf.WriteString(" parameters:\n")
+		buf.WriteString("   user   : id of the user to be enabled\n")
+		buf.WriteString(" examples:\n")
+		buf.WriteString("   enable-user jdoe\n")
+	case "disable-user":
+		buf.WriteString(" syntax:\n")
+		buf.WriteString("   disable-user user\n")
+		buf.WriteString(" parameters:\n")
+		buf.WriteString("   user   : id of the user to be disabled\n")
+		buf.WriteString(" examples:\n")
+		buf.WriteString("   disable-user jdoe\n")
 	default:
 		if interactive {
 			buf.WriteString("Unknown command. Type 'help' to see available commands")
@@ -1463,7 +1505,6 @@ func (cli Zms) HelpListCommand() string {
 	buf.WriteString("   export-domain domain [file.yaml] - no file means stdout\n")
 	buf.WriteString("   update-domain domain [file.yaml] - no file means stdin\n")
 	buf.WriteString("   delete-domain domain\n")
-	buf.WriteString("   set-default-admins domain admin [admin ...] (for system administrators only)\n")
 	buf.WriteString("   get-signed-domains [matching_tag]\n")
 	buf.WriteString("   use-domain [domain]\n")
 	buf.WriteString("   check-domain [domain]\n")
@@ -1536,6 +1577,13 @@ func (cli Zms) HelpListCommand() string {
 	buf.WriteString("   show-server-template template\n")
 	buf.WriteString("   set-domain-template template [template]\n")
 	buf.WriteString("   delete-domain-template template\n")
+	buf.WriteString("\n")
+	buf.WriteString(" System Administrator commands:\n")
+	buf.WriteString("   set-default-admins domain admin [admin ...]\n")
+	buf.WriteString("   list-user\n")
+	buf.WriteString("   enable-user user\n")
+	buf.WriteString("   disable-user user\n")
+	buf.WriteString("   delete-user user\n")
 	buf.WriteString("\n")
 	buf.WriteString(" Other commands:\n")
 	buf.WriteString("   get-user-token [authorized_service]\n")

--- a/libs/go/zmscli/user.go
+++ b/libs/go/zmscli/user.go
@@ -1,0 +1,46 @@
+// Copyright 2017 Yahoo Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+
+package zmscli
+
+import (
+	"bytes"
+	"strconv"
+
+	"github.com/yahoo/athenz/clients/go/zms"
+)
+
+func (cli Zms) ListUsers() (*string, error) {
+	var buf bytes.Buffer
+	users, err := cli.Zms.GetUserList()
+	if err != nil {
+		return nil, err
+	}
+	buf.WriteString("users:\n")
+	for _, item := range users.Names {
+		buf.WriteString("    - " + string(item) + "\n")
+	}
+	s := buf.String()
+	return &s, nil
+}
+
+func (cli Zms) DeleteUser(user string) (*string, error) {
+	err := cli.Zms.DeleteUser(zms.SimpleName(user))
+	if err != nil {
+		return nil, err
+	}
+	s := "[Deleted user: " + user + "]"
+	return &s, nil
+}
+
+func (cli Zms) UpdateUserState(user string, state *bool) (*string, error) {
+	meta := zms.UserMeta{
+		Enabled: state,
+	}
+	err := cli.Zms.PutUserMeta(zms.SimpleName(user), &meta)
+	if err != nil {
+		return nil, err
+	}
+	s := "[Updated user: " + user + " state: " + strconv.FormatBool(*state) + "]"
+	return &s, nil
+}

--- a/libs/go/zmssvctoken/token_test.go
+++ b/libs/go/zmssvctoken/token_test.go
@@ -209,3 +209,17 @@ func TestBadVerifier(t *testing.T) {
 	require.NotNil(t, err)
 	require.Equal(t, "Unable to create verifier: Unable to load public key", err.Error())
 }
+
+func TestMultipleTokenCallsOnBuilder(t *testing.T) {
+	a := assert.New(t)
+	tb, err := NewTokenBuilder("domain", "service", rsaPrivateKeyPEM, "v1")
+	require.Nil(t, err)
+	tok1 := tb.Token()
+	tok2 := tb.Token()
+	s1, err := tok1.Value()
+	a.Nil(err)
+	a.NotEmpty(s1)
+	s2, err := tok2.Value()
+	a.Nil(err)
+	a.NotEmpty(s2)
+}


### PR DESCRIPTION
zms-cli has been updated to support 4 new user commands:

list-user -> list all registered user principals in Athens system
delete-user -> delete all personal domains and subdomains for this user (e.g. user.joe, user.joe.qa, etc) and remove user from all roles in the system
disable-user -> mark all the personal domains and subdomains for this user (e.g. user.joe, user.joe.qa, etc) as disabled
enable-user -> mark all the personal domains and subdomains for this user (e.g. user.joe, user.joe.qa, etc) as enabled