### PR TITLE
cache aws creds for 10 mins

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -142,6 +142,7 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_AWS_REGION_NAME          = "athenz.zts.aws_region_name";
     public static final String ZTS_PROP_AWS_PUBLIC_CERT          = "athenz.zts.aws_public_cert";
     public static final String ZTS_PROP_AWS_BOOT_TIME_OFFSET     = "athenz.zts.aws_boot_time_offset";
+    public static final String ZTS_PROP_AWS_CREDS_CACHE_TIMEOUT  = "athenz.zts.aws_creds_cache_timeout";
 
     public static final String ZTS_PROP_METRIC_FACTORY_CLASS             = "athenz.zts.metric_factory_class";
     public static final String ZTS_PROP_CERT_SIGNER_FACTORY_CLASS        = "athenz.zts.cert_signer_factory_class";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
@@ -18,11 +18,13 @@ package com.yahoo.athenz.zts.store;
 import java.security.PublicKey;
 import java.util.HashMap;
 import java.util.Map;
+
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
@@ -56,17 +58,20 @@ public class CloudStore {
     String awsRole = null;
     String awsRegion;
     boolean awsEnabled;
+    private int cacheTimeout;
     BasicSessionCredentials credentials;
     private Map<String, String> cloudAccountCache;
+    private ConcurrentHashMap<String, AWSTemporaryCredentials> awsCredsCache;
     private HttpClient httpClient;
 
     private ScheduledExecutorService scheduledThreadPool = null;
 
     public CloudStore() {
 
-        // initialize our account cache
+        // initialize our account and cred cache
 
         cloudAccountCache = new HashMap<>();
+        awsCredsCache = new ConcurrentHashMap<>();
 
         // Instantiate and start our HttpClient
 
@@ -85,9 +90,15 @@ public class CloudStore {
 
         awsRegion = System.getProperty(ZTSConsts.ZTS_PROP_AWS_REGION_NAME);
 
+        // get the default cache timeout
+
+        cacheTimeout = Integer.parseInt(
+                System.getProperty(ZTSConsts.ZTS_PROP_AWS_CREDS_CACHE_TIMEOUT, "600"));
+
         // initialize aws support
 
-        awsEnabled = Boolean.parseBoolean(System.getProperty(ZTSConsts.ZTS_PROP_AWS_ENABLED, "false"));
+        awsEnabled = Boolean.parseBoolean(
+                System.getProperty(ZTSConsts.ZTS_PROP_AWS_ENABLED, "false"));
         initializeAwsSupport();
     }
 
@@ -140,12 +151,13 @@ public class CloudStore {
                     "Unable to fetch aws role credentials");
         }
 
-        // Start our thread to get aws temporary credentials
+        // Start our thread to get/update aws temporary credentials
 
-        int credsUpdateTime = ZTSUtils.retrieveConfigSetting(ZTSConsts.ZTS_PROP_AWS_CREDS_UPDATE_TIMEOUT, 900);
+        int credsUpdateTime = ZTSUtils.retrieveConfigSetting(
+                ZTSConsts.ZTS_PROP_AWS_CREDS_UPDATE_TIMEOUT, 900);
 
         scheduledThreadPool = Executors.newScheduledThreadPool(1);
-        scheduledThreadPool.scheduleAtFixedRate(new RoleCredentialsFetcher(), credsUpdateTime,
+        scheduledThreadPool.scheduleAtFixedRate(new AWSCredentialsUpdater(), credsUpdateTime,
                 credsUpdateTime, TimeUnit.SECONDS);
     }
 
@@ -386,18 +398,77 @@ public class CloudStore {
                 .build();
     }
 
+    String getCacheKey(final String account, final String roleName, final String principal,
+            Integer durationSeconds, final String externalId) {
+
+        StringBuilder cacheKey = new StringBuilder(256);
+        cacheKey.append(account).append(':').append(roleName).append(':').append(principal);
+        cacheKey.append(':');
+        if (durationSeconds != null) {
+            cacheKey.append(durationSeconds.intValue());
+        }
+        cacheKey.append(':');
+        if (externalId != null) {
+            cacheKey.append(externalId);
+        }
+        return cacheKey.toString();
+    }
+
+    boolean removeExpiredCredentials() {
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Checking for expired cached credentials in {} entries", awsCredsCache.size());
+        }
+
+        // iterate through all entries in the map and remove any
+        // entries that have been expired already
+
+        long now = System.currentTimeMillis();
+        return awsCredsCache.entrySet().removeIf(entry -> entry.getValue().getExpiration().millis() < now);
+    }
+
+    AWSTemporaryCredentials getCachedCreds(final String cacheKey, Integer durationSeconds) {
+
+        AWSTemporaryCredentials tempCreds = awsCredsCache.get(cacheKey);
+        if (tempCreds == null) {
+            return null;
+        }
+
+        // we're going to cache any creds for 10 mins only
+
+        long diffSeconds = (tempCreds.getExpiration().millis() - System.currentTimeMillis()) / 1000;
+        if (durationSeconds == null) {
+            durationSeconds = 3600; // default 1 hour
+        }
+        if (durationSeconds - diffSeconds > cacheTimeout) {
+            return null;
+        }
+
+        return tempCreds;
+    }
+
+    void putCacheCreds(final String key, AWSTemporaryCredentials tempCreds) {
+        awsCredsCache.put(key, tempCreds);
+    }
+
     public AWSTemporaryCredentials assumeAWSRole(String account, String roleName, String principal,
-                                                 Integer durationSeconds, String externalId) {
+            Integer durationSeconds, String externalId) {
 
         if (!awsEnabled) {
             throw new ResourceException(ResourceException.INTERNAL_SERVER_ERROR,
                     "AWS Support not enabled");
         }
 
+        final String cacheKey = getCacheKey(account, roleName, principal,
+                durationSeconds, externalId);
+        AWSTemporaryCredentials tempCreds = getCachedCreds(cacheKey, durationSeconds);
+        if (tempCreds != null) {
+            return tempCreds;
+        }
+
         AssumeRoleRequest req = getAssumeRoleRequest(account, roleName, principal,
                 durationSeconds, externalId);
 
-        AWSTemporaryCredentials tempCreds;
         try {
             AWSSecurityTokenService client = getTokenServiceClient();
             AssumeRoleResult res = client.assumeRole(req);
@@ -415,6 +486,7 @@ public class CloudStore {
             return null;
         }
 
+        putCacheCreds(cacheKey, tempCreds);
         return tempCreds;
     }
 
@@ -454,19 +526,26 @@ public class CloudStore {
         return verified;
     }
 
-    class RoleCredentialsFetcher implements Runnable {
+    class AWSCredentialsUpdater implements Runnable {
 
         @Override
         public void run() {
 
             if (LOGGER.isDebugEnabled()) {
-                LOGGER.debug("RoleCredentialsFetcher: Starting aws role credentials fetcher task...");
+                LOGGER.debug("AWSCredentialsUpdater: Starting aws credentials updater task...");
             }
 
             try {
                 fetchRoleCredentials();
             } catch (Exception ex) {
-                LOGGER.error("RoleCredentialsFetcher: unable to fetch aws role credentials: {}",
+                LOGGER.error("AWSCredentialsUpdater: unable to fetch aws role credentials: {}",
+                        ex.getMessage());
+            }
+
+            try {
+                removeExpiredCredentials();
+            } catch (Exception ex) {
+                LOGGER.error("AWSCredentialsUpdater: unable to remove expired aws credentials: {}",
                         ex.getMessage());
             }
         }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
@@ -401,6 +401,13 @@ public class CloudStore {
     String getCacheKey(final String account, final String roleName, final String principal,
             Integer durationSeconds, final String externalId) {
 
+        // if our cache is disabled there is no need to generate
+        // a cache key since all other operations are no-ops
+
+        if (cacheTimeout == 0) {
+            return "";
+        }
+
         StringBuilder cacheKey = new StringBuilder(256);
         cacheKey.append(account).append(':').append(roleName).append(':').append(principal);
         cacheKey.append(':');
@@ -429,6 +436,12 @@ public class CloudStore {
 
     AWSTemporaryCredentials getCachedCreds(final String cacheKey, Integer durationSeconds) {
 
+        // if our cache is disabled there is no need for a lookup
+
+        if (cacheTimeout == 0) {
+            return null;
+        }
+
         AWSTemporaryCredentials tempCreds = awsCredsCache.get(cacheKey);
         if (tempCreds == null) {
             return null;
@@ -448,6 +461,13 @@ public class CloudStore {
     }
 
     void putCacheCreds(final String key, AWSTemporaryCredentials tempCreds) {
+
+        // if our cache is disabled we do nothing
+
+        if (cacheTimeout == 0) {
+            return;
+        }
+
         awsCredsCache.put(key, tempCreds);
     }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import com.yahoo.rdl.Timestamp;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.mockito.Mockito;
@@ -706,6 +707,101 @@ public class CloudStoreTest {
         
         final String req3 = "{invalid-json";
         assertNull(cloudStore.getSshKeyReqType(req3));
+        cloudStore.close();
+    }
+
+    @Test
+    public void testGetCacheKey() {
+        CloudStore cloudStore = new CloudStore();
+        assertEquals(cloudStore.getCacheKey("account", "role", "user", null, null), "account:role:user::");
+        assertEquals(cloudStore.getCacheKey("account", "role", "user", 100, null), "account:role:user:100:");
+        assertEquals(cloudStore.getCacheKey("account", "role", "user", null, "ext"), "account:role:user::ext");
+        assertEquals(cloudStore.getCacheKey("account", "role", "user", null, "100"), "account:role:user::100");
+        assertEquals(cloudStore.getCacheKey("account", "role", "user", 100, "ext"), "account:role:user:100:ext");
+        cloudStore.close();
+    }
+
+    @Test
+    public void testGetCachedCreds() {
+        CloudStore cloudStore = new CloudStore();
+        AWSTemporaryCredentials creds = new AWSTemporaryCredentials();
+        creds.setAccessKeyId("keyid");
+        creds.setSecretAccessKey("accesskey");
+        creds.setSessionToken("token");
+        // set the expiration for 1 hour from now
+        creds.setExpiration(Timestamp.fromMillis(System.currentTimeMillis() + 3600*1000));
+        cloudStore.putCacheCreds("account:role:user::", creds);
+
+        // fetching with a different cache key should not match anything
+        assertNull(cloudStore.getCachedCreds("account:role:user:100:", null));
+        assertNull(cloudStore.getCachedCreds("account:role:user::ext", null));
+
+        // fetching with null duration should match and return our object
+        assertNotNull(cloudStore.getCachedCreds("account:role:user::", null));
+
+        // fetching with 1 hour duration should match and return our object
+        assertNotNull(cloudStore.getCachedCreds("account:role:user::", 3600));
+
+        // fetching with 45 min duration should match duration
+        assertNotNull(cloudStore.getCachedCreds("account:role:user::", 2700));
+
+        // fetching with 1 hour and 5 min duration should match and return our object
+        assertNotNull(cloudStore.getCachedCreds("account:role:user::", 3900));
+
+        // fetching with 1 hour and 11 min duration should not match
+        assertNull(cloudStore.getCachedCreds("account:role:user::", 4260));
+
+        // fetching with 2 hour duration should not match
+        assertNull(cloudStore.getCachedCreds("account:role:user::", 7200));
+        cloudStore.close();
+    }
+
+    @Test
+    public void testRemoveExpiredCredentials() {
+        CloudStore cloudStore = new CloudStore();
+
+        AWSTemporaryCredentials creds = new AWSTemporaryCredentials();
+        creds.setAccessKeyId("keyid");
+        creds.setSecretAccessKey("accesskey");
+        creds.setSessionToken("token");
+        // set the expiration for 1 hour from now
+        creds.setExpiration(Timestamp.fromMillis(System.currentTimeMillis() + 3600*1000));
+        cloudStore.putCacheCreds("account:role:user::", creds);
+
+        assertFalse(cloudStore.removeExpiredCredentials());
+
+        // now let's add an expired entry
+        AWSTemporaryCredentials creds2 = new AWSTemporaryCredentials();
+        creds2.setAccessKeyId("keyid");
+        creds2.setSecretAccessKey("accesskey");
+        creds2.setSessionToken("token");
+        // expired credential
+        creds2.setExpiration(Timestamp.fromMillis(System.currentTimeMillis() - 1000));
+        cloudStore.putCacheCreds("account:role:user2::", creds2);
+
+        assertTrue(cloudStore.removeExpiredCredentials());
+        cloudStore.close();
+    }
+
+    @Test
+    public void testGetCachedAWSCredentials() {
+        CloudStore cloudStore = new CloudStore();
+        cloudStore.awsEnabled = true;
+
+        AWSTemporaryCredentials creds = new AWSTemporaryCredentials();
+        creds.setAccessKeyId("keyid");
+        creds.setSecretAccessKey("accesskey");
+        creds.setSessionToken("token");
+        // set the expiration for 1 hour from now
+        creds.setExpiration(Timestamp.fromMillis(System.currentTimeMillis() + 3600 * 1000));
+        cloudStore.putCacheCreds("account:role:user::ext", creds);
+
+        AWSTemporaryCredentials testCreds = cloudStore.assumeAWSRole("account", "role", "user",
+                null, "ext");
+        assertNotNull(testCreds);
+        assertEquals(testCreds.getAccessKeyId(), "keyid");
+        assertEquals(testCreds.getSecretAccessKey(), "accesskey");
+        assertEquals(testCreds.getSessionToken(), "token");
         cloudStore.close();
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
@@ -757,6 +757,29 @@ public class CloudStoreTest {
     }
 
     @Test
+    public void testGetCachedCredsDisabled() {
+        System.setProperty(ZTSConsts.ZTS_PROP_AWS_CREDS_CACHE_TIMEOUT, "0");
+        CloudStore cloudStore = new CloudStore();
+
+        assertEquals(cloudStore.getCacheKey("account", "role", "user", null, null), "");
+        assertEquals(cloudStore.getCacheKey("account", "role", "user", 100, null), "");
+        assertEquals(cloudStore.getCacheKey("account", "role", "user", 100, "ext"), "");
+
+        AWSTemporaryCredentials creds = new AWSTemporaryCredentials();
+        creds.setAccessKeyId("keyid");
+        creds.setSecretAccessKey("accesskey");
+        creds.setSessionToken("token");
+        // set the expiration for 1 hour from now
+        creds.setExpiration(Timestamp.fromMillis(System.currentTimeMillis() + 3600*1000));
+        cloudStore.putCacheCreds("account:role:user::", creds);
+
+        // with disabled cache there is nothing to match
+        assertNull(cloudStore.getCachedCreds("account:role:user::", null));
+        cloudStore.close();
+        System.clearProperty(ZTSConsts.ZTS_PROP_AWS_CREDS_CACHE_TIMEOUT);
+    }
+
+    @Test
     public void testRemoveExpiredCredentials() {
         CloudStore cloudStore = new CloudStore();
 


### PR DESCRIPTION
Since AWS STS assume role call is rate limited, we don't want a bad service to pass large number of requests simultaneously and thus invoke the rate limiting and affect assume role requests from other services. We're going to cache the aws creds by default for 10 mins so during that time we'll return the cached copy instead of asking for new creds from AWS STS.