### PR TITLE
move validation code to server

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/SimplePrincipal.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/SimplePrincipal.java
@@ -23,7 +23,6 @@ import org.slf4j.LoggerFactory;
 
 import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.Principal;
-import com.yahoo.athenz.auth.util.Validate;
 
 public class SimplePrincipal implements Principal {
 
@@ -58,10 +57,6 @@ public class SimplePrincipal implements Principal {
      * @return a Principal for the given set of roles in a domain
      */
     public static Principal create(String domain, String creds, List<String> roles, Authority authority) {
-        if (!Validate.domainName(domain)) {
-            LOG.error("createRolePrincipal: domain name doesn't validate: " + domain);
-            return null;
-        }
         if (roles == null || roles.size() == 0) {
             LOG.error("createRolePrincipal: zero roles");
             return null;
@@ -92,15 +87,6 @@ public class SimplePrincipal implements Principal {
      */
     public static Principal create(String domain, String name, String creds, long issueTime,
             Authority authority) {
-        
-        if (!Validate.domainName(domain)) {
-            LOG.error("createPrincipal: domain name doesn't validate: " + domain);
-            return null;
-        }
-        if (!Validate.principalName(name)) {
-            LOG.error("createPrincipal: principal name doesn't validate: " + name);
-            return null;
-        }
         String matchDomain = (authority == null) ? null : authority.getDomain();
         if (matchDomain != null && !domain.equals(matchDomain)) {
             LOG.error("createPrincipal: domain mismatch for user {} in authority {}",

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Validate.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/util/Validate.java
@@ -23,8 +23,8 @@ import java.util.regex.Pattern;
  */
 public class Validate {
 
-    private static final String PRINCIPAL_REGEX = "((([a-zA-Z_][a-zA-Z0-9_-]*\\.)*[a-zA-Z_][a-zA-Z0-9_-]*):)?(([a-zA-Z_][a-zA-Z0-9_-]*\\.)*[a-zA-Z_][a-zA-Z0-9_-]*)";
-    private static final String DOMAIN_REGEX = "([a-zA-Z_][a-zA-Z0-9_-]*\\.)*[a-zA-Z_][a-zA-Z0-9_-]*";
+    private static final String PRINCIPAL_REGEX = "((([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*):)?(([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*)";
+    private static final String DOMAIN_REGEX = "([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*";
     
     private static Pattern principalPattern = Pattern.compile(PRINCIPAL_REGEX);
     private static Pattern domainPattern = Pattern.compile(DOMAIN_REGEX);

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/SimplePrincipalTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/SimplePrincipalTest.java
@@ -73,8 +73,8 @@ public class SimplePrincipalTest {
         assertEquals(p.getFullName(), "user.jdoe");
         assertEquals(p.getFullName(), "user.jdoe");
         
-        assertNull(SimplePrincipal.create(null, "jdoe", fakeCreds));
-        assertNull(SimplePrincipal.create("user", null, fakeCreds));
+        assertNotNull(SimplePrincipal.create(null, "jdoe", fakeCreds));
+        assertNotNull(SimplePrincipal.create("user", null, fakeCreds));
         
         List<String> roles = new ArrayList<String>();
         roles.add("role1");
@@ -87,19 +87,6 @@ public class SimplePrincipalTest {
         
         Authority authority = null;
         assertNull(SimplePrincipal.create(null, null, authority));
-    }
-    
-    @Test
-    public void testSimplePrincipalInvalidDomain() {
-        
-        List<String> roles = new ArrayList<String>();
-        roles.add("storage.tenant.weather.updater");
-        
-        UserAuthority userAuthority = new UserAuthority();
-        userAuthority.initialize();
-
-        assertNull(SimplePrincipal.create("user test invalid#$%",
-                fakeCreds, roles, userAuthority));
     }
     
     @Test
@@ -128,18 +115,6 @@ public class SimplePrincipalTest {
 
         assertEquals(p.getRoles().size(), 1);
         assertTrue(p.getRoles().contains("newrole"));
-    }
-    
-    @Test
-    public void testSimplePrincipalInvalidName() {
-        
-        // we output warning but still create a principal
-        
-        UserAuthority userAuthority = new UserAuthority();
-        userAuthority.initialize();
-
-        assertNull(SimplePrincipal.create("user", "jdoe invalid#$%",
-                fakeCreds, 0, userAuthority));
     }
     
     @Test

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/ValidateTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/util/ValidateTest.java
@@ -55,13 +55,13 @@ public class ValidateTest {
         
         assertFalse(Validate.domainName("domain$sub"));
         assertFalse(Validate.domainName("coretech:domain"));
-        assertFalse(Validate.domainName("55"));
-        assertFalse(Validate.domainName("3com.gov"));
     }
     
     @Test
     public void testDomainNameValidationValid() {
         
+        assertTrue(Validate.domainName("55"));
+        assertTrue(Validate.domainName("3com.gov"));
         assertTrue(Validate.domainName("domain"));
         assertTrue(Validate.domainName("domain.sub.sub"));
         assertTrue(Validate.domainName("domain_"));


### PR DESCRIPTION
we should move the validation code to the server since the library doesn't know what is the current regex allowed for principal components and could get out of sync.