### PR TITLE
handle cache when duration is <=0

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
@@ -450,7 +450,7 @@ public class CloudStore {
         // we're going to cache any creds for 10 mins only
 
         long diffSeconds = (tempCreds.getExpiration().millis() - System.currentTimeMillis()) / 1000;
-        if (durationSeconds == null) {
+        if (durationSeconds == null || durationSeconds <= 0) {
             durationSeconds = 3600; // default 1 hour
         }
         if (durationSeconds - diffSeconds > cacheTimeout) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
@@ -736,8 +736,14 @@ public class CloudStoreTest {
         assertNull(cloudStore.getCachedCreds("account:role:user:100:", null));
         assertNull(cloudStore.getCachedCreds("account:role:user::ext", null));
 
-        // fetching with null duration should match and return our object
+        // fetching with null duration should match (default to 3600) and return our object
         assertNotNull(cloudStore.getCachedCreds("account:role:user::", null));
+
+        // fetching with 0 duration should match (default to 3600) and return our object
+        assertNotNull(cloudStore.getCachedCreds("account:role:user::", 0));
+
+        // fetching with negative duration should match (default to 3600) and return our object
+        assertNotNull(cloudStore.getCachedCreds("account:role:user::", -1));
 
         // fetching with 1 hour duration should match and return our object
         assertNotNull(cloudStore.getCachedCreds("account:role:user::", 3600));


### PR DESCRIPTION
if duration seconds specified for aws temp creds is either 0 or < 0 then we always default back to 1 hour so handle that case for cache support as well.