### PR TITLE
make signer/verifier + ybase64 support public

### DIFF
--- a/libs/go/zmssvctoken/keystore.go
+++ b/libs/go/zmssvctoken/keystore.go
@@ -72,7 +72,7 @@ func (k *keyStore) loadKey(src keySource) ([]byte, error) {
 		return nil, err
 	}
 
-	s, err := new(yBase64).DecodeString(data.Key)
+	s, err := new(YBase64).DecodeString(data.Key)
 	if err != nil {
 		return nil, err
 	}

--- a/libs/go/zmssvctoken/signer_test.go
+++ b/libs/go/zmssvctoken/signer_test.go
@@ -64,31 +64,31 @@ awIDAQAB
 -----END PUBLIC KEY-----
 `)
 
-func testSV(t *testing.T, s signer, v verifier) {
+func testSV(t *testing.T, s Signer, v Verifier) {
 	input := `
 Now is the time
 for all good men
 to come to the aid of the party
 `
-	sig, err := s.sign(input)
+	sig, err := s.Sign(input)
 	require.Nil(t, err)
-	err = v.verify(input, sig)
+	err = v.Verify(input, sig)
 	require.Nil(t, err)
 	input += "X"
-	err = v.verify(input, sig)
+	err = v.Verify(input, sig)
 	require.NotNil(t, err)
 }
 
 func TestRSASigner(t *testing.T) {
-	signer, err := newSigner(rsaPrivateKeyPEM)
+	signer, err := NewSigner(rsaPrivateKeyPEM)
 	require.Nil(t, err)
-	verifier, err := newVerifier(rsaPublicKeyPEM)
+	verifier, err := NewVerifier(rsaPublicKeyPEM)
 	testSV(t, signer, verifier)
 }
 
 func TestECDSASigner(t *testing.T) {
-	signer, err := newSigner(ecdsaPrivateKeyPEM)
+	signer, err := NewSigner(ecdsaPrivateKeyPEM)
 	require.Nil(t, err)
-	verifier, err := newVerifier(ecdsaPublicKeyPEM)
+	verifier, err := NewVerifier(ecdsaPublicKeyPEM)
 	testSV(t, signer, verifier)
 }

--- a/libs/go/zmssvctoken/token_test.go
+++ b/libs/go/zmssvctoken/token_test.go
@@ -95,11 +95,11 @@ func TestTokenPubValidateNegative(t *testing.T) {
 	start := fmt.Sprint(time.Now().Unix())
 	e := fmt.Sprint(time.Now().Add(time.Hour).Unix())
 
-	signer, err := newSigner(rsaPrivateKeyPEM)
+	signer, err := NewSigner(rsaPrivateKeyPEM)
 	require.Nil(t, err)
 
 	genTok := func(s string) string {
-		sig, err := signer.sign(s)
+		sig, err := signer.Sign(s)
 		require.Nil(t, err)
 		return s + ";s=" + sig
 	}

--- a/libs/go/zmssvctoken/ybase64.go
+++ b/libs/go/zmssvctoken/ybase64.go
@@ -18,15 +18,15 @@ func getEncoding() *base64.Encoding {
 // YBase64 is a variant of the std base64 encoding with URL safe
 // characters, used by Yahoo circa web 1.0. It uses '.' and '_' as replacements
 // for '+' and '/' and uses '-' instead of '=' as the padding character.
-type yBase64 struct {
+type YBase64 struct {
 }
 
 // EncodeToString encodes an array of bytes to a string
-func (lb *yBase64) EncodeToString(b []byte) string {
+func (lb *YBase64) EncodeToString(b []byte) string {
 	return getEncoding().EncodeToString(b)
 }
 
 // DecodeString decodes a string encoded using EncodeToString
-func (lb *yBase64) DecodeString(s string) ([]byte, error) {
+func (lb *YBase64) DecodeString(s string) ([]byte, error) {
 	return getEncoding().DecodeString(s)
 }

--- a/libs/go/zmssvctoken/ybase64_test.go
+++ b/libs/go/zmssvctoken/ybase64_test.go
@@ -28,7 +28,7 @@ justo. Sed nec vestibulum libero.
 
 func testReplay(t *testing.T, input []byte) {
 	a := assert.New(t)
-	var lb64 yBase64
+	var lb64 YBase64
 	s := lb64.EncodeToString(input)
 	b, err := lb64.DecodeString(s)
 	require.Nil(t, err)
@@ -43,14 +43,14 @@ func TestEdgeChars(t *testing.T) {
 	a := assert.New(t)
 	input := []byte{0x3f << 2, 0x00, 0x00, 0x3e << 2}
 	testReplay(t, []byte(input))
-	var lb64 yBase64
+	var lb64 YBase64
 	a.Equal("/AAA+A==", base64.StdEncoding.EncodeToString(input))
 	a.Equal("_AAA.A--", lb64.EncodeToString(input))
 }
 
 func TestBadPadding(t *testing.T) {
 	a := assert.New(t)
-	var lb64 yBase64
+	var lb64 YBase64
 	s := lb64.EncodeToString([]byte("goobledegooks"))
 	s = s + "--"
 	_, err := lb64.DecodeString(s)


### PR DESCRIPTION
allows other utilities to take advantage of these interfaces instead of implementing their own. The version go version of zpu will use these methods.