### PR TITLE
add package documentation in doc.go files

### DIFF
--- a/clients/go/zms/doc.go
+++ b/clients/go/zms/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Package zms contains a client library to talk to Athenz ZMS.
+package zms

--- a/clients/go/zts/doc.go
+++ b/clients/go/zts/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Package zts contains a client library to talk to Athenz ZTS.
+package zts

--- a/libs/go/zmscli/doc.go
+++ b/libs/go/zmscli/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Package zmscli is ZMS Client application library to manage
+// an Athenz domain in ZMS Server.
+package zmscli

--- a/libs/go/zmssvctoken/doc.go
+++ b/libs/go/zmssvctoken/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Package zmssvctoken generates/validates Athenz NTokens
+// given private/public keys.
+package zmssvctoken

--- a/libs/go/ztsroletoken/doc.go
+++ b/libs/go/ztsroletoken/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Package ztsroletoken generates roletokens.
+package ztsroletoken

--- a/utils/athenz-conf/doc.go
+++ b/utils/athenz-conf/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Athenz-conf is a program to generate an athenz.conf file based
+// on service details stored in ZMS Server.
+package main

--- a/utils/zms-cli/doc.go
+++ b/utils/zms-cli/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Zms-cli is a program to manage your Athenz domain in ZMS Server.
+package main

--- a/utils/zms-svctoken/doc.go
+++ b/utils/zms-svctoken/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Zms-svctoken is a program to generate service tokens
+// based on given private key and service details
+package main

--- a/utils/zpe-updater/devel/doc.go
+++ b/utils/zpe-updater/devel/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Package devel provides utility functions for testing
+// (StartMockServer and CreateFile).
+package devel

--- a/utils/zpe-updater/doc.go
+++ b/utils/zpe-updater/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Package zpu is a utility library to update ZPE Policy.
+package zpu

--- a/utils/zpe-updater/test_data/doc.go
+++ b/utils/zpe-updater/test_data/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Package test_data contains test data for zpe-updater
+// as .go files.
+package test_data

--- a/utils/zpe-updater/util/doc.go
+++ b/utils/zpe-updater/util/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Package util provides utility types and functions
+// for zpe-updater.
+package util

--- a/utils/zts-rolecert/doc.go
+++ b/utils/zts-rolecert/doc.go
@@ -1,0 +1,10 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Zts-rolecert is a program to use Athenz Service
+// Identity certificate to request a X509 Certificate
+// for the requested role from ZTS Server.
+//
+// Once ZTS validates the service identity certificate,
+// it will issue a new 30-day X509 Certificate for the role.
+package main

--- a/utils/zts-roletoken/doc.go
+++ b/utils/zts-roletoken/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Zts-roletoken is a program to request a role token from
+// ZTS Server for the given identity to access a role
+// in a provider domain.
+package main

--- a/utils/zts-svccert/README.md
+++ b/utils/zts-svccert/README.md
@@ -1,11 +1,7 @@
 zts-svccert
 ===========
 
-ZTS Service Certificate Client application in Go to generate service tokens
-based on given private key and service details, then generate a CSR using
-the same private key and then request a X509 Certificate for that service
-token from ZTS Server. Once ZTS validates the NToken and CSR, it will issue
-a new 30-day X509 Certificate for the service.
+ZTS Service Certificate Client application in Go to generate service tokens based on given private key and service details, then generate a CSR using the same private key and then request a X509 Certificate for that service token from ZTS Server. Once ZTS validates the NToken and CSR, it will issue a new 30-day X509 Certificate for the service.
 
 ```shell
 $ zts-svccert -domain <domain> -service <service> -private-key <key-file> -key-version <version> -zts <zts-server-url> -dns-domain <dns-domain> [-cert-file <output-cert-file>]

--- a/utils/zts-svccert/doc.go
+++ b/utils/zts-svccert/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2017 Oath, Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+//
+// Zts-svccert is a program to generate service token, generate a CSR
+// and request a X509 Certificate for that service token from ZTS Server.
+package main


### PR DESCRIPTION
Objective is to ensure that all entries in https://godoc.org/github.com/yahoo/athenz have a short summary as package or program description.

@havetisyan 