### PR TITLE
ZTS should not send empty policy data since the client must expand the expiration periodically.

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -885,14 +885,6 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
         EntityTag eTag = new EntityTag(modified.toString());
         String tag = eTag.toString();
         
-        // Set timestamp for domain rather than youngest policy.
-        // Since a policy could have been deleted, and can only be detected
-        // via the domain modified timestamp.
-        
-        if (matchingTag != null && matchingTag.equals(tag)) {
-            signedPoliciesResult.done(ResourceException.NOT_MODIFIED, matchingTag);
-        }
-        
         // first get our PolicyData object
         
         PolicyData policyData = new PolicyData()


### PR DESCRIPTION
I believe ZTS should not send empty policy data since the client must expand the expiration periodically.

When ZPU receives an empty data, it doesn't update the policy file, nor the expiration.
https://github.com/yahoo/athenz/blob/86165415e025ce5f3c6ba862c04e2cb3c2ec1b53/utils/zpe-updater/zpu_client.go#L90-L93

I think it's ok to send empty policy data with "HTTP/1.1 304 Not Modified" if the zpe client is not checking the expiration of the policy file.
And the current implementation of this open-source seems to not be checking it.
https://github.com/yahoo/athenz/search?utf8=%E2%9C%93&q=DENY_DOMAIN_EXPIRED&type=

However, the previous implementation does so, I think we should keep the backward compatibility.