### PR TITLE
Use apache connector provider for zts client

### DIFF
--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -629,13 +629,13 @@ public class ZTSClient implements Closeable {
         final ClientConfig config = new ClientConfig();
         config.property(ClientProperties.CONNECT_TIMEOUT, reqConnectTimeout);
         config.property(ClientProperties.READ_TIMEOUT, reqReadTimeout);
-        
+        config.connectorProvider(new ApacheConnectorProvider());
+
         // if we're asked to use a proxy for our request
         // we're going to set the property that is supported
         // by the apache connector and use that
         
         if (proxyUrl != null) {
-            config.connectorProvider(new ApacheConnectorProvider());
             config.property(ClientProperties.PROXY_URI, proxyUrl);
         }
         


### PR DESCRIPTION
Before we were using apache connector only when proxy option was set but we should use it always.