### PR TITLE
Athenz servers should provide the detailed error messages

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/rest/Http.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/rest/Http.java
@@ -128,13 +128,14 @@ public class Http {
         
         if (authErrMsg.length() > 0) {
             request.setAttribute(INVALID_CRED_ATTR, authErrMsg.toString());
-            LOG.error("authenticate: {}", authErrMsg.toString());
+            authErrMsg.insert(0, "authenticate: ");
         } else {
             request.setAttribute(INVALID_CRED_ATTR, "No credentials provided");
-            LOG.error("authenticate: No credentials provided");
+            authErrMsg.insert(0, "authenticate: No credentials provided");
         }
+        LOG.error(authErrMsg.toString());
 
-        throw new ResourceException (ResourceException.UNAUTHORIZED, "Invalid credentials");
+        throw new ResourceException (ResourceException.UNAUTHORIZED, "Invalid credentials: " + authErrMsg.toString());
     }
 
     public static String authenticatedUser(HttpServletRequest request,


### PR DESCRIPTION
@havetisyan Hi Henry,

For now, Athenz servers only provide "Invalid credentials" message in the response.
https://github.com/yahoo/athenz/blob/master/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/rest/Http.java#L137

To let users easily determine the cause of the error, I believe it's better to provide detailed error messages in  the response.

Thank you,
Chris