### PR TITLE
mark sig/key id as optional

### DIFF
--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -3557,7 +3557,9 @@ func (self *DomainData) Validate() error {
 }
 
 //
-// SignedDomain - A domain object signed with server's private key
+// SignedDomain - A domain object signed with server's private key. The
+// signature and keyid are optional if the metaonly flag is set to true in the
+// getSignedDomains api call
 //
 type SignedDomain struct {
 
@@ -3569,12 +3571,12 @@ type SignedDomain struct {
 	//
 	// signature generated based on the domain object
 	//
-	Signature string `json:"signature"`
+	Signature string `json:"signature,omitempty" rdl:"optional"`
 
 	//
 	// the identifier of the key used to generate the signature
 	//
-	KeyId string `json:"keyId"`
+	KeyId string `json:"keyId,omitempty" rdl:"optional"`
 }
 
 //
@@ -3622,22 +3624,6 @@ func (self *SignedDomain) UnmarshalJSON(b []byte) error {
 func (self *SignedDomain) Validate() error {
 	if self.Domain == nil {
 		return fmt.Errorf("SignedDomain: Missing required field: domain")
-	}
-	if self.Signature == "" {
-		return fmt.Errorf("SignedDomain.signature is missing but is a required field")
-	} else {
-		val := rdl.Validate(ZMSSchema(), "String", self.Signature)
-		if !val.Valid {
-			return fmt.Errorf("SignedDomain.signature does not contain a valid String (%v)", val.Error)
-		}
-	}
-	if self.KeyId == "" {
-		return fmt.Errorf("SignedDomain.keyId is missing but is a required field")
-	} else {
-		val := rdl.Validate(ZMSSchema(), "String", self.KeyId)
-		if !val.Valid {
-			return fmt.Errorf("SignedDomain.keyId does not contain a valid String (%v)", val.Error)
-		}
 	}
 	return nil
 }

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -385,10 +385,10 @@ func init() {
 	sb.AddType(tDomainData.Build())
 
 	tSignedDomain := rdl.NewStructTypeBuilder("Struct", "SignedDomain")
-	tSignedDomain.Comment("A domain object signed with server's private key")
+	tSignedDomain.Comment("A domain object signed with server's private key. The signature and keyid are optional if the metaonly flag is set to true in the getSignedDomains api call")
 	tSignedDomain.Field("domain", "DomainData", false, nil, "domain object with its roles, policies and services")
-	tSignedDomain.Field("signature", "String", false, nil, "signature generated based on the domain object")
-	tSignedDomain.Field("keyId", "String", false, nil, "the identifier of the key used to generate the signature")
+	tSignedDomain.Field("signature", "String", true, nil, "signature generated based on the domain object")
+	tSignedDomain.Field("keyId", "String", true, nil, "the identifier of the key used to generate the signature")
 	sb.AddType(tSignedDomain.Build())
 
 	tSignedDomains := rdl.NewStructTypeBuilder("Struct", "SignedDomains")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/SignedDomain.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/SignedDomain.java
@@ -3,14 +3,21 @@
 //
 
 package com.yahoo.athenz.zms;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yahoo.rdl.*;
 
 //
-// SignedDomain - A domain object signed with server's private key
+// SignedDomain - A domain object signed with server's private key. The
+// signature and keyid are optional if the metaonly flag is set to true in the
+// getSignedDomains api call
 //
 public class SignedDomain {
     public DomainData domain;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String signature;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String keyId;
 
     public SignedDomain setDomain(DomainData domain) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -328,10 +328,10 @@ public class ZMSSchema {
             .field("applicationId", "String", true, "associated application id");
 
         sb.structType("SignedDomain")
-            .comment("A domain object signed with server's private key")
+            .comment("A domain object signed with server's private key. The signature and keyid are optional if the metaonly flag is set to true in the getSignedDomains api call")
             .field("domain", "DomainData", false, "domain object with its roles, policies and services")
-            .field("signature", "String", false, "signature generated based on the domain object")
-            .field("keyId", "String", false, "the identifier of the key used to generate the signature");
+            .field("signature", "String", true, "signature generated based on the domain object")
+            .field("keyId", "String", true, "the identifier of the key used to generate the signature");
 
         sb.structType("SignedDomains")
             .comment("A list of signed domain objects")

--- a/core/zms/src/main/rdl/SignedDomains.rdli
+++ b/core/zms/src/main/rdl/SignedDomains.rdli
@@ -49,11 +49,13 @@ type DomainData Struct {
     String applicationId (optional); // associated application id
 }
 
-//A domain object signed with server's private key 
+//A domain object signed with server's private key. The signature
+//and keyid are optional if the metaonly flag is set to true in the
+//getSignedDomains api call
 type SignedDomain Struct {
     DomainData domain; //domain object with its roles, policies and services
-    String signature; //signature generated based on the domain object
-    String keyId; //the identifier of the key used to generate the signature
+    String signature (optional); //signature generated based on the domain object
+    String keyId (optional); //the identifier of the key used to generate the signature
 }
 
 //A list of signed domain objects


### PR DESCRIPTION
when the caller requests get signed api with metaonly flag set to true, zms server does not sign any data since there is no data to sign. Thus, for signature and key id, it returns null values. However, those fields are set as required in the rdl so the go client which validates data received from the server, rejects the response as invalid since those values are not preset. those two fields should be marked as optional in the response.