### PR TITLE
provide property options to set ssl mode for jdbc connections

### DIFF
--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -193,6 +193,17 @@ athenz.zms.solution_templates_fname=/home/athenz/conf/zms_server/solution_templa
 # the configured MySQL server.
 #athenz.zms.jdbc_ro_password=
 
+# If using the jdbc connector (either mysql or aws) for zms
+# data storage, this property specifies if the jdbc client
+# should establish an SSL connection to the database server or not
+#athenz.zms.jdbc_use_ssl=false
+
+# if using the jdbc connector (either mysql or aws) for zms
+# data storage and the athenz.zms.jdbc_use_ssl property is set
+# to true, this property specifies whether or not the jdbc client
+# must verify the server certificate or not
+#athenz.zms.jdbc_verify_server_certificate=false
+
 # If the athenz.zms.object_store_factory_class property is using
 # the aws rds mysql object store factory identified with
 # com.yahoo.athenz.zms.store.impl.AWSObjectStoreFactory, then

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -42,13 +42,16 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_CONFLICT_RETRY_COUNT      = "athenz.zms.request_conflict_retry_count";
     public static final String ZMS_PROP_CONFLICT_RETRY_SLEEP_TIME = "athenz.zms.request_conflict_retry_sleep_time";
 
-    public static final String ZMS_PROP_JDBC_RW_STORE     = "athenz.zms.jdbc_store";
-    public static final String ZMS_PROP_JDBC_RW_USER      = "athenz.zms.jdbc_user";
-    public static final String ZMS_PROP_JDBC_RW_PASSWORD  = "athenz.zms.jdbc_password";
-    public static final String ZMS_PROP_JDBC_RO_STORE     = "athenz.zms.jdbc_ro_store";
-    public static final String ZMS_PROP_JDBC_RO_USER      = "athenz.zms.jdbc_ro_user";
-    public static final String ZMS_PROP_JDBC_RO_PASSWORD  = "athenz.zms.jdbc_ro_password";
-    public static final String ZMS_PROP_JDBC_APP_NAME     = "athenz.zms.jdbc_app_name";
+    public static final String ZMS_PROP_JDBC_RW_STORE           = "athenz.zms.jdbc_store";
+    public static final String ZMS_PROP_JDBC_RW_USER            = "athenz.zms.jdbc_user";
+    public static final String ZMS_PROP_JDBC_RW_PASSWORD        = "athenz.zms.jdbc_password";
+    public static final String ZMS_PROP_JDBC_RO_STORE           = "athenz.zms.jdbc_ro_store";
+    public static final String ZMS_PROP_JDBC_RO_USER            = "athenz.zms.jdbc_ro_user";
+    public static final String ZMS_PROP_JDBC_RO_PASSWORD        = "athenz.zms.jdbc_ro_password";
+    public static final String ZMS_PROP_JDBC_APP_NAME           = "athenz.zms.jdbc_app_name";
+    public static final String ZMS_PROP_JDBC_VERIFY_SERVER_CERT = "athenz.zms.jdbc_verify_server_certificate";
+    public static final String ZMS_PROP_JDBC_USE_SSL            = "athenz.zms.jdbc_use_ssl";
+
     public static final String ZMS_PROP_FILE_STORE_NAME   = "athenz.zms.file_store_name";
     public static final String ZMS_PROP_FILE_STORE_QUOTA  = "athenz.zms.file_store_quota";
     public static final String ZMS_PROP_FILE_STORE_PATH   = "athenz.zms.file_store_path";
@@ -65,6 +68,11 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_AWS_RDS_MASTER_PORT        = "athenz.zms.aws_rds_master_port";
     public static final String ZMS_PROP_AWS_RDS_REPLICA_INSTANCE   = "athenz.zms.aws_rds_replica_instance";
     public static final String ZMS_PROP_AWS_RDS_CREDS_REFRESH_TIME = "athenz.zms.aws_rds_creds_refresh_time";
+
+    public static final String DB_PROP_USER               = "user";
+    public static final String DB_PROP_PASSWORD           = "password";
+    public static final String DB_PROP_USE_SSL            = "useSSL";
+    public static final String DB_PROP_VERIFY_SERVER_CERT = "verifyServerCertificate";
 
     public static final String ZMS_PROP_USER_AUTHORITY_CLASS      = "athenz.zms.user_authority_class";
     public static final String ZMS_PROP_PRINCIPAL_AUTHORITY_CLASS = "athenz.zms.principal_authority_class";

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/AWSObjectStoreFactory.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/AWSObjectStoreFactory.java
@@ -40,14 +40,6 @@ public class AWSObjectStoreFactory implements ObjectStoreFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(AWSObjectStoreFactory.class);
     
-    static final String ATHENZ_PROP_DB_VERIFY_SERVER_CERT = "athenz.db.verify_server_certificate";
-    static final String ATHENZ_PROP_DB_USE_SSL            = "athenz.db.use_ssl";
-    
-    static final String ATHENZ_DB_USER               = "user";
-    static final String ATHENZ_DB_PASSWORD           = "password";
-    static final String ATHENZ_DB_USE_SSL            = "useSSL";
-    static final String ATHENZ_DB_VERIFY_SERVER_CERT = "verifyServerCertificate";
-    
     private static Properties mysqlMasterConnectionProperties = new Properties();
     private static Properties mysqlReplicaConnectionProperties = new Properties();
     @SuppressWarnings("FieldCanBeLocal")
@@ -77,12 +69,12 @@ public class AWSObjectStoreFactory implements ObjectStoreFactory {
             LOG.debug("Connecting to master {} with auth token {}", jdbcMasterStore, rdsMasterToken);
         }
         
-        mysqlMasterConnectionProperties.setProperty(ATHENZ_DB_VERIFY_SERVER_CERT,
-                System.getProperty(ATHENZ_PROP_DB_VERIFY_SERVER_CERT, "true"));
-        mysqlMasterConnectionProperties.setProperty(ATHENZ_DB_USE_SSL,
-                System.getProperty(ATHENZ_PROP_DB_USE_SSL, "true"));
-        mysqlMasterConnectionProperties.setProperty(ATHENZ_DB_USER, rdsUser);
-        mysqlMasterConnectionProperties.setProperty(ATHENZ_DB_PASSWORD, rdsMasterToken);
+        mysqlMasterConnectionProperties.setProperty(ZMSConsts.DB_PROP_VERIFY_SERVER_CERT,
+                System.getProperty(ZMSConsts.ZMS_PROP_JDBC_VERIFY_SERVER_CERT, "true"));
+        mysqlMasterConnectionProperties.setProperty(ZMSConsts.DB_PROP_USE_SSL,
+                System.getProperty(ZMSConsts.ZMS_PROP_JDBC_USE_SSL, "true"));
+        mysqlMasterConnectionProperties.setProperty(ZMSConsts.DB_PROP_USER, rdsUser);
+        mysqlMasterConnectionProperties.setProperty(ZMSConsts.DB_PROP_PASSWORD, rdsMasterToken);
         
         PoolableDataSource dataMasterSource = DataSourceFactory.create(jdbcMasterStore, mysqlMasterConnectionProperties);
         
@@ -99,12 +91,12 @@ public class AWSObjectStoreFactory implements ObjectStoreFactory {
                 LOG.debug("Connecting to replica {} with auth token {}", jdbcReplicaStore, rdsReplicaToken);
             }
             
-            mysqlReplicaConnectionProperties.setProperty(ATHENZ_DB_VERIFY_SERVER_CERT,
-                    System.getProperty(ATHENZ_PROP_DB_VERIFY_SERVER_CERT, "true"));
-            mysqlReplicaConnectionProperties.setProperty(ATHENZ_DB_USE_SSL,
-                    System.getProperty(ATHENZ_PROP_DB_USE_SSL, "true"));
-            mysqlReplicaConnectionProperties.setProperty(ATHENZ_DB_USER, rdsUser);
-            mysqlReplicaConnectionProperties.setProperty(ATHENZ_DB_PASSWORD, rdsReplicaToken);
+            mysqlReplicaConnectionProperties.setProperty(ZMSConsts.DB_PROP_VERIFY_SERVER_CERT,
+                    System.getProperty(ZMSConsts.ZMS_PROP_JDBC_VERIFY_SERVER_CERT, "true"));
+            mysqlReplicaConnectionProperties.setProperty(ZMSConsts.DB_PROP_USE_SSL,
+                    System.getProperty(ZMSConsts.ZMS_PROP_JDBC_USE_SSL, "true"));
+            mysqlReplicaConnectionProperties.setProperty(ZMSConsts.DB_PROP_USER, rdsUser);
+            mysqlReplicaConnectionProperties.setProperty(ZMSConsts.DB_PROP_PASSWORD, rdsReplicaToken);
             
             dataReplicaSource = DataSourceFactory.create(jdbcReplicaStore, mysqlReplicaConnectionProperties);
         }
@@ -155,7 +147,7 @@ public class AWSObjectStoreFactory implements ObjectStoreFactory {
         
         try {
             final String rdsToken = getAuthToken(hostname, rdsPort, rdsUser, rdsIamRole);
-            mysqlProperties.setProperty(ATHENZ_DB_PASSWORD, rdsToken);
+            mysqlProperties.setProperty(ZMSConsts.DB_PROP_PASSWORD, rdsToken);
         } catch (Throwable t) {
             LOG.error("CredentialsUpdater: unable to update auth token: " + t.getMessage());
         }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/JDBCObjectStoreFactory.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/JDBCObjectStoreFactory.java
@@ -28,8 +28,6 @@ import com.yahoo.athenz.zms.store.jdbc.JDBCObjectStore;
 public class JDBCObjectStoreFactory implements ObjectStoreFactory {
 
     private static final String JDBC               = "jdbc";
-    private static final String ATHENZ_DB_USER     = "user";
-    private static final String ATHENZ_DB_PASSWORD = "password";
     
     @Override
     public ObjectStore create(PrivateKeyStore keyStore) {
@@ -40,9 +38,13 @@ public class JDBCObjectStoreFactory implements ObjectStoreFactory {
         String jdbcPassword = keyStore.getApplicationSecret(jdbcAppName, password);
         
         Properties readWriteProperties = new Properties();
-        readWriteProperties.setProperty(ATHENZ_DB_USER, jdbcUser);
-        readWriteProperties.setProperty(ATHENZ_DB_PASSWORD, jdbcPassword);
-        
+        readWriteProperties.setProperty(ZMSConsts.DB_PROP_USER, jdbcUser);
+        readWriteProperties.setProperty(ZMSConsts.DB_PROP_PASSWORD, jdbcPassword);
+        readWriteProperties.setProperty(ZMSConsts.DB_PROP_VERIFY_SERVER_CERT,
+                System.getProperty(ZMSConsts.ZMS_PROP_JDBC_VERIFY_SERVER_CERT, "false"));
+        readWriteProperties.setProperty(ZMSConsts.DB_PROP_USE_SSL,
+                System.getProperty(ZMSConsts.ZMS_PROP_JDBC_USE_SSL, "false"));
+
         PoolableDataSource readWriteSrc = DataSourceFactory.create(jdbcStore, readWriteProperties);
         
         // now check to see if we also have a read-only jdbc store configured
@@ -57,9 +59,12 @@ public class JDBCObjectStoreFactory implements ObjectStoreFactory {
             final String jdbcReadOnlyPassword = keyStore.getApplicationSecret(jdbcAppName, readOnlyPassword);
             
             Properties readOnlyProperties = new Properties();
-            readOnlyProperties.setProperty(ATHENZ_DB_USER, jdbcReadOnlyUser);
-            readOnlyProperties.setProperty(ATHENZ_DB_PASSWORD, jdbcReadOnlyPassword);
-            
+            readOnlyProperties.setProperty(ZMSConsts.DB_PROP_USER, jdbcReadOnlyUser);
+            readOnlyProperties.setProperty(ZMSConsts.DB_PROP_PASSWORD, jdbcReadOnlyPassword);
+            readOnlyProperties.setProperty(ZMSConsts.DB_PROP_VERIFY_SERVER_CERT,
+                    System.getProperty(ZMSConsts.ZMS_PROP_JDBC_VERIFY_SERVER_CERT, "false"));
+            readOnlyProperties.setProperty(ZMSConsts.DB_PROP_USE_SSL,
+                    System.getProperty(ZMSConsts.ZMS_PROP_JDBC_USE_SSL, "false"));
             readOnlySrc = DataSourceFactory.create(jdbcReadOnlyStore, readOnlyProperties);
         }
         

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -209,6 +209,17 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # to the configured zts database
 #athenz.zts.cert_jdbc_password=
 
+# If using the jdbc connector (either mysql or aws) for zts
+# certificate data storage, this property specifies if the jdbc client
+# should establish an SSL connection to the database server or not
+#athenz.zts.cert_jdbc_use_ssl=false
+
+# if using the jdbc connector (either mysql or aws) for zms
+# certificate data storage and the athenz.zts.cert_jdbc_use_ssl property
+# is set to true, this property specifies whether or not the jdbc client
+# must verify the server certificate or not
+#athenz.zts.cert_jdbc_verify_server_certificate=false
+
 # If the athenz.zts.cert_record_store_factory_class property is using
 # the aws rds mysql object store factory identified with
 # com.yahoo.athenz.zts.cert.impl.AWSObjectStoreFactory, then

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -75,17 +75,25 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_SELF_SIGNER_CERT_DN              = "athenz.zts.self_signer_cert_dn";
     public static final String ZTS_PROP_OSTK_HOST_SIGNER_SERVICE         = "athenz.zts.ostk_host_signer_service";
     
-    public static final String ZTS_PROP_CERT_JDBC_STORE         = "athenz.zts.cert_jdbc_store";
-    public static final String ZTS_PROP_CERT_JDBC_USER          = "athenz.zts.cert_jdbc_user";
-    public static final String ZTS_PROP_CERT_JDBC_PASSWORD      = "athenz.zts.cert_jdbc_password";
-    public static final String ZTS_PROP_CERT_JDBC_APP_NAME      = "athenz.zts.cert_jdbc_app_name";
-    public static final String ZTS_PROP_CERT_OP_TIMEOUT         = "athenz.zts.cert_op_timeout";
-    public static final String ZTS_PROP_CERT_DNS_SUFFIX         = "athenz.zts.cert_dns_suffix";
+    public static final String ZTS_PROP_CERT_JDBC_STORE              = "athenz.zts.cert_jdbc_store";
+    public static final String ZTS_PROP_CERT_JDBC_USER               = "athenz.zts.cert_jdbc_user";
+    public static final String ZTS_PROP_CERT_JDBC_PASSWORD           = "athenz.zts.cert_jdbc_password";
+    public static final String ZTS_PROP_CERT_JDBC_APP_NAME           = "athenz.zts.cert_jdbc_app_name";
+    public static final String ZTS_PROP_CERT_JDBC_VERIFY_SERVER_CERT = "athenz.zts.cert_jdbc_verify_server_certificate";
+    public static final String ZTS_PROP_CERT_JDBC_USE_SSL            = "athenz.zts.cert_jdbc_use_ssl";
+    public static final String ZTS_PROP_CERT_OP_TIMEOUT              = "athenz.zts.cert_op_timeout";
+    public static final String ZTS_PROP_CERT_DNS_SUFFIX              = "athenz.zts.cert_dns_suffix";
+    public static final String ZTS_PROP_CERT_FILE_STORE_PATH         = "athenz.zts.cert_file_store_path";
+    public static final String ZTS_PROP_CERT_FILE_STORE_NAME         = "athenz.zts.cert_file_store_name";
+
     public static final String ZTS_PROP_PROVIDER_ENDPOINTS      = "athenz.zts.provider_endpoints";
-    public static final String ZTS_PROP_CERT_FILE_STORE_PATH    = "athenz.zts.cert_file_store_path";
-    public static final String ZTS_PROP_CERT_FILE_STORE_NAME    = "athenz.zts.cert_file_store_name";
     public static final String ZTS_PROP_INSTANCE_NTOKEN_TIMEOUT = "athenz.zts.instance_token_timeout";
     public static final String ZTS_PROP_X509_CA_CERT_FNAME      = "athenz.zts.x509_ca_cert_fname";
+
+    public static final String DB_PROP_USER               = "user";
+    public static final String DB_PROP_PASSWORD           = "password";
+    public static final String DB_PROP_USE_SSL            = "useSSL";
+    public static final String DB_PROP_VERIFY_SERVER_CERT = "verifyServerCertificate";
 
     public static final String ZTS_PROP_AWS_RDS_USER               = "athenz.zts.aws_rds_user";
     public static final String ZTS_PROP_AWS_RDS_IAM_ROLE           = "athenz.zts.aws_rds_iam_role";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/AWSCertRecordStoreFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/AWSCertRecordStoreFactory.java
@@ -39,14 +39,6 @@ public class AWSCertRecordStoreFactory implements CertRecordStoreFactory {
 
     private static final Logger LOG = LoggerFactory.getLogger(AWSCertRecordStoreFactory.class);
     
-    static final String ATHENZ_PROP_DB_VERIFY_SERVER_CERT = "athenz.db.verify_server_certificate";
-    static final String ATHENZ_PROP_DB_USE_SSL            = "athenz.db.use_ssl";
-    
-    static final String ATHENZ_DB_USER               = "user";
-    static final String ATHENZ_DB_PASSWORD           = "password";
-    static final String ATHENZ_DB_USE_SSL            = "useSSL";
-    static final String ATHENZ_DB_VERIFY_SERVER_CERT = "verifyServerCertificate";
-    
     private static Properties mysqlConnectionProperties = new Properties();
     private static String rdsUser = null;
     private static String rdsIamRole = null;
@@ -70,13 +62,13 @@ public class AWSCertRecordStoreFactory implements CertRecordStoreFactory {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Connecting to {} with auth token {}", jdbcStore, rdsToken);
         }
-        
-        mysqlConnectionProperties.setProperty(ATHENZ_DB_VERIFY_SERVER_CERT,
-                System.getProperty(ATHENZ_PROP_DB_VERIFY_SERVER_CERT, "true"));
-        mysqlConnectionProperties.setProperty(ATHENZ_DB_USE_SSL,
-                System.getProperty(ATHENZ_PROP_DB_USE_SSL, "true"));
-        mysqlConnectionProperties.setProperty(ATHENZ_DB_USER, rdsUser);
-        mysqlConnectionProperties.setProperty(ATHENZ_DB_PASSWORD, rdsToken);
+
+        mysqlConnectionProperties.setProperty(ZTSConsts.DB_PROP_VERIFY_SERVER_CERT,
+                System.getProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_VERIFY_SERVER_CERT, "true"));
+        mysqlConnectionProperties.setProperty(ZTSConsts.DB_PROP_USE_SSL,
+                System.getProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_USE_SSL, "true"));
+        mysqlConnectionProperties.setProperty(ZTSConsts.DB_PROP_USER, rdsUser);
+        mysqlConnectionProperties.setProperty(ZTSConsts.DB_PROP_PASSWORD, rdsToken);
         
         PoolableDataSource dataSource = DataSourceFactory.create(jdbcStore, mysqlConnectionProperties);
         
@@ -123,7 +115,7 @@ public class AWSCertRecordStoreFactory implements CertRecordStoreFactory {
             
             try {
                 final String rdsToken = getAuthToken(rdsMaster, rdsPort, rdsUser, rdsIamRole);
-                mysqlConnectionProperties.setProperty(ATHENZ_DB_PASSWORD, rdsToken);
+                mysqlConnectionProperties.setProperty(ZTSConsts.DB_PROP_PASSWORD, rdsToken);
                 
             } catch (Throwable t) {
                 LOG.error("CredentialsUpdater: unable to update auth token: {}", t.getMessage());

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreFactory.java
@@ -27,8 +27,6 @@ import com.yahoo.athenz.zts.cert.CertRecordStoreFactory;
 public class JDBCCertRecordStoreFactory implements CertRecordStoreFactory {
 
     private static final String JDBC               = "jdbc";
-    private static final String ATHENZ_DB_USER     = "user";
-    private static final String ATHENZ_DB_PASSWORD = "password";
     
     @Override
     public CertRecordStore create(PrivateKeyStore keyStore) {
@@ -41,9 +39,13 @@ public class JDBCCertRecordStoreFactory implements CertRecordStoreFactory {
         String jdbcPassword = keyStore.getApplicationSecret(jdbcAppName, password);
             
         Properties props = new Properties();
-        props.setProperty(ATHENZ_DB_USER, jdbcUser);
-        props.setProperty(ATHENZ_DB_PASSWORD, jdbcPassword);
-        
+        props.setProperty(ZTSConsts.DB_PROP_USER, jdbcUser);
+        props.setProperty(ZTSConsts.DB_PROP_PASSWORD, jdbcPassword);
+        props.setProperty(ZTSConsts.DB_PROP_VERIFY_SERVER_CERT,
+                System.getProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_VERIFY_SERVER_CERT, "false"));
+        props.setProperty(ZTSConsts.DB_PROP_USE_SSL,
+                System.getProperty(ZTSConsts.ZTS_PROP_CERT_JDBC_USE_SSL, "false"));
+
         PoolableDataSource src = DataSourceFactory.create(jdbcStore, props);
         return new JDBCCertRecordStore(src);
     }


### PR DESCRIPTION
primary change - provide 2 new properties for both zms and zts servers to specify the ssl mode for jdbc connections and control whether or not the server certificate must be verified or not.

all other changes - just moving the common property names from aws and mysql implementations to the zms/zts consts class.