### PR TITLE
cert refresher fixes

### DIFF
--- a/libs/java/cert_refresher/examples/tls-support/src/main/java/com/yahoo/athenz/example/http/tls/client/HttpTLSClient.java
+++ b/libs/java/cert_refresher/examples/tls-support/src/main/java/com/yahoo/athenz/example/http/tls/client/HttpTLSClient.java
@@ -57,6 +57,7 @@ public class HttpTLSClient {
         try {
             KeyRefresher keyRefresher = Utils.generateKeyRefresher(trustStorePath, trustStorePassword,
                     certPath, keyPath);
+            keyRefresher.startup();
             SSLContext sslContext = Utils.buildSSLContext(keyRefresher.getKeyManagerProxy(),
                     keyRefresher.getTrustManagerProxy());
             

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/SocketTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/SocketTest.java
@@ -49,7 +49,7 @@ import static org.junit.Assert.assertEquals;
 public class SocketTest {
 
     private final int listenPort = 2000;
-    private boolean running = true;
+    private final boolean running = true;
     private KeyRefresher keyRefresher;
 
     @Before
@@ -74,6 +74,7 @@ public class SocketTest {
         SSLServerSocket sslServerSocket = (SSLServerSocket) sslServerSocketFactory.createServerSocket(port);
 
         new Thread(() -> {
+            //noinspection InfiniteLoopStatement
             while(running) {
                 try {
                     final Socket s = sslServerSocket.accept();
@@ -83,6 +84,7 @@ public class SocketTest {
                             BufferedReader is = new BufferedReader(new InputStreamReader(s.getInputStream()));
                             OutputStream os = s.getOutputStream();
 
+                            //noinspection ConstantConditions,InfiniteLoopStatement
                             while(running) {
                                 String line = is.readLine();
                                 if (line.equals("ping")) {


### PR DESCRIPTION
2 fixes for the cert refresher logic when checking for file updates

a) it was correctly storing the checksum so it would treat the file as changed
b) if the file is a relative path, it came from resources and as such it should not check for any updates.