### PR TITLE
auto cleanup of expired cert records

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/CertSigner.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/CertSigner.java
@@ -59,6 +59,14 @@ public interface CertSigner {
         return null;
     }
 
+    /** Retrieve the certificate max expiry time supported
+     * by the given signer
+     * @return expiry time in minutes
+     */
+    default int getMaxCertExpiryTimeMins() {
+        return 0;
+    }
+    
     /**
      * Close the certSigner signer object and release all
      * allocated resources (if any)

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/CertRecordStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/CertRecordStore.java
@@ -17,12 +17,21 @@ package com.yahoo.athenz.zts.cert;
 
 public interface CertRecordStore {
 
-    // get a new connection to the cert record store
+    /**
+     * Get a new connection to the certificate record store. In case
+     * of failure, a ResourceException is thrown.
+     * @return CertRecordStoreConnection object
+     */
     CertRecordStoreConnection getConnection();
     
-    // operation timeout in seconds
+    /**
+     * Set the operation timeout in seconds
+     * @param opTimeout timeout in seconds
+     */
     void setOperationTimeout(int opTimeout);
     
-    // clear all connections to the cert record store
+    /**
+     * Clear all connections to the cert record store
+     */
     void clearConnections();
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/CertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/CertRecordStoreConnection.java
@@ -19,11 +19,53 @@ import java.io.Closeable;
 
 public interface CertRecordStoreConnection extends Closeable {
 
+    /**
+     * Close the connection to the certificate record store
+     */
     void close();
+    
+    /**
+     * Set the timeout for the certificate record store operation
+     * @param opTimout operation timeout in seconds
+     */
     void setOperationTimeout(int opTimout);
 
+    /**
+     * Retrieve the certificate record for the given instance
+     * @param provider name of the provider
+     * @param instanceId instance id
+     * @return X509CertRecord object or null if not found
+     */
     X509CertRecord getX509CertRecord(String provider, String instanceId);
+    
+    /**
+     * Update the specified certificate record in the store
+     * @param certRecord X509CertRecord to be updated
+     * @return true on success otherwise false
+     */
     boolean updateX509CertRecord(X509CertRecord certRecord);
+    
+    /**
+     * Insert a new certificate record in the store
+     * @param certRecord X509CertRecord to be created
+     * @return true on success otherwise false
+     */
     boolean insertX509CertRecord(X509CertRecord certRecord);
+    
+    /**
+     * Delete the certificate record for the given instance
+     * @param provider name of the provider
+     * @param instanceId instance id
+     * @return true on success otherwise false
+     */
     boolean deleteX509CertRecord(String provider, String instanceId);
+    
+    /**
+     * Delete all expired x509 certificate records. A certificate is
+     * considered expired if it hasn't been updated within the
+     * specified number of minutes
+     * @param expiryTimeMins expiry time in minutes
+     * @return number of records deleted
+     */
+    int deleteExpiredX509CertRecords(int expiryTimeMins);
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/AWSCertRecordStoreFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/AWSCertRecordStoreFactory.java
@@ -127,7 +127,7 @@ public class AWSCertRecordStoreFactory implements CertRecordStoreFactory {
                 mysqlConnectionProperties.setProperty(ATHENZ_DB_PASSWORD, rdsToken);
                 
             } catch (Throwable t) {
-                LOG.error("CredentialsUpdater: unable to update auth token: " + t.getMessage());
+                LOG.error("CredentialsUpdater: unable to update auth token: {}", t.getMessage());
             }
         }
     }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
@@ -68,6 +68,29 @@ public class FileCertRecordStoreConnection implements CertRecordStoreConnection 
         return true;
     }
     
+    @Override
+    public int deleteExpiredX509CertRecords(int expiryTimeMins) {
+        String[] fnames = rootDir.list();
+        if (fnames == null) {
+            return 0;
+        }
+        long currentTime = System.currentTimeMillis();
+        int count = 0;
+        for (String fname : fnames) {
+            
+            // if the modification timestamp is older than
+            // specified number of minutes then we'll delete it
+            
+            File f = new File(rootDir, fname);
+            if (currentTime - f.lastModified() < expiryTimeMins * 60 * 1000) {
+                continue;
+            }
+            f.delete();
+            count += 1;
+        }
+        return count;
+    }
+    
     private synchronized X509CertRecord getCertRecord(String provider, String instanceId) {
         File f = new File(rootDir, provider + "-" + instanceId);
         if (!f.exists()) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -145,23 +145,6 @@ public class InstanceCertManagerTest {
     }
     
     @Test
-    public void testGetX509CertRecordNoConnection() throws IOException {
-        
-        InstanceCertManager instance = new InstanceCertManager(null, null);
-
-        Path path = Paths.get("src/test/resources/athenz.instanceid.pem");
-        String pem = new String(Files.readAllBytes(path));
-        X509Certificate cert = Crypto.loadX509Certificate(pem);
-        
-        CertRecordStore certStore = Mockito.mock(CertRecordStore.class);
-        Mockito.when(certStore.getConnection()).thenReturn(null);
-        instance.setCertStore(certStore);
-
-        X509CertRecord certRecord = instance.getX509CertRecord("ostk", cert);
-        assertNull(certRecord);
-    }
-    
-    @Test
     public void testUpdateX509CertRecord() {
         InstanceCertManager instance = new InstanceCertManager(null, null);
 
@@ -181,19 +164,6 @@ public class InstanceCertManagerTest {
     public void testUpdateX509CertRecordNoCertStore() {
         InstanceCertManager instance = new InstanceCertManager(null, null);
         instance.setCertStore(null);
-        X509CertRecord x509CertRecord = new X509CertRecord();
-        boolean result = instance.updateX509CertRecord(x509CertRecord);
-        assertFalse(result);
-    }
-    
-    @Test
-    public void testUpdateX509CertRecordNoConnection() {
-        InstanceCertManager instance = new InstanceCertManager(null, null);
-
-        CertRecordStore certStore = Mockito.mock(CertRecordStore.class);
-        Mockito.when(certStore.getConnection()).thenReturn(null);
-        instance.setCertStore(certStore);
-
         X509CertRecord x509CertRecord = new X509CertRecord();
         boolean result = instance.updateX509CertRecord(x509CertRecord);
         assertFalse(result);
@@ -225,19 +195,6 @@ public class InstanceCertManagerTest {
     }
     
     @Test
-    public void testInsertX509CertRecordNoConnection() {
-        InstanceCertManager instance = new InstanceCertManager(null, null);
-
-        CertRecordStore certStore = Mockito.mock(CertRecordStore.class);
-        Mockito.when(certStore.getConnection()).thenReturn(null);
-        instance.setCertStore(certStore);
-
-        X509CertRecord x509CertRecord = new X509CertRecord();
-        boolean result = instance.insertX509CertRecord(x509CertRecord);
-        assertFalse(result);
-    }
-    
-    @Test
     public void testDeleteX509CertRecord() {
         InstanceCertManager instance = new InstanceCertManager(null, null);
 
@@ -256,18 +213,6 @@ public class InstanceCertManagerTest {
     public void testDeleteX509CertRecordNoCertStore() {
         InstanceCertManager instance = new InstanceCertManager(null, null);
         instance.setCertStore(null);
-        boolean result = instance.deleteX509CertRecord("provider", "instance");
-        assertFalse(result);
-    }
-    
-    @Test
-    public void testDeleteX509CertRecordNoConnection() {
-        InstanceCertManager instance = new InstanceCertManager(null, null);
-
-        CertRecordStore certStore = Mockito.mock(CertRecordStore.class);
-        Mockito.when(certStore.getConnection()).thenReturn(null);
-        instance.setCertStore(certStore);
-
         boolean result = instance.deleteX509CertRecord("provider", "instance");
         assertFalse(result);
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/AWSCertRecordStoreFactoryTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/AWSCertRecordStoreFactoryTest.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl;
+
+import java.sql.SQLException;
+
+import org.testng.annotations.Test;
+
+import com.yahoo.athenz.zts.ZTSConsts;
+import com.yahoo.athenz.zts.cert.CertRecordStore;
+
+import static org.testng.Assert.*;
+
+public class AWSCertRecordStoreFactoryTest {
+
+    class TestAWSCertRecordStoreFactory extends AWSCertRecordStoreFactory {
+        
+        @Override
+        String getAuthToken(String hostname, int port, String rdsUser, String rdsIamRole) {
+            if (rdsUser.equals("rds-user")) {
+                return "token";
+            }
+            return null;
+        }
+    }
+    
+    @Test
+    public void testCreate() throws SQLException {
+        
+        System.setProperty(ZTSConsts.ZTS_PROP_AWS_RDS_MASTER_INSTANCE, "instance");
+        System.setProperty(ZTSConsts.ZTS_PROP_AWS_RDS_USER, "rds-user");
+        System.setProperty(ZTSConsts.ZTS_PROP_AWS_RDS_IAM_ROLE, "role");
+        System.setProperty(ZTSConsts.ZTS_PROP_AWS_RDS_CREDS_REFRESH_TIME, "1");
+        
+        AWSCertRecordStoreFactory factory = new TestAWSCertRecordStoreFactory();
+        CertRecordStore store = factory.create(null);
+        
+        // sleep a couple of seconds for the updater to run
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException e) {
+        }
+        assertNotNull(store);
+    }
+}

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnectionTest.java
@@ -109,5 +109,44 @@ public class FileCertRecordStoreConnectionTest {
         assertTrue(result);
         
         con.deleteX509CertRecord("unknown", "instance-id");
+        con.close();
+    }
+    
+    @Test
+    public void testdeleteExpiredX509CertRecords() throws Exception {
+        
+        // make sure the directory does not exist
+        
+        ZMSFileChangeLogStore.deleteDirectory(new File("/tmp/zts-cert-tests"));
+
+        FileCertRecordStore store = new FileCertRecordStore(new File("/tmp/zts-cert-tests"));
+        FileCertRecordStoreConnection con = (FileCertRecordStoreConnection) store.getConnection();
+        assertNotNull(con);
+        
+        X509CertRecord certRecord = new X509CertRecord();
+        Date now = new Date();
+
+        certRecord.setService("cn");
+        certRecord.setProvider("ostk");
+        certRecord.setInstanceId("instance-id");
+        certRecord.setCurrentIP("current-ip");
+        certRecord.setCurrentSerial("current-serial");
+        certRecord.setCurrentTime(now);
+        certRecord.setPrevIP("prev-ip");
+        certRecord.setPrevSerial("prev-serial");
+        certRecord.setPrevTime(now);
+        
+        boolean result = con.insertX509CertRecord(certRecord);
+        assertTrue(result);
+        
+        X509CertRecord certRecordCheck = con.getX509CertRecord("ostk", "instance-id");
+        assertNotNull(certRecordCheck);
+        
+        Thread.sleep(1000);
+        con.deleteExpiredX509CertRecords(0);
+
+        certRecordCheck = con.getX509CertRecord("ostk", "instance-id");
+        assertNull(certRecordCheck);
+        con.close();
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/HttpCertSignerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/HttpCertSignerTest.java
@@ -34,7 +34,7 @@ import org.testng.annotations.Test;
 public class HttpCertSignerTest {
     
     @BeforeClass
-    public void stup() {
+    public void setup() {
         System.setProperty(ZTSConsts.ZTS_PROP_CERTSIGN_BASE_URI, "https://localhost:443/certsign/v2");
     }
     
@@ -308,5 +308,24 @@ public class HttpCertSignerTest {
         String pem = certSigner.getSSHCertificate("user");
         assertNotNull(pem);
         assertEquals(pem, "user-key");
+    }
+    
+    @Test
+    public void testGetMaxCertExpiryTime() {
+        
+        System.clearProperty(ZTSConsts.ZTS_PROP_CERTSIGN_MAX_EXPIRY_TIME);
+        
+        HttpCertSignerFactory certFactory = new HttpCertSignerFactory();
+        
+        HttpCertSigner certSigner = (HttpCertSigner) certFactory.create();
+        assertEquals(certSigner.getMaxCertExpiryTimeMins(), 43200);
+        certSigner.close();
+        
+        System.setProperty(ZTSConsts.ZTS_PROP_CERTSIGN_MAX_EXPIRY_TIME, "1200");
+        certSigner = (HttpCertSigner) certFactory.create();
+        assertEquals(certSigner.getMaxCertExpiryTimeMins(), 1200);
+        certSigner.close();
+
+        System.clearProperty(ZTSConsts.ZTS_PROP_CERTSIGN_MAX_EXPIRY_TIME);
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreFactoryTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreFactoryTest.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl;
+
+import java.sql.SQLException;
+
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.zts.ZTSConsts;
+import com.yahoo.athenz.zts.cert.CertRecordStore;
+
+import static org.testng.Assert.*;
+
+public class JDBCCertRecordStoreFactoryTest {
+
+    @Test
+    public void testCreate() throws SQLException {
+        
+        System.setProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_STORE, "jdbc:mysql://localhost");
+        System.setProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_USER, "user");
+        System.setProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_PASSWORD, "password");
+        
+        PrivateKeyStore keyStore = Mockito.mock(PrivateKeyStore.class);
+        Mockito.doReturn("password").when(keyStore).getApplicationSecret("jdbc", "password");
+        
+        JDBCCertRecordStoreFactory factory = new JDBCCertRecordStoreFactory();
+        CertRecordStore store = factory.create(keyStore);
+        assertNotNull(store);
+    }
+}

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/SelfCertSignerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/SelfCertSignerTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl;
+
+import static org.testng.Assert.*;
+
+import com.yahoo.athenz.common.server.cert.CertSigner;
+import com.yahoo.athenz.zts.ZTSConsts;
+
+import org.testng.annotations.Test;
+
+public class SelfCertSignerTest {
+    
+    @Test
+    public void testSelfCertSignerFactory() {
+        SelfCertSignerFactory certFactory = new SelfCertSignerFactory();
+        assertNotNull(certFactory);
+
+        CertSigner certSigner = certFactory.create();
+        assertNotNull(certSigner);
+
+        certSigner.close();
+    }
+
+    @Test
+    public void testGetMaxCertExpiryTime() {
+        
+        System.clearProperty(ZTSConsts.ZTS_PROP_CERTSIGN_MAX_EXPIRY_TIME);
+        
+        SelfCertSignerFactory certFactory = new SelfCertSignerFactory();
+        
+        SelfCertSigner certSigner = (SelfCertSigner) certFactory.create();
+        assertEquals(certSigner.getMaxCertExpiryTimeMins(), 43200);
+        certSigner.close();
+        
+        System.setProperty(ZTSConsts.ZTS_PROP_CERTSIGN_MAX_EXPIRY_TIME, "1200");
+        certSigner = (SelfCertSigner) certFactory.create();
+        assertEquals(certSigner.getMaxCertExpiryTimeMins(), 1200);
+        certSigner.close();
+
+        System.clearProperty(ZTSConsts.ZTS_PROP_CERTSIGN_MAX_EXPIRY_TIME);
+    }
+}


### PR DESCRIPTION
ZTS needs to auto cleanup any cert records that are longer than the configured expiry time for the http signer. Those are already expired so there is no point of keeping them and increasing the db size. It will have a daily thread to delete all expired cert records.