### PR TITLE
UI depends on @athenz/auth-core instead

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "request": "~2.79.0",
     "serve-favicon": "~2.4.0",
     "url-pattern": "~1.0.1",
-    "@athenz/auth-core": "file:../libs/nodejs/auth_core"
+    "@athenz/auth-core": "^1.0.0"
   },
   "devDependencies": {
     "bootstrap": "~3.3.6",


### PR DESCRIPTION
`@athenz/auth-core` package is available on npm registry now. The UI should
depends on `@athenz/auth-core` package instead of the relative path. This is
one more change as a part of #250.

See also: https://github.com/yahoo/athenz/pull/250#issuecomment-332199611