### PR TITLE
fix package doc strings

### DIFF
--- a/clients/go/zms/doc.go
+++ b/clients/go/zms/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Package zms contains a client library to talk to Athenz ZMS.
 package zms

--- a/clients/go/zms/examples/get-access/example.md
+++ b/clients/go/zms/examples/get-access/example.md
@@ -2,8 +2,7 @@
 
 ## Scenario
 
-Use the service cert present locally on the box to talk to ZMS, find out if the current principal has "Access"
-to a specified resource, in a given domain.
+Use the service cert present locally on the box to talk to ZMS, find out if the current principal has "Access" to a specified resource, in a given domain.
 
 Principal Domain: home.userid
 Principal identity: home.userid.helloworld

--- a/clients/go/zms/examples/get-access/main.go
+++ b/clients/go/zms/examples/get-access/main.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
 
+// Get-access is a demo program to query if the current principal has
+// "Access" to a specified resource, in a given domain.
 package main
 
 import (
@@ -10,7 +12,6 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
-
 	"strings"
 
 	"github.com/yahoo/athenz/clients/go/zms"

--- a/clients/go/zts/doc.go
+++ b/clients/go/zts/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Package zts contains a client library to talk to Athenz ZTS.
 package zts

--- a/clients/go/zts/examples/get-role-token/main.go
+++ b/clients/go/zts/examples/get-role-token/main.go
@@ -1,6 +1,8 @@
 // Copyright 2017 Yahoo Holdings, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms
 
+// Get-role-token is a demo program to use the service cert present
+// locally on the box to talk to ZTS and fetch a role token.
 package main
 
 import (

--- a/libs/go/zmscli/doc.go
+++ b/libs/go/zmscli/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Package zmscli is ZMS Client application library to manage
 // an Athenz domain in ZMS Server.
 package zmscli

--- a/libs/go/zmssvctoken/doc.go
+++ b/libs/go/zmssvctoken/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Package zmssvctoken generates/validates Athenz NTokens
 // given private/public keys.
 package zmssvctoken

--- a/libs/go/ztsroletoken/doc.go
+++ b/libs/go/ztsroletoken/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Package ztsroletoken generates roletokens.
 package ztsroletoken

--- a/utils/athenz-conf/doc.go
+++ b/utils/athenz-conf/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Athenz-conf is a program to generate an athenz.conf file based
 // on service details stored in ZMS Server.
 package main

--- a/utils/zms-cli/doc.go
+++ b/utils/zms-cli/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Zms-cli is a program to manage your Athenz domain in ZMS Server.
 package main

--- a/utils/zms-svctoken/doc.go
+++ b/utils/zms-svctoken/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Zms-svctoken is a program to generate service tokens
 // based on given private key and service details
 package main

--- a/utils/zpe-updater/cmd/tools/main.go
+++ b/utils/zpe-updater/cmd/tools/main.go
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
 
+// Tools is a program that runs zpu.PolicyUpdater.
 package main
 
 import (

--- a/utils/zpe-updater/devel/doc.go
+++ b/utils/zpe-updater/devel/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Package devel provides utility functions for testing
 // (StartMockServer and CreateFile).
 package devel

--- a/utils/zpe-updater/doc.go
+++ b/utils/zpe-updater/doc.go
@@ -1,5 +1,5 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Package zpu is a utility library to update ZPE Policy.
 package zpu

--- a/utils/zpe-updater/test_data/data.go
+++ b/utils/zpe-updater/test_data/data.go
@@ -1,6 +1,7 @@
 // Copyright 2017 Yahoo Holdings, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
 
+// Package test_data contains test data packed as Go files.
 package test_data
 
 var EndPoints = map[string]string{

--- a/utils/zpe-updater/util/doc.go
+++ b/utils/zpe-updater/util/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Package util provides utility types and functions
 // for zpe-updater.
 package util

--- a/utils/zts-rolecert/doc.go
+++ b/utils/zts-rolecert/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Zts-rolecert is a program to use Athenz Service
 // Identity certificate to request a X509 Certificate
 // for the requested role from ZTS Server.

--- a/utils/zts-roletoken/doc.go
+++ b/utils/zts-roletoken/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Zts-roletoken is a program to request a role token from
 // ZTS Server for the given identity to access a role
 // in a provider domain.

--- a/utils/zts-svccert/doc.go
+++ b/utils/zts-svccert/doc.go
@@ -1,6 +1,6 @@
 // Copyright 2017 Oath, Inc.
 // Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
-//
+
 // Zts-svccert is a program to generate service token, generate a CSR
 // and request a X509 Certificate for that service token from ZTS Server.
 package main


### PR DESCRIPTION
PR fixes the package doc strings (need to add a blank line between the copyright block and the package comment)

@havetisyan 