### PR TITLE
Keystore implementation handles null password appnames

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -135,7 +135,7 @@ public class ZTSUtils {
     public static String getApplicationSecret(final PrivateKeyStore privateKeyStore,
             final String keyStorePasswordAppName, final String keyStorePassword) {
 
-        if (privateKeyStore == null || keyStorePasswordAppName == null) {
+        if (privateKeyStore == null) {
             return keyStorePassword;
         }
         return privateKeyStore.getApplicationSecret(keyStorePasswordAppName, keyStorePassword);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
@@ -329,7 +329,8 @@ public class ZTSUtilsTest {
         assertEquals(ZTSUtils.getApplicationSecret(null, "appname", "pass"), "pass");
         
         PrivateKeyStore keyStore = Mockito.mock(PrivateKeyStore.class);
-        assertEquals(ZTSUtils.getApplicationSecret(keyStore, null, "pass"), "pass");
+        Mockito.when(keyStore.getApplicationSecret(null, "pass")).thenReturn("app234");
+        assertEquals(ZTSUtils.getApplicationSecret(keyStore, null, "pass"), "app234");
         
         Mockito.when(keyStore.getApplicationSecret("appname", "passname")).thenReturn("app123");
         assertEquals(ZTSUtils.getApplicationSecret(keyStore, "appname", "passname"), "app123");


### PR DESCRIPTION
Keystore implementation handles the case where keyStorePasswordAppName is null so the zts server does not need to check for that in its code.