### PR TITLE
zmssvctoken: fix golint issues and correct comments

### DIFF
--- a/libs/go/zmssvctoken/keyserver_test.go
+++ b/libs/go/zmssvctoken/keyserver_test.go
@@ -53,7 +53,7 @@ func (s *server) close() error {
 	return s.l.Close()
 }
 
-func newServer(h handler) (s *server, baseUrl string, err error) {
+func newServer(h handler) (s *server, baseURL string, err error) {
 
 	listener, err := net.Listen("tcp", ":0")
 	if err != nil {
@@ -61,10 +61,10 @@ func newServer(h handler) (s *server, baseUrl string, err error) {
 	}
 
 	port := listener.Addr().(*net.TCPAddr).Port
-	baseUrl = fmt.Sprintf("http://:%d/v1", port)
+	baseURL = fmt.Sprintf("http://:%d/v1", port)
 	s = &server{
 		l: listener,
 		h: h,
 	}
-	return s, baseUrl, nil
+	return s, baseURL, nil
 }

--- a/libs/go/zmssvctoken/signer.go
+++ b/libs/go/zmssvctoken/signer.go
@@ -18,12 +18,12 @@ import (
 
 var hash = crypto.SHA256
 
-// signer signs a string and returns the signature
+// Signer signs a string and returns the signature.
 type Signer interface {
 	Sign(input string) (string, error)
 }
 
-// verifier verifies the signature for a string
+// Verifier verifies the signature for a string.
 type Verifier interface {
 	Verify(input, signature string) error
 }
@@ -40,6 +40,7 @@ func hashString(input string) ([]byte, error) {
 	return h.Sum(nil), nil
 }
 
+// NewSigner creates an instance of Signer using the given private key (ECDSA or RSA).
 func NewSigner(privateKeyPEM []byte) (Signer, error) {
 	block, _ := pem.Decode(privateKeyPEM)
 	if block == nil {
@@ -68,6 +69,7 @@ type sign struct {
 	key crypto.Signer
 }
 
+// Sign signs the given input string using the internal key.
 func (s *sign) Sign(input string) (string, error) {
 	hashed, err := hashString(input)
 	if err != nil {
@@ -88,6 +90,7 @@ type rsaVerify struct {
 	key *rsa.PublicKey
 }
 
+// Verify verifies the signature of the input using the RSA public key.
 func (r *rsaVerify) Verify(hashed []byte, sig []byte) error {
 	return rsa.VerifyPKCS1v15(r.key, hash, hashed, sig)
 }
@@ -96,6 +99,7 @@ type ecdsaVerify struct {
 	key *ecdsa.PublicKey
 }
 
+// Verify verifies the signature of the input using the ECDSA public key.
 func (e *ecdsaVerify) Verify(hashed []byte, sig []byte) error {
 	var s struct {
 		R, S *big.Int
@@ -110,6 +114,7 @@ func (e *ecdsaVerify) Verify(hashed []byte, sig []byte) error {
 	return nil
 }
 
+// NewVerifier creates an instance of Verifier using the given public key.
 func NewVerifier(publicKeyPEM []byte) (Verifier, error) {
 	block, _ := pem.Decode(publicKeyPEM)
 	if block == nil {
@@ -137,8 +142,8 @@ type verify struct {
 	iv internalVerifier
 }
 
+// Verify verifies the ybase64-encoded signature of the input.
 func (v *verify) Verify(input, signature string) error {
-
 	sigBytes, err := new(YBase64).DecodeString(signature)
 	if err != nil {
 		return err

--- a/libs/go/zmssvctoken/token.go
+++ b/libs/go/zmssvctoken/token.go
@@ -1,8 +1,8 @@
 // Copyright 2016 Yahoo Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
 
-// Package svctoken produces and validates ntokens given appropriate keys.
-// It can only produce service tokens but can validate any principal token
+// Package zmssvctoken produces and validates ntokens given appropriate keys.
+// It can only produce service tokens but can validate any principal token.
 package zmssvctoken
 
 import (
@@ -33,24 +33,24 @@ const (
 	tagSignature      = "s"
 )
 
-// NToken provides access to useful fields in an ntoken
+// NToken provides access to useful fields in an ntoken.
 type NToken struct {
 	Version        string    // the token version e.g. S1, U1
 	Domain         string    // domain for which token is valid
 	Name           string    // local principal name
 	KeyVersion     string    // key version as registered in Athenz
 	Hostname       string    // optional hostname
-	IPAddress      string    // optional I/P address
+	IPAddress      string    // optional IP address
 	GenerationTime time.Time // time token was generated
 	ExpiryTime     time.Time // time token expires
 }
 
-// PrincipalName returns the fully qualified principal name for the token
+// PrincipalName returns the fully qualified principal name for the token.
 func (n *NToken) PrincipalName() string {
 	return n.Domain + "." + n.Name
 }
 
-// IsExpired is a convenience function to check token expiry
+// IsExpired is a convenience function to check token expiry.
 func (n *NToken) IsExpired() bool {
 	return n.ExpiryTime.Before(time.Now())
 }
@@ -196,21 +196,21 @@ func (n *NToken) String() string {
 }
 
 // Token is a mechanism to get an ntoken as a string.
-// It guarantees that the returned token has not expired
+// It guarantees that the returned token has not expired.
 type Token interface {
 	// Value returns the value of the current token or
-	// an error if it couldn't be generated for any reason
+	// an error if it couldn't be generated for any reason.
 	Value() (string, error)
 }
 
 // TokenBuilder provides a mechanism to set optional ntoken attributes and
-// a means to get the token value with efficient auto-refresh
+// a means to get the token value with efficient auto-refresh.
 type TokenBuilder interface {
-	// SetExpiration sets the duration for which the token is valid (default=1h)
+	// SetExpiration sets the duration for which the token is valid (default=1h).
 	SetExpiration(t time.Duration)
-	// SetHostname sets the hostname for the token (default=current hostname)
+	// SetHostname sets the hostname for the token (default=current hostname).
 	SetHostname(h string)
-	// SetIPAddress sets the I/P address for the token (default=host I/P address)
+	// SetIPAddress sets the IP address for the token (default=host IP address).
 	SetIPAddress(ip string)
 	// Token returns a Token instance with the fields correctly set for
 	// the current token. Multiple calls to Token will return the same implementation.
@@ -228,8 +228,8 @@ type tokenBuilder struct {
 }
 
 // NewTokenBuilder returns a TokenBuilder implementation for the specified
-// domain/ name, with a private key (PEM format) and its key-version. The key-version
-// should be the same string that was used to register the key with Athenz
+// domain/name, with a private key (PEM format) and its key-version. The key-version
+// should be the same string that was used to register the key with Athenz.
 func NewTokenBuilder(domain, name string, privateKeyPEM []byte, keyVersion string) (TokenBuilder, error) {
 	s, err := NewSigner(privateKeyPEM)
 	if err != nil {
@@ -308,7 +308,7 @@ func (t *token) Value() (string, error) {
 	return t.cachedToken, nil
 }
 
-// TokenValidator provides a mechanism to validate tokens
+// TokenValidator provides a mechanism to validate tokens.
 type TokenValidator interface {
 	// Validate returns an unexpired NToken object from its
 	// string representation.
@@ -332,7 +332,7 @@ func (tv *tokenValidator) Validate(token string) (*NToken, error) {
 }
 
 // NewPubKeyTokenValidator returns NToken objects from signed token strings
-// given a public key to verify signatures
+// given a public key to verify signatures.
 func NewPubKeyTokenValidator(publicKeyPEM []byte) (TokenValidator, error) {
 	v, err := NewVerifier(publicKeyPEM)
 	if err != nil {
@@ -343,6 +343,7 @@ func NewPubKeyTokenValidator(publicKeyPEM []byte) (TokenValidator, error) {
 	}, nil
 }
 
+// ValidationConfig contains data to change runtime parameters from the default values.
 type ValidationConfig struct {
 	ZTSBaseUrl            string        // the ZTS base url including the /zts/v1 version path, default
 	PublicKeyFetchTimeout time.Duration // timeout for fetching the public key from ZTS, default: 5s

--- a/libs/go/zmssvctoken/validate_test.go
+++ b/libs/go/zmssvctoken/validate_test.go
@@ -66,7 +66,7 @@ var (
 	hangSource      = source("d500")
 	noKeySource     = source("nks")
 	badEncSource    = source("bes")
-	badJsonSource   = source("bjs")
+	badJSONSource   = source("bjs")
 	keyRotateSource = source("rotate")
 )
 
@@ -98,7 +98,7 @@ var handlerMap = map[keySource]handler{
 	hangSource:      hang,
 	noKeySource:     noKey,
 	badEncSource:    badBase64,
-	badJsonSource:   badJSON,
+	badJSONSource:   badJSON,
 	keyRotateSource: ch.getKey,
 }
 
@@ -111,8 +111,8 @@ func TestCachedValidate(t *testing.T) {
 		}
 		return s404(src)
 	}
-	s, baseUrl, err := newServer(h)
-	t.Log(baseUrl)
+	s, baseURL, err := newServer(h)
+	t.Log(baseURL)
 
 	require.Nil(t, err)
 	go func() {
@@ -121,7 +121,7 @@ func TestCachedValidate(t *testing.T) {
 	defer s.close()
 
 	config := ValidationConfig{
-		ZTSBaseUrl:            baseUrl,
+		ZTSBaseUrl:            baseURL,
 		CacheTTL:              2 * time.Second,
 		PublicKeyFetchTimeout: 1 * time.Second,
 	}
@@ -164,7 +164,7 @@ func TestCachedValidate(t *testing.T) {
 	a.Contains(err.Error(), "illegal base64 data")
 
 	// bad JSON
-	_, err = validator.Validate(makeToken(t, badJsonSource))
+	_, err = validator.Validate(makeToken(t, badJSONSource))
 	require.NotNil(t, err)
 	a.Contains(err.Error(), "JSON")
 

--- a/libs/go/zmssvctoken/ybase64.go
+++ b/libs/go/zmssvctoken/ybase64.go
@@ -21,12 +21,12 @@ func getEncoding() *base64.Encoding {
 type YBase64 struct {
 }
 
-// EncodeToString encodes an array of bytes to a string
+// EncodeToString encodes an array of bytes to a string.
 func (lb *YBase64) EncodeToString(b []byte) string {
 	return getEncoding().EncodeToString(b)
 }
 
-// DecodeString decodes a string encoded using EncodeToString
+// DecodeString decodes a string encoded using EncodeToString.
 func (lb *YBase64) DecodeString(s string) ([]byte, error) {
 	return getEncoding().DecodeString(s)
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/HttpCertSigner.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/HttpCertSigner.java
@@ -152,7 +152,7 @@ public class HttpCertSigner implements CertSigner {
     @Override
     public String generateX509Certificate(String csr, String keyUsage) {
         
-        // Key Usage value used in go - https://golang.org/src/crypto/x509/x509.go?s=18153:18173#L558
+        // Key Usage value used in Go - https://golang.org/src/crypto/x509/x509.go?s=18153:18173#L558
         // we're only interested in ExtKeyUsageClientAuth - with value of 2
         
         final String extKeyUsage = ZTSConsts.ZTS_CERT_USAGE_CLIENT.equals(keyUsage) ? "2" : null;

--- a/utils/zms-cli/README.md
+++ b/utils/zms-cli/README.md
@@ -1,7 +1,7 @@
 zms-cli
 =======
 
-ZMS Client application in go to manage your Athenz domain in ZMS Server.
+ZMS Client application in Go to manage your Athenz domain in ZMS Server.
 
 ## License
 

--- a/utils/zms-svctoken/README.md
+++ b/utils/zms-svctoken/README.md
@@ -1,7 +1,7 @@
 zms-svctoken
 ============
 
-ZMS Service Token Client application in go to generate service tokens
+ZMS Service Token Client application in Go to generate service tokens
 based on given private key and service details:
 
 ```shell

--- a/utils/zts-rolecert/README.md
+++ b/utils/zts-rolecert/README.md
@@ -1,10 +1,10 @@
 zts-rolecert
 ============
 
-ZTS Role Certificate Client application in go to use Athenz Service
+ZTS Role Certificate Client application in Go to use Athenz Service
 Identity certificate to request a X509 Certificate for the requested
 role from ZTS Server. Once ZTS validates the service identity certificate,
-it will issue a new 30-day X509 Certificate for the role
+it will issue a new 30-day X509 Certificate for the role.
 
 ```shell
 $ zts-rolecert -domain <domain> -service <service> -svc-key-file <key-file> -svc-cert-file <cert-file> -zts <zts-server-url> -role-domain <domain> -role-name <name> -dns-domain <dns-domain> [-role-cert-file <output-cert-file>]

--- a/utils/zts-roletoken/README.md
+++ b/utils/zts-roletoken/README.md
@@ -1,7 +1,7 @@
 zts-roletoken
 =============
 
-ZTS Role Token Client application in go to request a role token from
+ZTS Role Token Client application in Go to request a role token from
 ZTS Server for the given identity to access a role in a provider domain:
 
 ```shell

--- a/utils/zts-svccert/README.md
+++ b/utils/zts-svccert/README.md
@@ -1,7 +1,7 @@
 zts-svccert
 ===========
 
-ZTS Service Certificate Client application in go to generate service tokens
+ZTS Service Certificate Client application in Go to generate service tokens
 based on given private key and service details, then generate a CSR using
 the same private key and then request a X509 Certificate for that service
 token from ZTS Server. Once ZTS validates the NToken and CSR, it will issue


### PR DESCRIPTION
* fix all golint issues in libs/go/zmssvctoken except the one related to the exported field (to avoid breaking API compatibility): `token.go:348:2: struct field ZTSBaseUrl should be ZTSBaseURL`
* make comment sentences end with a period
* Use the official name of the Go language (with the capital 'G') - as in https://golang.org/

@havetisyan