### PR TITLE
Use Throwable instead of Exception for updater thread run

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
@@ -996,8 +996,8 @@ public class DataStore implements DataCacheProvider {
                     lastDeleteRunTime = System.currentTimeMillis();
                 }
                 
-            } catch (Exception ex) {
-                LOGGER.error("DataUpdater: unable to process domain changes: " + ex.getMessage());
+            } catch (Throwable t) {
+                LOGGER.error("DataUpdater: unable to process domain changes: " + t.getMessage());
             }
         }
     }


### PR DESCRIPTION
This would allow us to log any major issues like out of heap, etc without having the data updater thread exit with no error messages.  Would be useful for debugging if there are any issues.