### PR TITLE
expiry/etag check

### DIFF
--- a/utils/zpe-updater/cmd/tools/main.go
+++ b/utils/zpe-updater/cmd/tools/main.go
@@ -79,7 +79,6 @@ func main() {
 	err = zpu.PolicyUpdater(zpuConfig)
 	if err != nil {
 		log.Fatalf("Policy updator failed, %v", err)
-
 	}
-	log.Println("Policy updator finished successfully ")
+	log.Println("Policy updator finished successfully")
 }

--- a/utils/zpe-updater/conf/zpu.conf
+++ b/utils/zpe-updater/conf/zpu.conf
@@ -1,4 +1,3 @@
-
 {
     "domains"       :   "<domain1>,<domain2>"
     "user"          :   "<user>"
@@ -7,5 +6,5 @@
     "logMaxsize"    :   <log file size in megabytes, default:100>
     "logMaxage"     :   <number of days, default:28>
     "logMaxbackups" :   <maximum number of backups, default:7>
-    "logCompress"   :    <false/true, default:true>
+    "logCompress"   :   <false/true, default:true>
 }

--- a/utils/zpe-updater/zpu_client_test.go
+++ b/utils/zpe-updater/zpu_client_test.go
@@ -76,8 +76,7 @@ func TestGetEtagForExistingPolicy(t *testing.T) {
 	ztsClient := zts.NewClient((*testConfig).Zts, nil)
 
 	//Policy File does not exist
-	etag, err := GetEtagForExistingPolicy(testConfig, ztsClient, DOMAIN, POLICIES_DIR)
-	a.Nil(err, "Empty Etag should be returned")
+	etag := GetEtagForExistingPolicy(testConfig, ztsClient, DOMAIN, POLICIES_DIR)
 	a.Empty(etag, "Empty Etag should be returned")
 
 	//Correct Policy File Exist
@@ -87,19 +86,15 @@ func TestGetEtagForExistingPolicy(t *testing.T) {
 	a.Nil(err)
 	err = ioutil.WriteFile(POLICIES_DIR+"/test.pol", policyJSON, 0755)
 	a.Nil(err)
-	etag, err = GetEtagForExistingPolicy(testConfig, ztsClient, "test", POLICIES_DIR)
+	etag = GetEtagForExistingPolicy(testConfig, ztsClient, "test", POLICIES_DIR)
 	errv := ValidateSignedPolicies(testConfig, ztsClient, policyData)
 	if errv != nil {
-		a.NotNil(err)
 		a.Empty(etag)
 	} else {
-		a.Nil(err)
 		a.NotEmpty(etag)
 	}
-
 	err = os.Remove(POLICIES_DIR + "/test.pol")
 	a.Nil(err)
-
 }
 
 func TestPolicyUpdaterEmptyDomain(t *testing.T) {


### PR DESCRIPTION
GetEtagForExistingPolicy - must never return failure - for any error case it should just return "" so the client can fetch the latest policy

expiry timeout - increase by default to 2 days (zts issues expiry of 7 days) instead of just relying on startup delay timeout. this way in case there are failures with retrieving the policy fail, it would not end up failing to fetch new policy files due to expiry time.