### PR TITLE
aws temporary creds enhancements

### DIFF
--- a/clients/go/zts/client.go
+++ b/clients/go/zts/client.go
@@ -687,9 +687,9 @@ func (client ZTSClient) PostInstanceRefreshRequest(domain CompoundName, service 
 	}
 }
 
-func (client ZTSClient) GetAWSTemporaryCredentials(domainName DomainName, role AWSArnRoleName) (*AWSTemporaryCredentials, error) {
+func (client ZTSClient) GetAWSTemporaryCredentials(domainName DomainName, role AWSArnRoleName, durationSeconds *int32, externalId string) (*AWSTemporaryCredentials, error) {
 	var data *AWSTemporaryCredentials
-	url := client.URL + "/domain/" + fmt.Sprint(domainName) + "/role/" + fmt.Sprint(role) + "/creds"
+	url := client.URL + "/domain/" + fmt.Sprint(domainName) + "/role/" + fmt.Sprint(role) + "/creds" + encodeParams(encodeOptionalInt32Param("durationSeconds", durationSeconds), encodeStringParam("externalId", string(externalId), ""))
 	resp, err := client.httpGet(url, nil)
 	if err != nil {
 		return data, err

--- a/clients/go/zts/zts_schema.go
+++ b/clients/go/zts/zts_schema.go
@@ -460,6 +460,8 @@ func init() {
 	mGetAWSTemporaryCredentials.Comment("perform an AWS AssumeRole of the target role and return the credentials. ZTS must have been granted the ability to assume the role in IAM, and granted the ability to ASSUME_AWS_ROLE in Athenz for this to succeed.")
 	mGetAWSTemporaryCredentials.Input("domainName", "DomainName", true, "", "", false, nil, "name of the domain containing the role, which implies the target account")
 	mGetAWSTemporaryCredentials.Input("role", "AWSArnRoleName", true, "", "", false, nil, "the target AWS role name in the domain account, in Athenz terms, i.e. \"the.role\"")
+	mGetAWSTemporaryCredentials.Input("durationSeconds", "Int32", false, "durationSeconds", "", true, nil, "how long the aws temp creds should be issued for")
+	mGetAWSTemporaryCredentials.Input("externalId", "String", false, "externalId", "", true, nil, "aws assume role external id")
 	mGetAWSTemporaryCredentials.Auth("", "", true, "")
 	mGetAWSTemporaryCredentials.Exception("BAD_REQUEST", "ResourceError", "")
 	mGetAWSTemporaryCredentials.Exception("FORBIDDEN", "ResourceError", "")

--- a/clients/java/zts/examples/tls-support/pom.xml
+++ b/clients/java/zts/examples/tls-support/pom.xml
@@ -27,7 +27,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <athenz.version>1.7.41</athenz.version>
+    <athenz.version>1.7.46</athenz.version>
   </properties>
 
   <dependencies>

--- a/clients/java/zts/examples/tls-support/src/main/java/com/yahoo/athenz/example/zts/tls/client/ZTSAWSCredsClient.java
+++ b/clients/java/zts/examples/tls-support/src/main/java/com/yahoo/athenz/example/zts/tls/client/ZTSAWSCredsClient.java
@@ -54,6 +54,9 @@ public class ZTSAWSCredsClient {
         final String ztsUrl = cmd.getOptionValue("ztsurl");
         final String keyPath = cmd.getOptionValue("key");
         final String certPath = cmd.getOptionValue("cert");
+        final String externalId = cmd.getOptionValue("id");
+        final String minTime = cmd.getOptionValue("min");
+        final String maxTime = cmd.getOptionValue("max");
         final String trustStorePath = cmd.getOptionValue("trustStorePath");
         final String trustStorePassword = cmd.getOptionValue("trustStorePassword");
 
@@ -68,9 +71,11 @@ public class ZTSAWSCredsClient {
                     keyRefresher.getTrustManagerProxy());
             
             // obtain temporary credential provider for our domain and role
-            
+
+            Integer minTimeSeconds = (minTime != null) ? Integer.parseInt(minTime) : null;
+            Integer maxTimeSeconds = (maxTime != null) ? Integer.parseInt(maxTime) : null;
             AWSCredentialsProviderImpl awsCredProvider = new AWSCredentialsProviderImpl(ztsUrl,
-                    sslContext, domainName, roleName);
+                    sslContext, domainName, roleName, externalId, minTimeSeconds, maxTimeSeconds);
 
             // retrieve and display aws temporary creds. Typically you just pass
             // the AWSCredentialsProvider object to any AWS api that requires it.
@@ -141,7 +146,7 @@ public class ZTSAWSCredsClient {
         Option cert = new Option("c", "cert", true, "certficate path");
         cert.setRequired(true);
         options.addOption(cert);
-        
+
         Option trustStore = new Option("t", "trustStorePath", true, "CA TrustStore path");
         trustStore.setRequired(true);
         options.addOption(trustStore);
@@ -153,7 +158,19 @@ public class ZTSAWSCredsClient {
         Option ztsUrl = new Option("z", "ztsurl", true, "ZTS Server url");
         ztsUrl.setRequired(true);
         options.addOption(ztsUrl);
-        
+
+        Option externalId = new Option("i", "id", true, "external id");
+        externalId.setRequired(false);
+        options.addOption(externalId);
+
+        Option minTime = new Option("n", "min", true, "min expiry time in seconds");
+        minTime.setRequired(false);
+        options.addOption(minTime);
+
+        Option maxTime = new Option("x", "max", true, "max expiry time in seconds");
+        maxTime.setRequired(false);
+        options.addOption(maxTime);
+
         CommandLineParser parser = new DefaultParser();
         HelpFormatter formatter = new HelpFormatter();
         CommandLine cmd = null;

--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSRDLGeneratedClient.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSRDLGeneratedClient.java
@@ -348,10 +348,16 @@ public class ZTSRDLGeneratedClient {
 
     }
 
-    public AWSTemporaryCredentials getAWSTemporaryCredentials(String domainName, String role) {
+    public AWSTemporaryCredentials getAWSTemporaryCredentials(String domainName, String role, Integer durationSeconds, String externalId) {
         WebTarget target = base.path("/domain/{domainName}/role/{role}/creds")
             .resolveTemplate("domainName", domainName)
             .resolveTemplate("role", role);
+        if (durationSeconds != null) {
+            target = target.queryParam("durationSeconds", durationSeconds);
+        }
+        if (externalId != null) {
+            target = target.queryParam("externalId", externalId);
+        }
         Invocation.Builder invocationBuilder = target.request("application/json");
         if (credsHeader != null) {
             invocationBuilder = credsHeader.startsWith("Cookie.") ? invocationBuilder.cookie(credsHeader.substring(7),

--- a/clients/java/zts/src/test/java/com/yahoo/athenz/zts/AWSCredentialsProviderImplTest.java
+++ b/clients/java/zts/src/test/java/com/yahoo/athenz/zts/AWSCredentialsProviderImplTest.java
@@ -39,10 +39,10 @@ public class AWSCredentialsProviderImplTest {
         AWSTemporaryCredentials awsTemporaryCredentialsTwo = new AWSTemporaryCredentials();
         awsTemporaryCredentialsTwo.setAccessKeyId("accessKeyTwo");
 
-
         //Check that get credentials calls refresh to get credentials from ZTS
 
-        Mockito.when(ztsClient.getAWSTemporaryCredentials(Mockito.any(), Mockito.any())).thenReturn(awsTemporaryCredentials, awsTemporaryCredentialsTwo);
+        Mockito.when(ztsClient.getAWSTemporaryCredentials(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(awsTemporaryCredentials, awsTemporaryCredentialsTwo);
         AWSCredentialsProviderImpl original = new AWSCredentialsProviderImpl(ztsClient, null, null);
 
         AWSCredentialsProviderImpl awsCredentialsProviderImpl = Mockito.spy(original);
@@ -54,7 +54,8 @@ public class AWSCredentialsProviderImplTest {
         Mockito.verify(awsCredentialsProviderImpl, Mockito.times(2)).refresh();
 
         //null credentials are returned in case of exception
-        Mockito.when(ztsClient.getAWSTemporaryCredentials(Mockito.any(), Mockito.any())).thenThrow(new ResourceException(400));
+        Mockito.when(ztsClient.getAWSTemporaryCredentials(Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any())).thenThrow(new ResourceException(400));
         Assert.assertNull(awsCredentialsProviderImpl.getCredentials());
     }
 }

--- a/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSRDLClientMock.java
+++ b/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSRDLClientMock.java
@@ -157,7 +157,8 @@ public class ZTSRDLClientMock extends ZTSRDLGeneratedClient implements java.io.C
     }
     
     @Override
-    public AWSTemporaryCredentials getAWSTemporaryCredentials(String domainName, String roleName) {
+    public AWSTemporaryCredentials getAWSTemporaryCredentials(String domainName, String roleName,
+            Integer durationSeconds, String externalId) {
         
         if (credsMap.isEmpty()) {
             throw new ZTSClientException(ZTSClientException.NOT_FOUND, "role is not assumed");
@@ -343,7 +344,18 @@ public class ZTSRDLClientMock extends ZTSRDLGeneratedClient implements java.io.C
         access.setGranted(action.equals("access") && resource.equals("resource"));
         return access;
     }
-    
+
+    @Override
+    public ResourceAccess getResourceAccessExt(String action, String resource,
+                                            String trustDomain, String principal) {
+        if (action.equals("exc")) {
+            throw new ResourceException(400, "Invalid request");
+        }
+        ResourceAccess access = new ResourceAccess();
+        access.setGranted(action.equals("access") && resource.equals("resource") && principal.equals("principal"));
+        return access;
+    }
+
     @Override
     public DomainMetrics postDomainMetrics(String domainName, DomainMetrics req) {
         if (domainName.equals("exc")) {

--- a/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
+++ b/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
@@ -458,6 +458,8 @@ public class ZTSSchema {
             .comment("perform an AWS AssumeRole of the target role and return the credentials. ZTS must have been granted the ability to assume the role in IAM, and granted the ability to ASSUME_AWS_ROLE in Athenz for this to succeed.")
             .pathParam("domainName", "DomainName", "name of the domain containing the role, which implies the target account")
             .pathParam("role", "AWSArnRoleName", "the target AWS role name in the domain account, in Athenz terms, i.e. \"the.role\"")
+            .queryParam("durationSeconds", "durationSeconds", "Int32", null, "how long the aws temp creds should be issued for")
+            .queryParam("externalId", "externalId", "String", null, "aws assume role external id")
             .auth("", "", true)
             .expected("OK")
             .exception("BAD_REQUEST", "ResourceError", "")

--- a/core/zts/src/main/rdl/AWSAuth.rdli
+++ b/core/zts/src/main/rdl/AWSAuth.rdli
@@ -25,9 +25,11 @@ type AWSTemporaryCredentials Struct {
 // perform an AWS AssumeRole of the target role and return the credentials. ZTS
 // must have been granted the ability to assume the role in IAM, and granted
 // the ability to ASSUME_AWS_ROLE in Athenz for this to succeed.
-resource AWSTemporaryCredentials GET "/domain/{domainName}/role/{role}/creds" {
+resource AWSTemporaryCredentials GET "/domain/{domainName}/role/{role}/creds?durationSeconds={durationSeconds}&externalId={externalId}" {
     DomainName domainName; //name of the domain containing the role, which implies the target account
     AWSArnRoleName role; //the target AWS role name in the domain account, in Athenz terms, i.e. "the.role"
+    Int32 durationSeconds (optional); //how long the aws temp creds should be issued for
+    String externalId (optional); //aws assume role external id
     authenticate;
     exceptions {
         ResourceError BAD_REQUEST;

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/AWSTemporaryCredentialsTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/AWSTemporaryCredentialsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,13 +16,11 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import org.testng.annotations.Test;
 
 import com.yahoo.rdl.Timestamp;
+
+import static org.testng.Assert.*;
 
 public class AWSTemporaryCredentialsTest {
 
@@ -46,17 +44,19 @@ public class AWSTemporaryCredentialsTest {
         assertEquals(i.getSessionToken(), "test_token");
         assertEquals(i.getExpiration(), Timestamp.fromMillis(123456789123L));
 
-        assertTrue(i.equals(i));
-        
-        assertFalse(i2.equals(i));
+        //noinspection EqualsWithItself
+        assertEquals(i, i);
+
+        assertNotEquals(i2, i);
         i2.setSessionToken(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setSecretAccessKey(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setAccessKeyId(null);
-        assertFalse(i2.equals(i));
-        
-        assertFalse(i.equals(new String()));
+        assertNotEquals(i2, i);
+
+        //noinspection EqualsBetweenInconvertibleTypes
+        assertNotEquals("", i);
 
     }
 

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/AccessTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/AccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,11 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.*;
+
+@SuppressWarnings("EqualsWithItself")
 public class AccessTest {
 
     @Test
@@ -40,13 +40,14 @@ public class AccessTest {
     public void testEqualsSameObj() {
         Access a = new Access().setGranted(true);
         Access b = new Access().setGranted(false);
-        assertTrue(a.equals(a));
-        assertFalse(a.equals(b));
+        assertEquals(a, a);
+        assertNotEquals(a, b);
     }
 
+    @SuppressWarnings("EqualsBetweenInconvertibleTypes")
     @Test
     public void testEqualsDifObj() {
         Access a = new Access();
-        assertFalse(a.equals(new String()));
+        assertNotEquals("", a);
     }
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/AssertionEffectTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/AssertionEffectTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,7 +29,7 @@ public class AssertionEffectTest {
     }
 
     @Test(expectedExceptions = { java.lang.IllegalArgumentException.class })
-    public void TestFromStringNG() throws Exception {
+    public void TestFromStringNG() {
         AssertionEffect.fromString("HOGE");
     }
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/DomainMetricTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/DomainMetricTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,15 +16,14 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.List;
 
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.*;
+
+@SuppressWarnings("EqualsBetweenInconvertibleTypes")
 public class DomainMetricTest {
 
     @Test
@@ -40,7 +39,7 @@ public class DomainMetricTest {
     }
 
     @Test(expectedExceptions = { java.lang.IllegalArgumentException.class })
-    public void testMetricTypeException() throws Exception {
+    public void testMetricTypeException() {
         DomainMetricType.fromString("NOT_EXIST");
     }
 
@@ -54,19 +53,20 @@ public class DomainMetricTest {
         dm2.setMetricType(DomainMetricType.ACCESS_ALLOWED);
         dm2.setMetricVal(1);
 
-        assertTrue(dm1.equals(dm2));
+        assertEquals(dm1, dm2);
 
         // change value
         dm2.setMetricVal(0);
-        assertFalse(dm1.equals(dm2));
+        assertNotEquals(dm1, dm2);
 
         // change type
         dm1.setMetricType(DomainMetricType.ACCESS_ALLOWED_DENY);
-        assertFalse(dm1.equals(dm2));
+        assertNotEquals(dm1, dm2);
 
-        assertFalse(dm1.equals(new String()));
+        assertNotEquals("", dm1);
     }
 
+    @SuppressWarnings("EqualsWithItself")
     @Test
     public void testDomainMetrics() {
         DomainMetrics dms1 = new DomainMetrics();
@@ -75,7 +75,7 @@ public class DomainMetricTest {
         DomainMetric dm = new DomainMetric();
 
         // set/get test
-        List<DomainMetric> dmlist = new ArrayList<DomainMetric>();
+        List<DomainMetric> dmlist = new ArrayList<>();
         dmlist.add(dm);
 
         dms1.setDomainName("test.org");
@@ -88,17 +88,17 @@ public class DomainMetricTest {
 
         //// equals
         // true case
-        assertTrue(dms1.equals(dms1));
-        assertTrue(dms1.equals(dms2));
+        assertEquals(dms1, dms1);
+        assertEquals(dms1, dms2);
 
         // false case
-        dms2.setMetricList(new ArrayList<DomainMetric>());
-        assertFalse(dms1.equals(dms2));
+        dms2.setMetricList(new ArrayList<>());
+        assertNotEquals(dms1, dms2);
 
         dms2.setDomainName("test.net");
-        assertFalse(dms1.equals(dms2));
+        assertNotEquals(dms1, dms2);
 
-        assertFalse(dms1.equals(new String()));
+        assertNotEquals("", dms1);
     }
 
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/DomainSignedPolicyDataTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/DomainSignedPolicyDataTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,6 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,6 +23,9 @@ import org.testng.annotations.Test;
 
 import com.yahoo.rdl.Timestamp;
 
+import static org.testng.Assert.*;
+
+@SuppressWarnings({"EqualsWithItself", "EqualsBetweenInconvertibleTypes"})
 public class DomainSignedPolicyDataTest implements Cloneable {
 
     @Test
@@ -60,7 +59,7 @@ public class DomainSignedPolicyDataTest implements Cloneable {
         a2.setAction("read");
         a2.setEffect(AssertionEffect.ALLOW);
 
-        List<Assertion> al = new ArrayList<Assertion>();
+        List<Assertion> al = new ArrayList<>();
         al.add(a);
 
         // set policy
@@ -71,7 +70,7 @@ public class DomainSignedPolicyDataTest implements Cloneable {
         p2.setName("test_policy");
         p2.setModified(Timestamp.fromMillis(1234567890123L));
 
-        List<Policy> pl = new ArrayList<Policy>();
+        List<Policy> pl = new ArrayList<>();
         pl.add(p);
 
         // set policy data
@@ -130,55 +129,55 @@ public class DomainSignedPolicyDataTest implements Cloneable {
         assertEquals(dspd.getSignedPolicyData(), spd);
 
         // equals true
-        assertTrue(a.equals(a));
-        assertTrue(p.equals(p));
-        assertTrue(pd.equals(pd));
-        assertTrue(spd.equals(spd));
-        assertTrue(dspd.equals(dspd));
+        assertEquals(a, a);
+        assertEquals(p, p);
+        assertEquals(pd, pd);
+        assertEquals(spd, spd);
+        assertEquals(dspd, dspd);
 
         // equals false
-        assertFalse(a2.equals(a));
+        assertNotEquals(a2, a);
         a2.setEffect(null);
-        assertFalse(a2.equals(a));
+        assertNotEquals(a2, a);
         a2.setAction(null);
-        assertFalse(a2.equals(a));
+        assertNotEquals(a2, a);
         a2.setResource(null);
-        assertFalse(a2.equals(a));
+        assertNotEquals(a2, a);
         a2.setRole(null);
-        assertFalse(a2.equals(a));
-        
-        
-        assertFalse(p2.equals(p));
+        assertNotEquals(a2, a);
+
+
+        assertNotEquals(p2, p);
         p2.setModified(null);
-        assertFalse(p2.equals(p));
+        assertNotEquals(p2, p);
         p2.setName(null);
-        assertFalse(p2.equals(p));
-        
-        assertFalse(pd2.equals(pd));
+        assertNotEquals(p2, p);
+
+        assertNotEquals(pd2, pd);
         pd2.setDomain(null);
-        assertFalse(pd2.equals(pd));
-        
-        assertFalse(spd2.equals(spd));
+        assertNotEquals(pd2, pd);
+
+        assertNotEquals(spd2, spd);
         spd2.setModified(null);
-        assertFalse(spd2.equals(spd));
+        assertNotEquals(spd2, spd);
         spd2.setZmsKeyId(null);
-        assertFalse(spd2.equals(spd));
+        assertNotEquals(spd2, spd);
         spd2.setZmsSignature(null);
-        assertFalse(spd2.equals(spd));
+        assertNotEquals(spd2, spd);
         spd2.setPolicyData(null);
-        assertFalse(spd2.equals(spd));
-        
-        assertFalse(dspd2.equals(dspd));
+        assertNotEquals(spd2, spd);
+
+        assertNotEquals(dspd2, dspd);
         dspd2.setSignature(null);
-        assertFalse(dspd2.equals(dspd));
+        assertNotEquals(dspd2, dspd);
         dspd2.setSignedPolicyData(null);
-        assertFalse(dspd2.equals(dspd));
-        
-        assertFalse(a.equals(new String()));
-        assertFalse(p.equals(new String()));
-        assertFalse(pd.equals(new String()));
-        assertFalse(spd.equals(new String()));
-        assertFalse(dspd.equals(new String()));
+        assertNotEquals(dspd2, dspd);
+
+        assertNotEquals("", a);
+        assertNotEquals("", p);
+        assertNotEquals("", pd);
+        assertNotEquals("", spd);
+        assertNotEquals("", dspd);
 
     }
 

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/HostServicesTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/HostServicesTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,6 +23,7 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+@SuppressWarnings({"EqualsWithItself", "EqualsBetweenInconvertibleTypes"})
 public class HostServicesTest {
 
     @Test
@@ -30,7 +31,7 @@ public class HostServicesTest {
         HostServices hs = new HostServices();
         HostServices hs2 = new HostServices();
 
-        List<String> nl = new ArrayList<String>();
+        List<String> nl = new ArrayList<>();
         nl.add("sample.service1");
 
         // set
@@ -41,13 +42,13 @@ public class HostServicesTest {
         // getter assertion
         assertEquals(hs.getHost(), "sample.com");
         assertEquals(hs.getNames(), nl);
-        assertTrue(hs.equals(hs));
-        
-        assertFalse(hs2.equals(hs));
+        assertEquals(hs, hs);
+
+        assertNotEquals(hs2, hs);
         hs2.setHost(null);
-        assertFalse(hs2.equals(hs));
-        
-        assertFalse(hs.equals(new String()));
+        assertNotEquals(hs2, hs);
+
+        assertNotEquals("", hs);
 
     }
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/IdentityTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/IdentityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@ import java.util.HashMap;
 
 import org.testng.annotations.Test;
 
+@SuppressWarnings({"EqualsWithItself", "EqualsBetweenInconvertibleTypes"})
 public class IdentityTest {
 
     @Test
@@ -60,20 +61,20 @@ public class IdentityTest {
         assertEquals(i.getServiceToken(), "sample_token");
         assertEquals(i.getAttributes(), attr);
 
-        assertTrue(i.equals(i));
-        
-        assertFalse(i2.equals(i));
+        assertEquals(i, i);
+
+        assertNotEquals(i2, i);
         i2.setServiceToken(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setSshCertificate(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setCaCertBundle(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setCertificate(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setName(null);
-        assertFalse(i2.equals(i));
-        
-        assertFalse(i.equals(new String()));
+        assertNotEquals(i2, i);
+
+        assertNotEquals("", i);
     }
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceIdentityTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceIdentityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@ import java.util.HashMap;
 
 import org.testng.annotations.Test;
 
+@SuppressWarnings("EqualsWithItself")
 public class InstanceIdentityTest {
 
     @Test
@@ -60,20 +61,21 @@ public class InstanceIdentityTest {
         assertEquals(i.getServiceToken(), "sample_token");
         assertEquals(i.getAttributes(), attr);
 
-        assertTrue(i.equals(i));
-        
-        assertFalse(i2.equals(i));
+        assertEquals(i, i);
+
+        assertNotEquals(i2, i);
         i2.setServiceToken(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setSshCertificate(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setX509CertificateSigner(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setX509CertificateSigner(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setName(null);
-        assertFalse(i2.equals(i));
-        
-        assertFalse(i.equals(new String()));
+        assertNotEquals(i2, i);
+
+        //noinspection EqualsBetweenInconvertibleTypes
+        assertNotEquals("", i);
     }
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceInformationTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceInformationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,11 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.*;
+
+@SuppressWarnings("EqualsBetweenInconvertibleTypes")
 public class InstanceInformationTest {
 
     @Test
@@ -48,23 +47,23 @@ public class InstanceInformationTest {
         assertEquals(i.getService(), "sample.service");
         assertEquals(i.getCsr(), "sample_csr");
 
-        assertTrue(i2.equals(i));
+        assertEquals(i2, i);
         
         i2.setService(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setService("sample.service");
 
         i2.setDomain(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setDomain("sample.com");
 
         i2.setSignature(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         
         i2.setDocument(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
 
-        assertFalse(i.equals(new String()));
+        assertNotEquals("", i);
     }
 
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRefreshInformationTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRefreshInformationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,9 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 public class InstanceRefreshInformationTest {
 
@@ -41,12 +39,12 @@ public class InstanceRefreshInformationTest {
         assertEquals(i.getCsr(), "sample_csr");
         assertEquals(i.getSsh(), "ssh");
         assertEquals(i.getToken(), Boolean.FALSE);
-        
-        assertTrue(i.equals(i2));
+
+        assertEquals(i, i2);
         
         i2.setCsr("sample_csr2");
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setCsr(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
     }
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRefreshRequestTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRefreshRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,11 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.*;
+
+@SuppressWarnings("EqualsWithItself")
 public class InstanceRefreshRequestTest {
 
     @Test
@@ -40,10 +39,11 @@ public class InstanceRefreshRequestTest {
         assertEquals(i.getExpiryTime(), (Integer) 123456789);
         assertEquals(i.getKeyId(), "v0");
 
-        assertTrue(i.equals(i));
-        assertFalse(i.equals(i2));
-        assertFalse(i2.equals(i));
-        assertFalse(i.equals(new String()));
+        assertEquals(i, i);
+        assertNotEquals(i, i2);
+        assertNotEquals(i2, i);
+        //noinspection EqualsBetweenInconvertibleTypes
+        assertNotEquals("", i);
     }
 
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRegisterInformationTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRegisterInformationTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2017 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,11 +16,9 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 public class InstanceRegisterInformationTest {
 
@@ -53,22 +51,22 @@ public class InstanceRegisterInformationTest {
         assertEquals(i.getProvider(), "provider");
         assertEquals(i.getSsh(), "ssh");
         assertEquals(i.getToken(), Boolean.FALSE);
-        
-        assertTrue(i.equals(i2));
+
+        assertEquals(i, i2);
         
         i2.setService(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setService("sample.service");
 
         i2.setDomain(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setDomain("sample.com");
 
         i2.setProvider(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
         i2.setProvider("provider");
 
         i2.setAttestationData(null);
-        assertFalse(i2.equals(i));
+        assertNotEquals(i2, i);
     }
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/RoleAccessTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/RoleAccessTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,6 +22,7 @@ import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+@SuppressWarnings("EqualsWithItself")
 public class RoleAccessTest {
 
     @Test
@@ -36,6 +37,7 @@ public class RoleAccessTest {
     @Test
     public void TestEqualsTrue() {
         RoleAccess ra = new RoleAccess();
+        //noinspection ResultOfMethodCallIgnored
         ra.equals(ra);
     }
 
@@ -46,8 +48,9 @@ public class RoleAccessTest {
 
         List<String> roles = Arrays.asList("role1", "role2", "role3");
         ra1.setRoles(roles);
-        Assert.assertFalse(ra1.equals(ra2));
-        Assert.assertFalse(ra1.equals(new String()));
+        Assert.assertNotEquals(ra1, ra2);
+        //noinspection EqualsBetweenInconvertibleTypes
+        Assert.assertNotEquals("", ra1);
     }
 
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/RoleTokenTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/RoleTokenTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,12 +16,11 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.*;
+
+@SuppressWarnings("EqualsWithItself")
 public class RoleTokenTest {
 
     @Test
@@ -36,11 +35,12 @@ public class RoleTokenTest {
         // getter assertion
         assertEquals(rt.getToken(), "sample_token");
         assertEquals(rt.getExpiryTime(), 30L);
-        assertTrue(rt.equals(rt));
-        assertFalse(rt.equals(rt2));
+        assertEquals(rt, rt);
+        assertNotEquals(rt, rt2);
         rt2.setToken(null);
-        assertFalse(rt2.equals(rt));
-        assertFalse(rt.equals(new String()));
+        assertNotEquals(rt2, rt);
+        //noinspection EqualsBetweenInconvertibleTypes
+        assertNotEquals("", rt);
 
     }
 

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/ServiceIdentityListTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/ServiceIdentityListTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,6 +25,7 @@ import java.util.List;
 
 import org.testng.annotations.Test;
 
+@SuppressWarnings({"ALL", "EqualsWithItself"})
 public class ServiceIdentityListTest {
 
     @Test
@@ -39,8 +40,8 @@ public class ServiceIdentityListTest {
         assertEquals(sil.getNames(), nl);
 
         assertTrue(sil.equals(sil));
+        //noinspection ObjectEqualsNull,ConstantConditions
         assertFalse(sil.equals(null));
         assertFalse(sil.equals(sil2));
     }
-
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/ServiceIdentityTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/ServiceIdentityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +16,6 @@
 
 package com.yahoo.athenz.zts;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -27,8 +23,11 @@ import org.testng.annotations.Test;
 
 import com.yahoo.rdl.Timestamp;
 
+import static org.testng.Assert.*;
+
 public class ServiceIdentityTest {
 
+    @SuppressWarnings({"EqualsWithItself", "ConstantConditions"})
     @Test
     public void testsetgetServiceIdentity() {
         ServiceIdentity si = new ServiceIdentity();
@@ -39,10 +38,10 @@ public class ServiceIdentityTest {
         pkey.setId("key01");
         pkey.setKey("pkey==");
 
-        List<PublicKeyEntry> pkeylist = new ArrayList<PublicKeyEntry>();
+        List<PublicKeyEntry> pkeylist = new ArrayList<>();
         pkeylist.add(pkey);
 
-        List<String> hosts = new ArrayList<String>();
+        List<String> hosts = new ArrayList<>();
         hosts.add("example.host");
 
         si.setExecutable("add-domain");
@@ -77,35 +76,38 @@ public class ServiceIdentityTest {
         assertEquals(si.getUser(), "user.test");
 
         // equals true
-        assertTrue(pkey.equals(pkey));
-        assertTrue(si.equals(si));
+        assertEquals(pkey, pkey);
+        assertEquals(si, si);
 
         // equals false
-        assertFalse(pkey.equals(new String()));
-        assertFalse(pkey.equals(new PublicKeyEntry()));
+        //noinspection EqualsBetweenInconvertibleTypes
+        assertNotEquals("", pkey);
+        assertNotEquals(pkey, new PublicKeyEntry());
         PublicKeyEntry pkey2 = new PublicKeyEntry().setKey("pkey==");
-        assertFalse(pkey2.equals(pkey));
+        assertNotEquals(pkey2, pkey);
 
-        assertFalse(si.equals(new String()));
+        //noinspection EqualsBetweenInconvertibleTypes
+        assertNotEquals("", si);
         
         si2.setGroup(null);
-        assertFalse(si2.equals(si));
+        assertNotEquals(si2, si);
         si2.setUser(null);
-        assertFalse(si2.equals(si));
+        assertNotEquals(si2, si);
         si2.setHosts(null);
-        assertFalse(si2.equals(si));
+        assertNotEquals(si2, si);
         si2.setExecutable(null);
-        assertFalse(si2.equals(si));
+        assertNotEquals(si2, si);
         si2.setModified(null);
-        assertFalse(si2.equals(si));
+        assertNotEquals(si2, si);
         si2.setProviderEndpoint(null);
-        assertFalse(si2.equals(si));
+        assertNotEquals(si2, si);
         si2.setPublicKeys(null);
-        assertFalse(si2.equals(si));
+        assertNotEquals(si2, si);
         si2.setName(null);
-        assertFalse(si2.equals(si));
+        assertNotEquals(si2, si);
+        //noinspection ObjectEqualsNull,SimplifiedTestNGAssertion
         assertFalse(si2.equals(null));
-        assertFalse(si.equals(new ServiceIdentity()));
+        assertNotEquals(si, new ServiceIdentity());
 
     }
 

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/TenantDomainsTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/TenantDomainsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,13 +23,14 @@ import java.util.List;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+@SuppressWarnings("EqualsWithItself")
 public class TenantDomainsTest {
 
     @Test
     public void TestsetgetTenantDomainNames() {
         TenantDomains td = new TenantDomains();
 
-        List<String> list = new ArrayList<String>(Arrays.asList("A", "B", "C"));
+        List<String> list = new ArrayList<>(Arrays.asList("A", "B", "C"));
 
         td.setTenantDomainNames(list);
 
@@ -39,6 +40,7 @@ public class TenantDomainsTest {
     @Test
     public void TestEqualsTrue() {
         TenantDomains td = new TenantDomains();
+        //noinspection ResultOfMethodCallIgnored
         td.equals(td);
     }
 
@@ -47,10 +49,11 @@ public class TenantDomainsTest {
         TenantDomains td1 = new TenantDomains();
         TenantDomains td2 = new TenantDomains();
 
-        td1.setTenantDomainNames(new ArrayList<String>(Arrays.asList("A", "B", "C")));
+        td1.setTenantDomainNames(new ArrayList<>(Arrays.asList("A", "B", "C")));
 
-        Assert.assertFalse(td1.equals(td2));
-        Assert.assertFalse(td1.equals(new String()));
+        Assert.assertNotEquals(td1, td2);
+        //noinspection EqualsBetweenInconvertibleTypes
+        Assert.assertNotEquals("", td1);
     }
 
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/ZTSCoreTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/ZTSCoreTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2016 Yahoo Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSHandler.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSHandler.java
@@ -25,7 +25,7 @@ public interface ZTSHandler {
     public RoleAccess getRoleAccess(ResourceContext context, String domainName, String principal);
     public TenantDomains getTenantDomains(ResourceContext context, String providerDomainName, String userName, String roleName, String serviceName);
     public Identity postInstanceRefreshRequest(ResourceContext context, String domain, String service, InstanceRefreshRequest req);
-    public AWSTemporaryCredentials getAWSTemporaryCredentials(ResourceContext context, String domainName, String role);
+    public AWSTemporaryCredentials getAWSTemporaryCredentials(ResourceContext context, String domainName, String role, Integer durationSeconds, String externalId);
     public Identity postOSTKInstanceInformation(ResourceContext context, OSTKInstanceInformation info);
     public Identity postOSTKInstanceRefreshRequest(ResourceContext context, String domain, String service, OSTKInstanceRefreshRequest req);
     public void postInstanceRegisterInformation(ResourceContext context, InstanceRegisterInformation info, PostInstanceRegisterInformationResult result);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java
@@ -352,11 +352,11 @@ public class ZTSResources {
     @GET
     @Path("/domain/{domainName}/role/{role}/creds")
     @Produces(MediaType.APPLICATION_JSON)
-    public AWSTemporaryCredentials getAWSTemporaryCredentials(@PathParam("domainName") String domainName, @PathParam("role") String role) {
+    public AWSTemporaryCredentials getAWSTemporaryCredentials(@PathParam("domainName") String domainName, @PathParam("role") String role, @QueryParam("durationSeconds") Integer durationSeconds, @QueryParam("externalId") String externalId) {
         try {
             ResourceContext context = this.delegate.newResourceContext(this.request, this.response);
             context.authenticate();
-            AWSTemporaryCredentials e = this.delegate.getAWSTemporaryCredentials(context, domainName, role);
+            AWSTemporaryCredentials e = this.delegate.getAWSTemporaryCredentials(context, domainName, role, durationSeconds, externalId);
             return e;
         } catch (ResourceException e) {
             int code = e.getCode();

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
@@ -40,7 +40,6 @@ import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
 import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
 import com.amazonaws.services.securitytoken.model.Credentials;
 import com.yahoo.athenz.auth.util.Crypto;
-import com.yahoo.athenz.common.server.cert.CertSigner;
 import com.yahoo.athenz.zts.AWSTemporaryCredentials;
 import com.yahoo.athenz.zts.OSTKInstanceInformation;
 import com.yahoo.athenz.zts.ResourceException;
@@ -53,59 +52,58 @@ import com.yahoo.rdl.Timestamp;
 public class CloudStore {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CloudStore.class);
-    
+
     String awsRole = null;
     String awsRegion;
     boolean awsEnabled;
     BasicSessionCredentials credentials;
-    Map<String, String> cloudAccountCache;
-    int credsUpdateTime = 900;
+    private Map<String, String> cloudAccountCache;
     private HttpClient httpClient;
 
-    private static ScheduledExecutorService scheduledThreadPool;
-    
-    public CloudStore(CertSigner certSigner) {
-        
+    private ScheduledExecutorService scheduledThreadPool = null;
+
+    public CloudStore() {
+
         // initialize our account cache
-        
+
         cloudAccountCache = new HashMap<>();
 
         // Instantiate and start our HttpClient
-        
+
         httpClient = new HttpClient();
         httpClient.setFollowRedirects(false);
         httpClient.setStopTimeout(1000);
         try {
             httpClient.start();
         } catch (Exception ex) {
-            LOGGER.error("CloudStore: unable to start http client: " + ex.getMessage());
+            LOGGER.error("CloudStore: unable to start http client", ex);
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
                     "Http client not available");
         }
-        
+
         // check to see if we are given region name
-        
+
         awsRegion = System.getProperty(ZTSConsts.ZTS_PROP_AWS_REGION_NAME);
-        
+
         // initialize aws support
-        
+
         awsEnabled = Boolean.parseBoolean(System.getProperty(ZTSConsts.ZTS_PROP_AWS_ENABLED, "false"));
         initializeAwsSupport();
     }
-    
+
     public void close() {
         if (scheduledThreadPool != null) {
             scheduledThreadPool.shutdownNow();
         }
         stopHttpClient();
     }
-    
+
     public void setHttpClient(HttpClient client) {
         stopHttpClient();
         httpClient = client;
     }
-    
-    void stopHttpClient() {
+
+    private void stopHttpClient() {
         if (httpClient == null) {
             return;
         }
@@ -114,29 +112,29 @@ public class CloudStore {
         } catch (Exception ignored) {
         }
     }
-    
+
     public boolean isAwsEnabled() {
         return awsEnabled;
     }
-    
+
     void initializeAwsSupport() {
-        
+
         // these operations require initialization of aws objects so
         // we'll process them only if we have been configured to run in aws
 
         if (!awsEnabled) {
             return;
         }
-        
+
         // initialize and load our bootstrap data
-        
+
         if (!loadBootMetaData()) {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
                     "Unable to load boot data");
         }
-        
+
         // finally fetch the role credentials
-        
+
         if (!fetchRoleCredentials())  {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
                     "Unable to fetch aws role credentials");
@@ -144,20 +142,20 @@ public class CloudStore {
 
         // Start our thread to get aws temporary credentials
 
-        credsUpdateTime = ZTSUtils.retrieveConfigSetting(ZTSConsts.ZTS_PROP_AWS_CREDS_UPDATE_TIMEOUT, 900);
+        int credsUpdateTime = ZTSUtils.retrieveConfigSetting(ZTSConsts.ZTS_PROP_AWS_CREDS_UPDATE_TIMEOUT, 900);
 
         scheduledThreadPool = Executors.newScheduledThreadPool(1);
         scheduledThreadPool.scheduleAtFixedRate(new RoleCredentialsFetcher(), credsUpdateTime,
                 credsUpdateTime, TimeUnit.SECONDS);
     }
-    
+
     public AmazonS3 getS3Client() {
-        
+
         if (!awsEnabled) {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
                     "AWS Support not enabled");
         }
-        
+
         if (credentials == null) {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
                     "AWS Role credentials are not available");
@@ -170,238 +168,216 @@ public class CloudStore {
     }
 
     boolean loadBootMetaData() {
-        
+
         // first load the dynamic document
-        
+
         String document = getMetaData("/dynamic/instance-identity/document");
         if (document == null) {
             return false;
         }
-        
+
         try {
             if (!parseInstanceInfo(document)) {
                 return false;
             }
         } catch (Exception ex) {
-            LOGGER.error("CloudStore: unable to parse instance identity document: "
-                    + document + ", error: " + ex.getMessage());
+            LOGGER.error("CloudStore: unable to parse instance identity document: {}, error: {}",
+                    document, ex.getMessage());
             return false;
         }
-        
+
         // then the document signature
-        
+
         String docSignature = getMetaData("/dynamic/instance-identity/pkcs7");
         if (docSignature == null) {
             return false;
         }
-        
+
         // next the iam profile data
-        
+
         String iamRole = getMetaData("/meta-data/iam/info");
         if (iamRole == null) {
             return false;
         }
-        
+
         // now parse and extract the profile details. we'll catch
         // all possible index out of bounds exceptions here and just
         // report the error and return false
-        
+
         try {
             if (!parseIamRoleInfo(iamRole)) {
                 return false;
             }
         } catch (Exception ex) {
-            LOGGER.error("CloudStore: unable to parse iam role data: " + iamRole
-                    + ", error: " + ex.getMessage());
+            LOGGER.error("CloudStore: unable to parse iam role data: {}, error: {}",
+                    iamRole, ex.getMessage());
             return false;
         }
-        
+
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("CloudStore: service meta information:");
-            LOGGER.debug("CloudStore:   role:    " + awsRole);
-            LOGGER.debug("CloudStore:   region:  " + awsRegion);
+            LOGGER.debug("CloudStore:   role:   {}", awsRole);
+            LOGGER.debug("CloudStore:   region: {}", awsRegion);
         }
         return true;
     }
-    
+
     boolean parseInstanceInfo(String document) {
-        
-        Struct instStruct = null;
-        try {
-            instStruct = JSON.fromString(document, Struct.class);
-        } catch (Exception ex) {
-            LOGGER.error("CloudStore: unable to parse instance identity document: "
-                    + ex.getMessage());
-        }
-        
+
+        Struct instStruct = JSON.fromString(document, Struct.class);
         if (instStruct == null) {
-            LOGGER.error("CloudStore: unable to parse instance identity document: " + document);
+            LOGGER.error("CloudStore: unable to parse instance identity document: {}", document);
             return false;
         }
-        
+
         // if we're overriding the region name, then we'll
         // extract that value here
-        
+
         if (awsRegion == null || awsRegion.isEmpty()) {
             awsRegion = instStruct.getString("region");
             if (awsRegion == null || awsRegion.isEmpty()) {
-                LOGGER.error("CloudStore: unable to extract region from instance identity document: " + document);
+                LOGGER.error("CloudStore: unable to extract region from instance identity document: {}",
+                        document);
                 return false;
             }
         }
-        
+
         return true;
     }
-        
+
     boolean parseIamRoleInfo(String iamRole) {
-        
-        Struct iamRoleStruct = null;
-        try {
-            iamRoleStruct = JSON.fromString(iamRole, Struct.class);
-        } catch (Exception ex) {
-            LOGGER.error("CloudStore: unable to parse iam role data: " + ex.getMessage());
-        }
-        
+
+        Struct iamRoleStruct = JSON.fromString(iamRole, Struct.class);
         if (iamRoleStruct == null) {
-            LOGGER.error("CloudStore: unable to parse iam role data: " + iamRole);
+            LOGGER.error("CloudStore: unable to parse iam role data: {}", iamRole);
             return false;
         }
-        
+
         // extract and parse our profile arn
         // "InstanceProfileArn" : "arn:aws:iam::1111111111111:instance-profile/iaas.athenz.zts,athenz",
 
         String profileArn = iamRoleStruct.getString("InstanceProfileArn");
         if (profileArn == null || profileArn.isEmpty()) {
-            LOGGER.error("CloudStore: unable to extract InstanceProfileArn from iam role data: " + iamRole);
+            LOGGER.error("CloudStore: unable to extract InstanceProfileArn from iam role data: {}", iamRole);
             return false;
         }
 
         return parseInstanceProfileArn(profileArn);
     }
-    
+
     boolean parseInstanceProfileArn(String profileArn) {
-        
+
         // "InstanceProfileArn" : "arn:aws:iam::1111111111111:instance-profile/iaas.athenz.zts,athenz",
 
         if (!profileArn.startsWith("arn:aws:iam::")) {
-            LOGGER.error("CloudStore: InstanceProfileArn does not start with 'arn:aws:iam::' : " + profileArn);
+            LOGGER.error("CloudStore: InstanceProfileArn does not start with 'arn:aws:iam::' : {}",
+                    profileArn);
             return false;
         }
-        
+
         int idx = profileArn.indexOf(":instance-profile/");
         if (idx == -1) {
-            LOGGER.error("CloudStore: unable to parse InstanceProfileArn: " + profileArn);
+            LOGGER.error("CloudStore: unable to parse InstanceProfileArn: {}", profileArn);
             return false;
         }
-        
+
         final String awsProfile = profileArn.substring(idx + ":instance-profile/".length());
-        
+
         // make sure we have valid profile and account data
-        
+
         if (awsProfile.isEmpty()) {
-            LOGGER.error("CloudStore: unable to extract profile/account data from InstanceProfileArn: " + profileArn);
+            LOGGER.error("CloudStore: unable to extract profile/account data from InstanceProfileArn: {}",
+                    profileArn);
             return false;
         }
-        
+
         // we need to extract the role from the profile
-        
+
         idx = awsProfile.indexOf(',');
         if (idx == -1) {
             awsRole = awsProfile;
         } else {
             awsRole = awsProfile.substring(0, idx);
         }
-    
+
         return true;
     }
-    
+
     boolean fetchRoleCredentials() {
-        
+
         // verify that we have a valid awsRole already retrieved
-        
+
         if (awsRole == null || awsRole.isEmpty()) {
             LOGGER.error("CloudStore: awsRole is not avaialble to fetch role credentials");
             return false;
         }
-        
-        String creds = getMetaData("/meta-data/iam/security-credentials/" + awsRole);
+
+        final String creds = getMetaData("/meta-data/iam/security-credentials/" + awsRole);
         if (creds == null) {
             return false;
         }
-        
-        Struct credsStruct = null;
-        try {
-            credsStruct = JSON.fromString(creds, Struct.class);
-        } catch (Exception ex) {
-            LOGGER.error("CloudStore: unable to parse role credentials data: " + ex.getMessage());
-        }
-        
+
+        Struct credsStruct = JSON.fromString(creds, Struct.class);
         if (credsStruct == null) {
-            LOGGER.error("CloudStore: unable to parse role credentials data: " + creds);
+            LOGGER.error("CloudStore: unable to parse role credentials data: {}", creds);
             return false;
         }
-        
+
         String accessKeyId = credsStruct.getString("AccessKeyId");
         String secretAccessKey = credsStruct.getString("SecretAccessKey");
         String token = credsStruct.getString("Token");
-        
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("CloudStore: access key id: " + accessKeyId);
-            LOGGER.debug("CloudStore: secret access key: " + secretAccessKey);
-        }
-        
-        try {
-            credentials = new BasicSessionCredentials(accessKeyId, secretAccessKey, token);
-        } catch (Exception ex) {
-            LOGGER.error("CloudStore: unable to generate session credentials from: "
-                    + creds + ", error: " + ex.getMessage());
-            return false;
-        }
-        
+
+        credentials = new BasicSessionCredentials(accessKeyId, secretAccessKey, token);
         return true;
     }
-    
+
     String getMetaData(String path) {
-        
+
         final String baseUri = "http://169.254.169.254/latest";
         ContentResponse response;
         try {
             response = httpClient.GET(baseUri + path);
-        } catch (InterruptedException | ExecutionException | TimeoutException e) {
-            LOGGER.error("CloudStore: unable to fetch requested uri '" + path + "': "
-                    + e.getMessage());
+        } catch (InterruptedException | ExecutionException | TimeoutException ex) {
+            LOGGER.error("CloudStore: unable to fetch requested uri '{}':{}",
+                    path, ex.getMessage());
             return null;
         }
         if (response.getStatus() != 200) {
-            LOGGER.error("CloudStore: unable to fetch requested uri '" + path +
-                    "' status: " + response.getStatus());
+            LOGGER.error("CloudStore: unable to fetch requested uri '{}' status:{}",
+                    path, response.getStatus());
             return null;
         }
-        
+
         String data = response.getContentAsString();
         if (data == null || data.isEmpty()) {
-            LOGGER.error("CloudStore: received empty response from uri '" + path +
-                    "' status: " + response.getStatus());
+            LOGGER.error("CloudStore: received empty response from uri '{}' status:{}",
+                    path, response.getStatus());
             return null;
         }
-        
+
         return data;
     }
-    
-    AssumeRoleRequest getAssumeRoleRequest(String account, String roleName, String principal) {
-        
+
+    AssumeRoleRequest getAssumeRoleRequest(String account, String roleName, String principal,
+                                           Integer durationSeconds, String externalId) {
+
         // assume the target role to get the credentials for the client
         // aws format is arn:aws:iam::<account-id>:role/<role-name>
-    
-        String arn = "arn:aws:iam::" + account + ":role/" + roleName;
-        
+
+        final String arn = "arn:aws:iam::" + account + ":role/" + roleName;
+
         AssumeRoleRequest req = new AssumeRoleRequest();
         req.setRoleArn(arn);
         req.setRoleSessionName(principal);
-        
+        if (durationSeconds != null && durationSeconds > 0) {
+            req.setDurationSeconds(durationSeconds);
+        }
+        if (externalId != null && !externalId.isEmpty()) {
+            req.setExternalId(externalId);
+        }
         return req;
     }
-    
+
     AWSSecurityTokenService getTokenServiceClient() {
 
         return AWSSecurityTokenServiceClientBuilder.standard()
@@ -409,42 +385,45 @@ public class CloudStore {
                 .withRegion(Regions.fromName(awsRegion))
                 .build();
     }
-    
-    public AWSTemporaryCredentials assumeAWSRole(String account, String roleName, String principal) {
+
+    public AWSTemporaryCredentials assumeAWSRole(String account, String roleName, String principal,
+                                                 Integer durationSeconds, String externalId) {
 
         if (!awsEnabled) {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
                     "AWS Support not enabled");
         }
 
-        AssumeRoleRequest req = getAssumeRoleRequest(account, roleName, principal);
-        
+        AssumeRoleRequest req = getAssumeRoleRequest(account, roleName, principal,
+                durationSeconds, externalId);
+
         AWSTemporaryCredentials tempCreds;
         try {
             AWSSecurityTokenService client = getTokenServiceClient();
             AssumeRoleResult res = client.assumeRole(req);
-        
+
             Credentials awsCreds = res.getCredentials();
             tempCreds = new AWSTemporaryCredentials()
                 .setAccessKeyId(awsCreds.getAccessKeyId())
                 .setSecretAccessKey(awsCreds.getSecretAccessKey())
                 .setSessionToken(awsCreds.getSessionToken())
                 .setExpiration(Timestamp.fromMillis(awsCreds.getExpiration().getTime()));
-            
+
         } catch (Exception ex) {
-            LOGGER.error("CloudStore: assumeAWSRole - unable to assume role: " + ex.getMessage());
+            LOGGER.error("CloudStore: assumeAWSRole - unable to assume role: {}, error: {}",
+                    req.getRoleArn(), ex.getMessage());
             return null;
         }
-        
+
         return tempCreds;
     }
 
     public String getCloudAccount(String domainName) {
         return cloudAccountCache.get(domainName);
     }
-    
+
     void updateAccount(String domainName, String account) {
-        
+
         /* if we have a value specified for the domain, then we're just
          * going to insert it into our map and update the record. If
          * the new value is not present and we had a value stored before
@@ -456,7 +435,7 @@ public class CloudStore {
             cloudAccountCache.remove(domainName);
         }
     }
-    
+
     public boolean verifyInstanceDocument(OSTKInstanceInformation info, String publicKey) {
 
         // for now we're only validating the document signature
@@ -467,45 +446,43 @@ public class CloudStore {
             verified = Crypto.verify(info.getDocument(), pub, info.getSignature());
             if (!verified) {
                 LOGGER.error("verifyInstanceDocument: OSTK document signature did not match");
-        } else if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("verifyInstanceDocument: OSTK document signature matched");
-        }
+            }
         } catch (Exception ex) {
             LOGGER.error("verifyInstanceDocument: Unable to verify signature: {}",
                     ex.getMessage());
         }
         return verified;
     }
-    
+
     class RoleCredentialsFetcher implements Runnable {
-        
+
         @Override
         public void run() {
 
             if (LOGGER.isDebugEnabled()) {
                 LOGGER.debug("RoleCredentialsFetcher: Starting aws role credentials fetcher task...");
             }
-            
+
             try {
                 fetchRoleCredentials();
             } catch (Exception ex) {
-                LOGGER.error("RoleCredentialsFetcher: unable to fetch aws role credentials: "
-                        + ex.getMessage());
+                LOGGER.error("RoleCredentialsFetcher: unable to fetch aws role credentials: {}",
+                        ex.getMessage());
             }
         }
     }
-    
+
     String getSshKeyReqType(String sshKeyReq) {
-        
+
         Struct keyReq = JSON.fromString(sshKeyReq, Struct.class);
         if (keyReq == null) {
-            LOGGER.error("getSshKeyReqType: Unable to parse ssh key req: " + sshKeyReq);
+            LOGGER.error("getSshKeyReqType: Unable to parse ssh key req: {}", sshKeyReq);
             return null;
         }
-        
+
         String sshType = keyReq.getString(ZTSConsts.ZTS_SSH_TYPE);
         if (sshType == null) {
-            LOGGER.error("getSshKeyReqType: SSH Key request does not have certtype: " + sshKeyReq);
+            LOGGER.error("getSshKeyReqType: SSH Key request does not have certtype: {}", sshKeyReq);
         }
         return sshType;
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -210,7 +210,7 @@ public class ZTSImplTest {
         ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 privateKey, "0");
 
-        cloudStore = new CloudStore(null);
+        cloudStore = new CloudStore();
         cloudStore.setHttpClient(null);
         
         System.setProperty(ZTSConsts.ZTS_PROP_SELF_SIGNER_PRIVATE_KEY_FNAME,
@@ -2139,7 +2139,7 @@ public class ZTSImplTest {
                 1200, null);
         com.yahoo.athenz.auth.token.RoleToken token = new com.yahoo.athenz.auth.token.RoleToken(roleToken.getToken());
         assertNotNull(token);
-        String unsignToken = token.getUnsignedToken();
+        assertNotNull(token.getUnsignedToken());
     }
  
     @Test
@@ -2440,7 +2440,7 @@ public class ZTSImplTest {
         ResourceContext context = createResourceContext(principal);
         
         try {
-            zts.getAWSTemporaryCredentials(context, "athenz.product", "aws_role_name");
+            zts.getAWSTemporaryCredentials(context, "athenz.product", "aws_role_name", null, null);
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 400);
@@ -2461,7 +2461,7 @@ public class ZTSImplTest {
         store.processDomain(signedDomain, false);
         
         try {
-            zts.getAWSTemporaryCredentials(createResourceContext(principal), "athenz.product", "aws_role_name");
+            zts.getAWSTemporaryCredentials(createResourceContext(principal), "athenz.product", "aws_role_name", null, null);
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 403);
@@ -2481,7 +2481,7 @@ public class ZTSImplTest {
         store.processDomain(signedDomain, false);
         
         try {
-            zts.getAWSTemporaryCredentials(createResourceContext(principal), "athenz.product", "aws_role_name");
+            zts.getAWSTemporaryCredentials(createResourceContext(principal), "athenz.product", "aws_role_name", null, null);
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 400);
@@ -2502,14 +2502,14 @@ public class ZTSImplTest {
         store.processDomain(signedDomain, false);
         
         AWSTemporaryCredentials creds = zts.getAWSTemporaryCredentials(
-                createResourceContext(principal), "athenz.product", "aws_role_name");
+                createResourceContext(principal), "athenz.product", "aws_role_name", null, null);
         assertNotNull(creds);
         
         // now try a failure case
         
         try {
             ((MockCloudStore) cloudStore).setMockFields("1234", "aws_role2_name", "user_domain.user101");
-            zts.getAWSTemporaryCredentials(createResourceContext(principal), "athenz.product", "aws_role_name");
+            zts.getAWSTemporaryCredentials(createResourceContext(principal), "athenz.product", "aws_role_name", null, null);
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 400);
@@ -2890,7 +2890,7 @@ public class ZTSImplTest {
     }
     
     @Test
-    public void testPostOSTKInstanceInformationInvalidCsr() throws IOException  {
+    public void testPostOSTKInstanceInformationInvalidCsr() {
         OSTKInstanceInformation info = new OSTKInstanceInformation()
                 .setCsr("invalid-csr")
                 .setDocument("Test Document")
@@ -3458,7 +3458,7 @@ public class ZTSImplTest {
 
         // create zts with a metric we can verify
         
-        CloudStore cloudStore = new CloudStore(null);
+        CloudStore cloudStore = new CloudStore();
         cloudStore.setHttpClient(null);
         ZtsMetricTester metric = new ZtsMetricTester();
         ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
@@ -3774,7 +3774,7 @@ public class ZTSImplTest {
         PrivateKey caPrivateKey = Crypto.loadPrivateKey(caKey, "athenz");
         CertSigner certSigner = new SelfCertSigner(caPrivateKey, caCertificate);
 
-        CloudStore cloudStore = new MockCloudStore(certSigner);
+        CloudStore cloudStore = new MockCloudStore();
         store.setCloudStore(cloudStore);
         zts.cloudStore = cloudStore;
         
@@ -3792,6 +3792,7 @@ public class ZTSImplTest {
     public void testGetRoleTokenCertInvalidRequests() throws Exception{
 
         // this csr is for sports:role.readers role
+
         RoleCertificateRequest req = new RoleCertificateRequest()
                 .setCsr(ROLE_CERT_CORETECH_REQUEST).setExpiryTime(3600L);
         
@@ -4282,7 +4283,7 @@ public class ZTSImplTest {
     }
     
     @Test
-    public void testPostInstanceRegisterInformationInvalidCSR() throws IOException {
+    public void testPostInstanceRegisterInformationInvalidCSR() {
 
         ChangeLogStore structStore = new ZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 privateKey, "0");
@@ -4923,7 +4924,7 @@ public class ZTSImplTest {
     }
     
     @Test
-    public void testPostInstanceRefreshInformationInvalidCSR() throws IOException {
+    public void testPostInstanceRefreshInformationInvalidCSR() {
 
         ChangeLogStore structStore = new ZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 privateKey, "0");
@@ -5536,7 +5537,7 @@ public class ZTSImplTest {
     }
     
     @Test
-    public void testPostInstanceRefreshInformationNullCSRs() throws IOException {
+    public void testPostInstanceRefreshInformationNullCSRs() {
         
         ChangeLogStore structStore = new ZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 privateKey, "0");
@@ -5833,7 +5834,7 @@ public class ZTSImplTest {
     }
     
     @Test
-    public void testDeleteInstanceIdentity() throws IOException {
+    public void testDeleteInstanceIdentity() {
 
         ChangeLogStore structStore = new ZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 privateKey, "0");
@@ -6625,7 +6626,7 @@ public class ZTSImplTest {
     }
 
     @Test
-    public void testPostInstanceRefreshRequestByUserInvalidCsr() throws IOException {
+    public void testPostInstanceRefreshRequestByUserInvalidCsr() {
 
         ChangeLogStore structStore = new ZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 privateKey, "0");

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/MockCloudStore.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/MockCloudStore.java
@@ -28,22 +28,15 @@ import com.yahoo.athenz.zts.store.CloudStore;
 
 public class MockCloudStore extends CloudStore {
 
-    String account = null;
-    String roleName = null;
-    String principal = null;
-    boolean skipSigCheck = false;
-    boolean returnNullClient = false;
+    private String account = null;
+    private String roleName = null;
+    private String principal = null;
     boolean returnSuperAWSRole = false;
-    int identityCheck = 0; // 0 call super, 1 - true, -1 false
     private AssumeRoleResult assumeRoleResult = null;
     private GetCallerIdentityResult callerIdentityResult = null;
     
     public MockCloudStore() {
-        super(null);
-    }
-    
-    public MockCloudStore(CertSigner certSigner) {
-        super(certSigner);
+        super();
     }
 
     @Override
@@ -57,15 +50,7 @@ public class MockCloudStore extends CloudStore {
         this.roleName = roleName;
         this.principal = principal;
     }
-    
-    public void skipDocumentSignatureCheck(boolean skipCheck) {
-        skipSigCheck = skipCheck;
-    }
-    
-    public void setIdentityCheckResult(int idCheck) {
-        identityCheck = idCheck;
-    }
-    
+
     void setAssumeRoleResult(AssumeRoleResult assumeRoleResult) {
         this.assumeRoleResult = assumeRoleResult;
     }
@@ -73,11 +58,7 @@ public class MockCloudStore extends CloudStore {
     void setGetCallerIdentityResult(GetCallerIdentityResult callerIdentityResult) {
         this.callerIdentityResult = callerIdentityResult;
     }
-    
-    void setReturnNullClient(boolean returnNullClient) {
-        this.returnNullClient = returnNullClient;
-    }
-    
+
     @Override
     AWSSecurityTokenServiceClient getTokenServiceClient() {
         AWSSecurityTokenServiceClient client = Mockito.mock(AWSSecurityTokenServiceClient.class);
@@ -91,7 +72,8 @@ public class MockCloudStore extends CloudStore {
     }
     
     @Override
-    public AWSTemporaryCredentials assumeAWSRole(String account, String roleName, String principal) {
+    public AWSTemporaryCredentials assumeAWSRole(String account, String roleName, String principal,
+                                                 Integer durationSeconds, String externalId) {
 
         if (!returnSuperAWSRole) {
             AWSTemporaryCredentials tempCreds = null;
@@ -102,7 +84,7 @@ public class MockCloudStore extends CloudStore {
             
             return tempCreds;
         } else {
-            return super.assumeAWSRole(account, roleName, principal);
+            return super.assumeAWSRole(account, roleName, principal, durationSeconds, externalId);
         }
     }
 }


### PR DESCRIPTION
2 enhancements to the AWS Temporary credentials:

a) if the assume role statement in aws is configued with an external id condition, ZTS server now support this. the zts java and go client apis have been extended to support an additional externalId argument that the caller can specify for improved security of their accounts.

b) aws now supports temp creds of up to 12 hours instead of the previous 1 hour. You can configure this extended limit in your IAM role configuration page. Similarly, ZTS now allows the caller to specify the maximum token timeout value that must be equal or less than the configured IAM value (otherwise STS will reject the request).