### PR TITLE
SolutionTemplate should be able to use placeholders in names

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -2139,7 +2139,7 @@ public class DBService {
                 Role templateRole = updateTemplateRole(role, domainName, roleName, templateParams);
                 firstEntry = auditLogSeparator(auditDetails, firstEntry);
                 auditDetails.append(" \"add-role\": ");
-                if (!processRole(con, originalRole, domainName, roleName, templateRole,
+                if (!processRole(con, originalRole, domainName, ZMSUtils.removeDomainPrefix(templateRole.getName(), domainName, ROLE_PREFIX), templateRole,
                         admin, auditRef, true, auditDetails)) {
                     return false;
                 }
@@ -2166,7 +2166,7 @@ public class DBService {
                 Policy templatePolicy = updateTemplatePolicy(policy, domainName, policyName, templateParams);
                 firstEntry = auditLogSeparator(auditDetails, firstEntry);
                 auditDetails.append(" \"add-policy\": ");
-                if (!processPolicy(con, originalPolicy, domainName, policyName, templatePolicy,
+                if (!processPolicy(con, originalPolicy, domainName, ZMSUtils.removeDomainPrefix(templatePolicy.getName(), domainName, POLICY_PREFIX), templatePolicy,
                         true, auditDetails)) {
                     return false;
                 }
@@ -2192,7 +2192,7 @@ public class DBService {
                 ServiceIdentity templateServiceIdentity = updateTemplateServiceIdentity(serviceIdentity, domainName, serviceIdentityName, templateParams);
                 firstEntry = auditLogSeparator(auditDetails, firstEntry);
                 auditDetails.append(" \"add-service\": ");
-                if (!processServiceIdentity(con, originalServiceIdentity, domainName, serviceIdentityName,
+                if (!processServiceIdentity(con, originalServiceIdentity, domainName, ZMSUtils.removeDomainPrefixForService(templateServiceIdentity.getName(), domainName),
                     templateServiceIdentity, auditDetails)) {
                     return false;
                 }


### PR DESCRIPTION
As in the current implementation, we cannot use placeholders in the names of role, policy or service. 
For example "builders" cannot be defined with a placeholder. (If we do, the API just doesn't work.)
https://github.com/yahoo/athenz/blob/master/servers/zms/conf/solution_templates.json#L14

However, the intended behavior as the implementation seems to be able to resolve the placeholders in the name field.
https://github.com/yahoo/athenz/blob/c34e24c8ba4c1b23c83faf46dbd9b66be62428ba/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java#L2292-L2298

