### PR TITLE
Add go zpe-updater binary to athenz-utils assembly

### DIFF
--- a/assembly/utils/utils.xml
+++ b/assembly/utils/utils.xml
@@ -46,6 +46,10 @@
       <directory>${basedir}/../../utils/zts-rolecert/target</directory>
       <outputDirectory>bin</outputDirectory>
     </fileSet>
+    <fileSet>
+      <directory>${basedir}/../../utils/zpe-updater/target</directory>
+      <outputDirectory>bin</outputDirectory>
+    </fileSet>
   </fileSets>
   <files>
     <file>

--- a/utils/zpe-updater/Makefile
+++ b/utils/zpe-updater/Makefile
@@ -9,13 +9,13 @@
 GOPKGNAME = github.com/yahoo/athenz/utils/zpe-updater
 PKG_DATE=$(shell date '+%Y-%m-%dT%H:%M:%S')
 BINARY=zpu
+SRC=cmd/tools/main.go
 FMT_LOG=/tmp/zpu-fmt.log
 IMPORTS_LOG=/tmp/zpu-imports.log
 
-export GOPATH = $(PWD)
 # check to see if go utility is installed
 GO := $(shell command -v go 2> /dev/null)
-
+export GOPATH=$(PWD)
 
 ifdef GO
 
@@ -81,10 +81,12 @@ unit: vet fmt
 darwin:
 	@echo "Building darwin client..."
 	GOOS=darwin go build -ldflags "-X main.VERSION=$(PKG_VERSION) -X main.BUILD_DATE=$(PKG_DATE)" $(GOPKGNAME)/...
+	GOOS=darwin go build -ldflags "-X main.VERSION=$(PKG_VERSION) -X main.BUILD_DATE=$(PKG_DATE)" -o target/darwin/$(BINARY) $(SRC)
 
 linux:
 	@echo "Building linux client..."
 	GOOS=linux go build -ldflags "-X main.VERSION=$(PKG_VERSION) -X main.BUILD_DATE=$(PKG_DATE)" $(GOPKGNAME)/...
+	GOOS=linux go build -ldflags "-X main.VERSION=$(PKG_VERSION) -X main.BUILD_DATE=$(PKG_DATE)" -o target/linux/$(BINARY) $(SRC)
 
 clean:
 	rm -rf target src bin pkg /tmp/zpu-go-build $(FMT_LOG) $(IMPORTS_LOG)

--- a/utils/zpe-updater/pom.xml
+++ b/utils/zpe-updater/pom.xml
@@ -4,7 +4,9 @@
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
+
         http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
For now, the document of zpu setup is guiding us to download the package with assembled tar file.
https://github.com/yahoo/athenz/blob/master/docs/setup_zpu.md#getting-software

I believe it's better to have both versions of java and go, and let users choose the solution.
(Go version has less dependency.)