### PR TITLE
Additional constructors for zms/zts clients

### DIFF
--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
@@ -57,14 +57,14 @@ public class ZMSClient implements Closeable {
     private static final Authority PRINCIPAL_AUTHORITY = new com.yahoo.athenz.auth.impl.PrincipalAuthority();
     
     /**
-     * Constructs a new ZMSClient object with media type set to application/json.
-     * The url for ZMS Server is automatically retrieved from the athenz_config
-     * package's configuration file (zms_url field). The client can only be used
+     * Constructs a new ZMSClient object with default settings.
+     * The url for ZMS Server is automatically retrieved from the athenz
+     * configuration file (zmsUrl field). The client can only be used
      * to retrieve objects from ZMS that do not require any authentication
      * otherwise addCredentials method must be used to set the principal identity.
      * Default read and connect timeout values are 30000ms (30sec). The application can
-     * change these values by using the yahoo.zms_java_client.read_timeout and
-     * yahoo.zms_java_client.connect_timeout system properties. The values specified
+     * change these values by using the athenz.zms.client.read_timeout and
+     * athenz.zms.client.connect_timeout system properties. The values specified
      * for timeouts must be in milliseconds.
      */
     public ZMSClient() {
@@ -72,18 +72,49 @@ public class ZMSClient implements Closeable {
     }
     
     /**
-     * Constructs a new ZMSClient object with the given ZMS Server url and
-     * media type set to application/json. The client can only be used
-     * to retrieve objects from ZMS that do not require any authentication
+     * Constructs a new ZMSClient object with the given ZMS Server url. The client
+     * can only be used to retrieve objects from ZMS that do not require any authentication
      * otherwise addCredentials method must be used to set the principal identity.
      * Default read and connect timeout values are 30000ms (30sec). The application can
-     * change these values by using the yahoo.zms_java_client.read_timeout and
-     * yahoo.zms_java_client.connect_timeout system properties. The values specified
+     * change these values by using the athenz.zms.client.read_timeout and
+     * athenz.zms.client.connect_timeout system properties. The values specified
      * for timeouts must be in milliseconds.
      * @param url ZMS Server url (e.g. https://server1.athenzcompany.com:4443/zms/v1)
      */
     public ZMSClient(String url) {
         initClient(url);
+    }
+    
+    /**
+     * Constructs a new ZMSClient object with the given ZMS Server url and
+     * given principal. The credentials from the principal object will be used
+     * to set call the addCredentials method for the zms client object.
+     * Default read and connect timeout values are 30000ms (30sec). The application can
+     * change these values by using the athenz.zms.client.read_timeout and
+     * athenz.zms.client.connect_timeout system properties. The values specified
+     * for timeouts must be in milliseconds.
+     * @param url ZMS Server url (e.g. https://server1.athenzcompany.com:4443/zms/v1)
+     * @param identity Principal object that includes credentials
+     */
+    public ZMSClient(String url, Principal identity) {
+        initClient(url);
+        addCredentials(identity);
+    }
+    
+    /**
+     * Constructs a new ZMSClient object with default settings and given
+     * principal object for credentials. The url for ZMS Server is
+     * automatically retrieved from the athenz configuration file
+     * (zmsUrl field).
+     * Default read and connect timeout values are 30000ms (30sec). The application can
+     * change these values by using the athenz.zms.client.read_timeout and
+     * athenz.zms.client.connect_timeout system properties. The values specified
+     * for timeouts must be in milliseconds.
+     * @param identity Principal object that includes credentials
+     */
+    public ZMSClient(Principal identity) {
+        initClient(null);
+        addCredentials(identity);
     }
     
     /**

--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -140,16 +140,33 @@ public class ZTSClient implements Closeable {
     }
     
     /**
+     * Constructs a new ZTSClient object with default settings.
+     * The url for ZTS Server is automatically retrieved from the athenz
+     * configuration file (ztsUrl field). The client can only be used
+     * to retrieve objects from ZTS that do not require any authentication
+     * otherwise addCredentials method must be used to set the principal identity.
+     * Default read and connect timeout values are 30000ms (30sec).
+     * The application can change these values by using the
+     * athenz.zts.client.read_timeout and athenz.zts.client.connect_timeout
+     * system properties. The values specified for timeouts must be in
+     * milliseconds.
+     */
+    public ZTSClient() {
+        initClient(null, null, null, null, null);
+        enablePrefetch = false; // can't use this domain and service for prefetch
+    }
+    
+    /**
      * Constructs a new ZTSClient object with the given ZTS Server Url.
      * If the specified zts url is null, then it is automatically
      * retrieved from athenz.conf configuration file (ztsUrl field).
      * Default read and connect timeout values are 30000ms (30sec).
      * The application can change these values by using the
-     * athenz.zts.client.read_timeout and athenz.zts.client.connct_timeout
+     * athenz.zts.client.read_timeout and athenz.zts.client.connect_timeout
      * system properties. The values specified for timeouts must be in
      * milliseconds. This client object can only be used for API calls
      * that require no authentication or setting the principal using
-     * addCredentials method before calling any other athentication
+     * addCredentials method before calling any other authentication
      * protected API.
      * @param ztsUrl ZTS Server's URL (optional)
      */
@@ -159,12 +176,23 @@ public class ZTSClient implements Closeable {
     }
     
     /**
+     * Constructs a new ZTSClient object with the given principal identity.
+     * The url for ZTS Server is automatically retrieved from the athenz
+     * configuration file (ztsUrl field). Default read and connect timeout values
+     * are 30000ms (30sec). The application can change these values by using the
+     * athenz.zts.client.read_timeout and athenz.zts.client.connect_timeout
+     * system properties. The values specified for timeouts must be in milliseconds.
+     * @param identity Principal identity for authenticating requests
+     */
+    public ZTSClient(Principal identity) {
+        this(null, identity);
+    }
+    
+    /**
      * Constructs a new ZTSClient object with the given principal identity
-     * and ZTS Server Url. If the specified zts url is null, then it is
-     * automatically retrieved from athenz.conf configuration file
-     * (ztsUrl field). Default read and connect timeout values are
+     * and ZTS Server Url. Default read and connect timeout values are
      * 30000ms (30sec). The application can change these values by using the
-     * athenz.zts.client.read_timeout and athenz.zts.client.connct_timeout
+     * athenz.zts.client.read_timeout and athenz.zts.client.connect_timeout
      * system properties. The values specified for timeouts must be in milliseconds.
      * @param ztsUrl ZTS Server's URL (optional)
      * @param identity Principal identity for authenticating requests
@@ -186,11 +214,27 @@ public class ZTSClient implements Closeable {
     /**
      * Constructs a new ZTSClient object with the given service details
      * identity provider (which will provide the ntoken for the service)
+     * The ZTS Server url is automatically retrieved from athenz.conf configuration
+     * file (ztsUrl field). Default read and connect timeout values are
+     * 30000ms (30sec). The application can change these values by using the
+     * athenz.zts.client.read_timeout and athenz.zts.client.connect_timeout
+     * system properties. The values specified for timeouts must be in milliseconds.
+     * @param domainName name of the domain
+     * @param serviceName name of the service
+     * @param siaProvider service identity provider for the client to request principals
+     */
+    public ZTSClient(String domainName, String serviceName, ServiceIdentityProvider siaProvider) {
+        this(null, domainName, serviceName, siaProvider);
+    }
+    
+    /**
+     * Constructs a new ZTSClient object with the given service details
+     * identity provider (which will provide the ntoken for the service)
      * and ZTS Server Url. If the specified zts url is null, then it is
      * automatically retrieved from athenz.conf configuration file
      * (ztsUrl field). Default read and connect timeout values are
      * 30000ms (30sec). The application can change these values by using the
-     * athenz.zts.client.read_timeout and athenz.zts.client.connct_timeout
+     * athenz.zts.client.read_timeout and athenz.zts.client.connect_timeout
      * system properties. The values specified for timeouts must be in milliseconds.
      * @param ztsUrl ZTS Server's URL (optional)
      * @param domainName name of the domain

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/SimpleServiceIdentityProvider.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/SimpleServiceIdentityProvider.java
@@ -59,6 +59,23 @@ public class SimpleServiceIdentityProvider implements ServiceIdentityProvider {
         this.setHost(getServerHostName());
     }
     
+    /**
+     * A simple implementation of the ServiceIdentityProvider interface.
+     * The caller specifies the domain and service name along with the
+     * private key for the given service
+     * @param domainName Name of the domain
+     * @param serviceName Name of the service
+     * @param privateKey the private key for the service
+     * @param keyId the registered key id in ZMS for this private key
+     * @param tokenTimeout how long in seconds the generated ntoken is valid for
+     */
+    public SimpleServiceIdentityProvider(String domainName, String serviceName,
+            PrivateKey privateKey, String keyId, long tokenTimeout) {
+
+        this(domainName, serviceName, privateKey, keyId);
+        this.tokenTimeout = tokenTimeout;
+    }
+    
     public Principal getIdentity(String domainName, String serviceName) {
         
         // all the role members in Athenz are normalized to lower case so we need to make

--- a/utils/zpe_policy_updater/src/main/java/com/yahoo/athenz/zpe_policy_updater/ZTSClientFactoryImpl.java
+++ b/utils/zpe_policy_updater/src/main/java/com/yahoo/athenz/zpe_policy_updater/ZTSClientFactoryImpl.java
@@ -21,6 +21,6 @@ public class ZTSClientFactoryImpl implements ZTSClientFactory {
 
     @Override
     public ZTSClient create() {
-        return new ZTSClient(null);
+        return new ZTSClient();
     }
 }


### PR DESCRIPTION
additional constructors for ZMSClient and ZTSClient objects in order to avoid asking the developers to pass nulls when using athenz configuration file to extract the server urls