### PR TITLE
change zts client error to warn there is no conf file

### DIFF
--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -302,13 +302,11 @@ public class ZTSClient implements Closeable {
             // and default to localhost as the url to avoid further
             // warnings from our generated client
 
+            LOG.warn("Unable to extract ZTS Url from conf file {}, exc: {}",
+                    confFileName, ex.getMessage());
+            
             if (!svcLoaderCacheKeys.get().isEmpty()) {
-                LOG.warn("Unable to extract ZTS Url from conf file {}, exc: {}",
-                        confFileName, ex.getMessage());
                 confZtsUrl = "https://localhost:4443/";
-            } else {
-                LOG.error("Unable to extract ZTS Url from conf file {}, exc: {}",
-                        confFileName, ex.getMessage());
             }
         }
     }


### PR DESCRIPTION
the primary use case now is to specify the zts url so there may never use a conf file. during the client init we should not flag this as an error instead it should be warn