### PR TITLE
Enable client x.509 cert generation for lambda

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -1972,8 +1972,23 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
                     caller, info.getDomain());
         }
         
-        // we need to validate the instance document
-        
+        // we need to validate the instance document, unless it isn't there i.e. lambda, then just validate the creds
+
+        String ssh = info.getSsh();
+        if (info.getDocument() == "lambda") {
+            if (!cloudStore.verifyInstanceIdentity(info)) {
+                throw requestError("postAWSInstanceInformation: unable to validate lambda identity",
+                                   caller, info.getDomain());
+            }
+            Identity identity = cloudStore.generateIdentity(info.getName(), info.getCsr(), null, null);
+            if (identity == null) {
+                throw requestError("postAWSInstanceInformation: unable to generate identity for lambda",
+                                   caller, info.getDomain());
+            }
+            metric.stopTiming(timerMetric);
+            return identity;
+        }
+
         if (!cloudStore.verifyInstanceDocument(info, account)) {
             throw requestError("postAWSInstanceInformation: unable to validate instance document",
                     caller, info.getDomain());

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -1974,7 +1974,6 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         
         // we need to validate the instance document, unless it isn't there i.e. lambda, then just validate the creds
 
-        String ssh = info.getSsh();
         if (info.getDocument() == "lambda") {
             if (!cloudStore.verifyInstanceIdentity(info)) {
                 throw requestError("postAWSInstanceInformation: unable to validate lambda identity",


### PR DESCRIPTION
The general idea is to specify no instance identity document for
lambda, which results in a client-only x.509 cert, and no SSH certs at
all. This is a short term fix on the legacy API only. The new
InstanceRegisterInformation API will need an attestationData definition
that accommodates this feature, when it gets implemented.