### PR TITLE
Improve npm package names

### DIFF
--- a/assembly/ui/ui.xml
+++ b/assembly/ui/ui.xml
@@ -46,12 +46,12 @@
       <directory>${basedir}/../../ui/node_modules</directory>
       <outputDirectory>node_modules</outputDirectory>
       <excludes>
-        <exclude>auth_core/</exclude>
+        <exclude>@athenz/auth-core/</exclude>
       </excludes>
     </fileSet>
     <fileSet>
       <directory>${basedir}/../../libs/nodejs/auth_core</directory>
-      <outputDirectory>node_modules/auth_core</outputDirectory>
+      <outputDirectory>node_modules/@athenz/auth-core</outputDirectory>
       <excludes>
         <exclude>node_modules/</exclude>
       </excludes>

--- a/clients/nodejs/zpe/config/config.js
+++ b/clients/nodejs/zpe/config/config.js
@@ -27,7 +27,7 @@ module.exports = function() {
   var userConfig = {};
   if (__dirname !== process.cwd() + '/config') {
     var parentModule = module.parent;
-    while (parentModule.id.match(/node_modules\/zpe_nodejs_client\//)) {
+    while (parentModule.id.match(/node_modules\/@athenz\/zpe-client\//)) {
       parentModule = parentModule.parent;
     }
     var module_path = parentModule.id.match(/(.*)(node_modules\/(\w+))/g);

--- a/clients/nodejs/zpe/package.json
+++ b/clients/nodejs/zpe/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zpe_nodejs_client",
+  "name": "@athenz/zpe-client",
   "version": "1.0.0",
   "description": "A Node.js client library to check assertion received from ZTS",
   "main": "index.js",
@@ -19,7 +19,6 @@
   },
   "keywords": [
     "athenz",
-    "zpe_nodejs_client",
     "yahoo"
   ],
   "bugs": {
@@ -31,7 +30,7 @@
     "lodash.clone": "^4.5.0",
     "memory-cache": "^0.2.0",
     "winston": "^2.3.1",
-    "auth_core": "file:../../../libs/nodejs/auth_core"
+    "@athenz/auth-core": "^1.0.0"
   },
   "devDependencies": {
     "bootstrap": "~3.3.6",

--- a/clients/nodejs/zpe/src/AuthZPEClient.js
+++ b/clients/nodejs/zpe/src/AuthZPEClient.js
@@ -3,7 +3,7 @@
 const winston = require('winston');
 
 let config = require('../config/config')();
-const RoleToken = require('auth_core').RoleToken;
+const RoleToken = require('@athenz/auth-core').RoleToken;
 const AccessCheckStatus = require('./AccessCheckStatus');
 const PublicKeyStore = require('./PublicKeyStore');
 const ZPEUpdater = require('./ZPEUpdater');

--- a/clients/nodejs/zpe/src/PublicKeyStore.js
+++ b/clients/nodejs/zpe/src/PublicKeyStore.js
@@ -1,7 +1,7 @@
 'use strict';
 
 let config = require('../config/config')();
-const YBase64 = require('auth_core').YBase64;
+const YBase64 = require('@athenz/auth-core').YBase64;
 const fs = require('fs');
 
 class PublicKeyStore {

--- a/clients/nodejs/zpe/src/ZPEUpdater.js
+++ b/clients/nodejs/zpe/src/ZPEUpdater.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const winston = require('winston');
 
 let config = require('../config/config')();
-const Crypto = require('auth_core').Crypto;
+const Crypto = require('@athenz/auth-core').Crypto;
 const ZPEMatch = require('./ZPEMatch');
 
 let _roleCache = require('memory-cache');

--- a/clients/nodejs/zts/config/config.js
+++ b/clients/nodejs/zts/config/config.js
@@ -27,7 +27,7 @@ module.exports = function() {
   var userConfig = {};
   if (__dirname !== process.cwd() + '/config') {
     var parentModule = module.parent;
-    while (parentModule.id.match(/node_modules\/zts_nodejs_client\//)) {
+    while (parentModule.id.match(/node_modules\/@athenz\/zts-client\//)) {
       parentModule = parentModule.parent;
     }
     var module_path = parentModule.id.match(/(.*)(node_modules\/(\w+))/g);

--- a/clients/nodejs/zts/package.json
+++ b/clients/nodejs/zts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zts_nodejs_client",
+  "name": "@athenz/zts-client",
   "version": "1.0.0",
   "description": "A Node.js client library to access ZTS",
   "main": "index.js",
@@ -19,7 +19,6 @@
   },
   "keywords": [
     "athenz",
-    "zts_nodejs_client",
     "yahoo"
   ],
   "bugs": {

--- a/libs/nodejs/auth_core/config/config.js
+++ b/libs/nodejs/auth_core/config/config.js
@@ -27,7 +27,7 @@ module.exports = function() {
   var userConfig = {};
   if (__dirname !== process.cwd() + '/config') {
     var parentModule = module.parent;
-    while (parentModule.id.match(/node_modules\/auth_core\//)) {
+    while (parentModule.id.match(/node_modules\/@athenz\/auth-core\//)) {
       parentModule = parentModule.parent;
     }
     var module_path = parentModule.id.match(/(.*)(node_modules\/(\w+))/g);

--- a/libs/nodejs/auth_core/package.json
+++ b/libs/nodejs/auth_core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "auth_core",
+  "name": "@athenz/auth-core",
   "version": "1.0.0",
   "description": "Core interfaces for authorization",
   "main": "index.js",
@@ -19,7 +19,6 @@
   },
   "keywords": [
     "athenz",
-    "auth_core",
     "yahoo"
   ],
   "bugs": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "athenz-ui",
+  "name": "@athenz/ui",
   "version": "1.0.0",
   "description": "AthenZ UI",
   "main": "index.js",
@@ -43,7 +43,7 @@
     "request": "~2.79.0",
     "serve-favicon": "~2.4.0",
     "url-pattern": "~1.0.1",
-    "auth_core": "file:../libs/nodejs/auth_core"
+    "@athenz/auth-core": "^1.0.0"
   },
   "devDependencies": {
     "bootstrap": "~3.3.6",

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "request": "~2.79.0",
     "serve-favicon": "~2.4.0",
     "url-pattern": "~1.0.1",
-    "@athenz/auth-core": "^1.0.0"
+    "@athenz/auth-core": "file:../libs/nodejs/auth_core"
   },
   "devDependencies": {
     "bootstrap": "~3.3.6",

--- a/ui/src/PublicKeyStore.js
+++ b/ui/src/PublicKeyStore.js
@@ -15,7 +15,7 @@
 
 var fs = require('fs');
 var config = require('../config/config.js')();
-var auth_core = require('auth_core');
+var auth_core = require('@athenz/auth-core');
 var YBase64 = auth_core.YBase64;
 var KeyStore = auth_core.KeyStore;
 

--- a/ui/src/utils/login.js
+++ b/ui/src/utils/login.js
@@ -17,7 +17,7 @@ var fs = require('fs');
 var userRoutes = require('../routeHandlers/user');
 var config = require('../../config/config.js')();
 var q = require('querystring');
-var auth_core = require('auth_core');
+var auth_core = require('@athenz/auth-core');
 var authority = new auth_core.PrincipalAuthority();
 authority.setKeyStore(require('../PublicKeyStore'));
 


### PR DESCRIPTION
I feel Athenz npm package's names aren't better for practices of Node.js.

1. Avoid redundant naming: "nodejs" in package name is redundant. npm packages are always provided for Node.js runtime.
2. Use hyphen instead of underscore: npm package name usually uses hyphen. e.g. `eslint-`, `babel-`.
3. Push all packages into one namespace: `auth-core` doesn't associate Athenz with the package name. Use scoped package name instead.

This changes is my proposal these issues. Please let me know if you have more idea on this.