### PR TITLE
We should add -h option when running the docker container

### DIFF
--- a/docs/setup_docker.md
+++ b/docs/setup_docker.md
@@ -31,7 +31,7 @@ and those three ports must be exposed and available on the docker host as well.
 Once docker is successfully installed, launch Athenz by executing the following docker command.
 
 ```shell
-$ docker run -itd -p 9443:9443 -p 4443:4443 -p 8443:8443 -e ZMS_SERVER=<server-hostname> -e UI_SERVER=<server-hostname> athenz/athenz
+$ docker run -itd -h <server-hostname> -p 9443:9443 -p 4443:4443 -p 8443:8443 -e ZMS_SERVER=<server-hostname> -e UI_SERVER=<server-hostname> athenz/athenz
 ```
 
 To access Athenz UI, open your browser with url


### PR DESCRIPTION
After solving #234, I discovered the self signed certificate has common name as the container id.
```
$ docker run -itd -p 9443:9443 -p 4443:4443 -p 8443:8443 -e ZMS_SERVER=localhost -e UI_SERVER=localhost tatyano/athenz
a912be84a9e0c4d6286c66a6a7f35a9f2bf76eb700b51acdbe0af992f9c65642

$ docker exec -it a912be84a9e0c4d6286c66a6a7f35a9f2bf76eb700b51acdbe0af992f9c65642 openssl x509 -in /opt/athenz/athenz-zms-1.7.29-SNAPSHOT/var/zms_server/certs/zms_cert.pem  -noout -subject
subject= /C=US/ST=CA/O=Athenz/OU=Testing Domain/CN=a912be84a9e0
```

For the use of dev environment, I believe it's better to define the host name with each of our preferences.
```
$ docker run -itd -h localhost -p 9443:9443 -p 4443:4443 -p 8443:8443 -e ZMS_SERVER=localhost -e UI_SERVER=localhost tatyano/athenz
62ffb722488cffce32a1b2514a6924612a3f027b38d6a27c25cc0525e0b3161e

$ docker exec -it 62ffb722488cffce32a1b2514a6924612a3f027b38d6a27c25cc0525e0b3161e openssl x509 -in /opt/athenz/athenz-zms-1.7.29-SNAPSHOT/var/zms_server/certs/zms_cert.pem  -noout -subject
subject= /C=US/ST=CA/O=Athenz/OU=Testing Domain/CN=localhost
```