### PR TITLE
add read only mode of operation to ZTS

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -50,7 +50,8 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_CHANGE_LOG_STORE_DIR   = "athenz.zts.change_log_store_dir";
     public static final String ZTS_PROP_NOAUTH_URI_LIST        = "athenz.zts.no_auth_uri_list";
     public static final String ZTS_PROP_ROLE_COMPLETE_FLAG     = "athenz.zts.role_complete_flag";
-    
+    public static final String ZTS_PROP_READ_ONLY_MODE         = "athenz.zts.read_only_mode";
+
     public static final String ZTS_PROP_CERT_REFRESH_IP_FNAME  = "athenz.zts.cert_refresh_ip_fname";
     public static final String ZTS_PROP_INSTANCE_CERT_IP_FNAME = "athenz.zts.instance_cert_ip_fname";
     

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -122,7 +122,8 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
     protected boolean statusCertSigner = false;
     protected Status successServerStatus = null;
     protected boolean includeRoleCompleteFlag = true;
-    
+    protected boolean readOnlyMode = false;
+
     private static final String TYPE_DOMAIN_NAME = "DomainName";
     private static final String TYPE_SIMPLE_NAME = "SimpleName";
     private static final String TYPE_ENTITY_NAME = "EntityName";
@@ -384,6 +385,11 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         
         includeRoleCompleteFlag = Boolean.parseBoolean(
                 System.getProperty(ZTSConsts.ZTS_PROP_ROLE_COMPLETE_FLAG, "true"));
+        
+        // check if we need to run in maintenance read only mode
+        
+        readOnlyMode = Boolean.parseBoolean(
+                System.getProperty(ZTSConsts.ZTS_PROP_READ_ONLY_MODE, "false"));
     }
     
     static String getServerHostName() {
@@ -1399,6 +1405,11 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         metric.increment(HTTP_POST);
         logPrincipal(ctx);
 
+        if (readOnlyMode) {
+            throw requestError("Server in Maintenance Read-Only mode. Please try your request later",
+                    caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN);
+        }
+        
         validateRequest(ctx.request(), caller);
         validate(domainName, TYPE_DOMAIN_NAME, caller);
         validate(roleName, TYPE_ENTITY_NAME, caller);
@@ -1670,6 +1681,11 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         final String callerTiming = "postinstanceregisterinformation_timing";
         metric.increment(HTTP_POST);
 
+        if (readOnlyMode) {
+            throw requestError("Server in Maintenance Read-Only mode. Please try your request later",
+                    caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN);
+        }
+        
         validateRequest(ctx.request(), caller);
         validate(info, TYPE_INSTANCE_REGISTER_INFO, caller);
         
@@ -1888,6 +1904,11 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         metric.increment(HTTP_POST);
         logPrincipal(ctx);
 
+        if (readOnlyMode) {
+            throw requestError("Server in Maintenance Read-Only mode. Please try your request later",
+                    caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN);
+        }
+        
         validateRequest(ctx.request(), caller);
         validate(provider, TYPE_SERVICE_NAME, caller);
         validate(domain, TYPE_DOMAIN_NAME, caller);
@@ -2229,6 +2250,11 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         metric.increment(HTTP_POST);
         logPrincipal(ctx);
 
+        if (readOnlyMode) {
+            throw requestError("Server in Maintenance Read-Only mode. Please try your request later",
+                    caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN);
+        }
+        
         validateRequest(ctx.request(), caller);
         validate(provider, TYPE_SERVICE_NAME, caller);
         validate(domain, TYPE_DOMAIN_NAME, caller);
@@ -2277,6 +2303,11 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         metric.increment(HTTP_POST);
         logPrincipal(ctx);
 
+        if (readOnlyMode) {
+            throw requestError("Server in Maintenance Read-Only mode. Please try your request later",
+                    caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN);
+        }
+        
         validateRequest(ctx.request(), caller);
         validate(domain, TYPE_DOMAIN_NAME, caller);
         validate(service, TYPE_SIMPLE_NAME, caller);
@@ -2449,8 +2480,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         metric.increment(HTTP_POST);
         logPrincipal(ctx);
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("postOSTKInstanceInformation: " + info);
+        if (readOnlyMode) {
+            throw requestError("Server in Maintenance Read-Only mode. Please try your request later",
+                    caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN);
         }
         
         validateRequest(ctx.request(), caller);
@@ -2565,8 +2597,9 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         metric.increment(HTTP_POST);
         logPrincipal(ctx);
 
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("postOSTKInstanceRefreshRequest: " + req);
+        if (readOnlyMode) {
+            throw requestError("Server in Maintenance Read-Only mode. Please try your request later",
+                    caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN);
         }
         
         validateRequest(ctx.request(), caller);
@@ -2854,6 +2887,11 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         metric.increment(HTTP_POST);
         logPrincipal(ctx);
 
+        if (readOnlyMode) {
+            throw requestError("Server in Maintenance Read-Only mode. Please try your request later",
+                    caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN);
+        }
+        
         validateRequest(ctx.request(), caller);
         validate(domainName, TYPE_DOMAIN_NAME, caller);
         validate(domainMetrics, TYPE_DOMAIN_METRICS, caller);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
@@ -70,6 +70,12 @@ public class InstanceCertManager {
         }
     }
     
+    public void shutdown() {
+        if (scheduledExecutor != null) {
+            scheduledExecutor.shutdownNow();
+        }
+    }
+    
     boolean loadAllowedIPAddresses(List<IPBlock> ipBlocks, final String propName) {
         
         // get the configured path for the list of ip addresses

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
@@ -90,6 +90,7 @@ public class CloudStore {
         
         httpClient = new HttpClient();
         httpClient.setFollowRedirects(false);
+        httpClient.setStopTimeout(1000);
         try {
             httpClient.start();
         } catch (Exception ex) {
@@ -125,23 +126,26 @@ public class CloudStore {
         initializeAwsSupport();
     }
     
-    void close() {
-        if (httpClient != null) {
-            try {
-                httpClient.stop();
-            } catch (Exception e) {
-            }
+    public void close() {
+        if (scheduledThreadPool != null) {
+            scheduledThreadPool.shutdownNow();
         }
+        stopHttpClient();
     }
     
     public void setHttpClient(HttpClient client) {
-        if (httpClient != null) {
-            try {
-                httpClient.stop();
-            } catch (Exception e) {
-            }
-        }
+        stopHttpClient();
         httpClient = client;
+    }
+    
+    void stopHttpClient() {
+        if (httpClient == null) {
+            return;
+        }
+        try {
+            httpClient.stop();
+        } catch (Exception e) {
+        }
     }
     
     public boolean isAwsEnabled() {

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
@@ -974,6 +974,9 @@ public class DataStore implements DataCacheProvider {
     }
 
     public void setCloudStore(CloudStore cloudStore) {
+        if (this.cloudStore != null) {
+            this.cloudStore.close();
+        }
         this.cloudStore = cloudStore;
     }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/InstanceProviderManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/InstanceProviderManagerTest.java
@@ -38,7 +38,6 @@ import org.testng.annotations.Test;
 import com.yahoo.athenz.auth.util.Crypto;
 import com.yahoo.athenz.common.utils.SignUtils;
 import com.yahoo.athenz.instance.provider.InstanceProvider;
-import com.yahoo.athenz.instance.provider.InstanceProviderClient;
 import com.yahoo.athenz.zms.DomainData;
 import com.yahoo.athenz.zms.Role;
 import com.yahoo.athenz.zms.RoleMember;

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -25,9 +25,6 @@ import com.yahoo.athenz.zts.InstanceIdentity;
 import com.yahoo.athenz.zts.ZTSConsts;
 import com.yahoo.athenz.zts.store.impl.ZMSFileChangeLogStore;
 import com.yahoo.athenz.zts.utils.IPBlock;
-import com.yahoo.athenz.zts.utils.IPPrefix;
-import com.yahoo.athenz.zts.utils.IPPrefixes;
-import com.yahoo.rdl.JSON;
 
 public class InstanceCertManagerTest {
 
@@ -53,6 +50,7 @@ public class InstanceCertManagerTest {
         assertEquals(identity.getName(), "cn");
         assertEquals(identity.getX509Certificate(), cert);
         assertEquals(identity.getX509CertificateSigner(), caCert);
+        instanceManager.shutdown();
     }
     
     @Test
@@ -64,6 +62,7 @@ public class InstanceCertManagerTest {
         InstanceCertManager instanceManager = new InstanceCertManager(null, certSigner);
         InstanceIdentity identity = instanceManager.generateIdentity("csr", "cn", null, 0);
         assertNull(identity);
+        instanceManager.shutdown();
     }
     
     @Test
@@ -75,6 +74,7 @@ public class InstanceCertManagerTest {
         InstanceCertManager instanceManager = new InstanceCertManager(null, certSigner);
         InstanceIdentity identity = instanceManager.generateIdentity("csr", "cn", null, 0);
         assertNull(identity);
+        instanceManager.shutdown();
     }
     
     @Test
@@ -96,6 +96,7 @@ public class InstanceCertManagerTest {
         
         X509CertRecord certRecord = instance.getX509CertRecord("ostk", cert);
         assertNotNull(certRecord);
+        instance.shutdown();
     }
     
     @Test
@@ -113,6 +114,7 @@ public class InstanceCertManagerTest {
         
         X509CertRecord certRecord = instance.getX509CertRecord("ostk", "1001");
         assertNotNull(certRecord);
+        instance.shutdown();
     }
     
     @Test
@@ -121,6 +123,7 @@ public class InstanceCertManagerTest {
         instance.setCertStore(null);
         X509CertRecord certRecord = instance.getX509CertRecord("ostk", (X509Certificate) null);
         assertNull(certRecord);
+        instance.shutdown();
     }
     
     @Test
@@ -142,6 +145,7 @@ public class InstanceCertManagerTest {
 
         X509CertRecord certRecord = instance.getX509CertRecord("ostk", cert);
         assertNull(certRecord);
+        instance.shutdown();
     }
     
     @Test
@@ -158,6 +162,7 @@ public class InstanceCertManagerTest {
         X509CertRecord x509CertRecord = new X509CertRecord();
         boolean result = instance.updateX509CertRecord(x509CertRecord);
         assertTrue(result);
+        instance.shutdown();
     }
     
     @Test
@@ -167,6 +172,7 @@ public class InstanceCertManagerTest {
         X509CertRecord x509CertRecord = new X509CertRecord();
         boolean result = instance.updateX509CertRecord(x509CertRecord);
         assertFalse(result);
+        instance.shutdown();
     }
     
     @Test
@@ -183,6 +189,7 @@ public class InstanceCertManagerTest {
         X509CertRecord x509CertRecord = new X509CertRecord();
         boolean result = instance.insertX509CertRecord(x509CertRecord);
         assertTrue(result);
+        instance.shutdown();
     }
     
     @Test
@@ -192,6 +199,7 @@ public class InstanceCertManagerTest {
         X509CertRecord x509CertRecord = new X509CertRecord();
         boolean result = instance.insertX509CertRecord(x509CertRecord);
         assertFalse(result);
+        instance.shutdown();
     }
     
     @Test
@@ -207,6 +215,7 @@ public class InstanceCertManagerTest {
 
         boolean result = instance.deleteX509CertRecord("provider", "instance");
         assertTrue(result);
+        instance.shutdown();
     }
     
     @Test
@@ -234,6 +243,7 @@ public class InstanceCertManagerTest {
         Mockito.when(certSigner.getSSHCertificate(ZTSConsts.ZTS_SSH_USER)).thenReturn(null);
         assertEquals(instanceManager.getSshCertificateSigner("host"), "ssh-host");
         assertEquals(instanceManager.getSshCertificateSigner("user"), "ssh-user");
+        instanceManager.shutdown();
     }
     
     @Test
@@ -248,6 +258,7 @@ public class InstanceCertManagerTest {
         result = instanceManager.generateSshIdentity(identity, "", null);
         assertTrue(result);
         assertNull(identity.getSshCertificate());
+        instanceManager.shutdown();
     }
     
     @Test
@@ -272,6 +283,7 @@ public class InstanceCertManagerTest {
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         boolean result = instanceManager.generateSshIdentity(identity, sshCsr, "host");
         assertFalse(result);
+        instanceManager.shutdown();
     }
     
     @Test
@@ -287,6 +299,7 @@ public class InstanceCertManagerTest {
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.service");
         boolean result = instanceManager.generateSshIdentity(identity, sshCsr, "host");
         assertFalse(result);
+        instanceManager.shutdown();
     }
     
     @Test
@@ -304,6 +317,7 @@ public class InstanceCertManagerTest {
         assertTrue(result);
         assertEquals(identity.getSshCertificate(), "ssh-cert");
         assertEquals(identity.getSshCertificateSigner(), "ssh-host");
+        instanceManager.shutdown();
     }
     
     @Test
@@ -329,6 +343,7 @@ public class InstanceCertManagerTest {
         assertTrue(instance.verifyCertRefreshIPAddress("10.2.9.25"));
         assertTrue(instance.verifyCertRefreshIPAddress("11.1.3.25"));
         assertTrue(instance.verifyCertRefreshIPAddress("11.1.9.25"));
+        instance.shutdown();
     }
     
     @Test
@@ -372,6 +387,7 @@ public class InstanceCertManagerTest {
         
         assertFalse(instance.verifyInstanceCertIPAddress("10.1.3.25"));
         assertFalse(instance.verifyInstanceCertIPAddress("10.1.9.25"));
+        instance.shutdown();
     }
     
     @Test
@@ -403,5 +419,6 @@ public class InstanceCertManagerTest {
         assertFalse(instance.loadAllowedIPAddresses(ipBlocks, propName));
 
         System.clearProperty(propName);
+        instance.shutdown();
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/HttpCertSignerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/HttpCertSignerTest.java
@@ -63,6 +63,7 @@ public class HttpCertSignerTest {
         Mockito.when(request.send()).thenThrow(new TimeoutException());
 
         assertNull(certSigner.generateX509Certificate("csr", null, 0));
+        certSigner.close();
     }
 
     @Test
@@ -82,6 +83,7 @@ public class HttpCertSignerTest {
         Mockito.when(response.getStatus()).thenReturn(400);
 
         assertNull(certSigner.generateX509Certificate("csr", null, 0));
+        certSigner.close();
     }
 
     @Test
@@ -102,6 +104,7 @@ public class HttpCertSignerTest {
         Mockito.when(response.getContentAsString()).thenReturn(null);
 
         assertNull(certSigner.generateX509Certificate("csr", null, 0));
+        certSigner.close();
     }
 
     @Test
@@ -122,6 +125,7 @@ public class HttpCertSignerTest {
         Mockito.when(response.getContentAsString()).thenReturn("");
 
         assertNull(certSigner.generateX509Certificate("csr", null, 0));
+        certSigner.close();
     }
 
     @Test
@@ -143,6 +147,7 @@ public class HttpCertSignerTest {
 
         String pem = certSigner.generateX509Certificate("csr", null, 0);
         assertEquals(pem, "pem-value");
+        certSigner.close();
     }
 
     @Test
@@ -166,6 +171,7 @@ public class HttpCertSignerTest {
 
         Mockito.when(response.getContentAsString()).thenReturn("invalid-json");
         assertNull(certSigner.generateX509Certificate("csr", null, 0));
+        certSigner.close();
     }
 
     @Test
@@ -180,6 +186,7 @@ public class HttpCertSignerTest {
         Mockito.when(httpClient.GET("https://localhost:443/certsign/v2/x509")).thenThrow(new TimeoutException());
 
         assertNull(certSigner.getCACertificate());
+        certSigner.close();
     }
 
     @Test
@@ -196,6 +203,7 @@ public class HttpCertSignerTest {
         Mockito.when(response.getStatus()).thenReturn(400);
 
         assertNull(certSigner.getCACertificate());
+        certSigner.close();
     }
 
     @Test
@@ -213,6 +221,7 @@ public class HttpCertSignerTest {
         Mockito.when(response.getContentAsString()).thenReturn(null);
 
         assertNull(certSigner.getCACertificate());
+        certSigner.close();
     }
 
     @Test
@@ -230,6 +239,7 @@ public class HttpCertSignerTest {
         Mockito.when(response.getContentAsString()).thenReturn("");
 
         assertNull(certSigner.getCACertificate());
+        certSigner.close();
     }
 
     @Test
@@ -248,6 +258,7 @@ public class HttpCertSignerTest {
 
         String pem = certSigner.getCACertificate();
         assertEquals(pem, "pem-value");
+        certSigner.close();
     }
 
     @Test
@@ -268,6 +279,7 @@ public class HttpCertSignerTest {
 
         Mockito.when(response.getContentAsString()).thenReturn("invalid-json");
         assertNull(certSigner.getCACertificate());
+        certSigner.close();
     }
     
     @Test
@@ -289,6 +301,7 @@ public class HttpCertSignerTest {
 
         String pem = certSigner.generateSSHCertificate("ssh-key-req");
         assertEquals(pem, "ssh-key");
+        certSigner.close();
     }
     
     @Test
@@ -308,6 +321,7 @@ public class HttpCertSignerTest {
         String pem = certSigner.getSSHCertificate("user");
         assertNotNull(pem);
         assertEquals(pem, "user-key");
+        certSigner.close();
     }
     
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
@@ -682,6 +682,7 @@ public class CloudStoreTest {
         assertEquals(awsCreds.getAccessKeyId(), "accesskeyid");
         assertEquals(awsCreds.getSessionToken(), "sessiontoken");
         assertEquals(awsCreds.getSecretAccessKey(), "secretaccesskey");
+        cloudStore.close();
     }
     
     @Test
@@ -697,5 +698,6 @@ public class CloudStoreTest {
         
         final String req3 = "{invalid-json";
         assertNull(cloudStore.getSshKeyReqType(req3));
+        cloudStore.close();
     }
 }


### PR DESCRIPTION
if athenz.zts.read_only_mode property is set to true then all post operations for x.509 certificates will be rejected since those require write access to the certificate record database.

this is useful when there are db operations that need to be carried that would require zts to be in read only mode (we already have same functionality in zms server).