### PR TITLE
allow config option to reset cert refresh db

### DIFF
--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -391,3 +391,16 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # the SAN DNS entries, this can be configured as an optional check
 # and can be skipped.
 #athenz.zts.cert_refresh_verify_hostnames=true
+
+# During certificate refresh operations zts server looks up
+# the original certificate details (serial number, timestamp, etc)
+# to detect compromise. If this database is lost, then server
+# will not be able to refresh any certs, so we provide an option
+# to regenerate the db based on requests rather than rejecting
+# all. So while the certs are refreshed, compromise will not be
+# detected during the first refresh, but during the second one
+# it will be detected. The value of the setting is the number
+# of milliseconds since epoch. Any refresh request where the cert
+# has a timestamp before this date will be handled successfully
+# if the db record is not found.
+#athenz.zts.cert_refresh_reset_time=0

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -75,6 +75,7 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_SELF_SIGNER_CERT_DN              = "athenz.zts.self_signer_cert_dn";
     public static final String ZTS_PROP_OSTK_HOST_SIGNER_SERVICE         = "athenz.zts.ostk_host_signer_service";
     public static final String ZTS_PROP_CERT_REFRESH_VERIFY_HOSTNAMES    = "athenz.zts.cert_refresh_verify_hostnames";
+    public static final String ZTS_PROP_CERT_REFRESH_RESET_TIME          = "athenz.zts.cert_refresh_reset_time";
 
     public static final String ZTS_PROP_CERT_JDBC_STORE              = "athenz.zts.cert_jdbc_store";
     public static final String ZTS_PROP_CERT_JDBC_USER               = "athenz.zts.cert_jdbc_user";

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -5505,7 +5505,7 @@ public class ZTSImplTest {
         
         PrincipalAuthority authority = new PrincipalAuthority();
         SimplePrincipal principal = (SimplePrincipal) SimplePrincipal.create("athenz", "production",
-                "v=S1;d=athenzn=production;s=signature", 0, authority);
+                "v=S1;d=athenz;n=production;s=signature", 0, authority);
         
         ResourceContext context = createResourceContext(principal);
         
@@ -6702,5 +6702,87 @@ public class ZTSImplTest {
         assertFalse(zts.isAuthorizedServicePrincipal(principal));
         assertFalse(zts.isAuthorizedServicePrincipal(principal));
         assertTrue(zts.isAuthorizedServicePrincipal(principal));
+    }
+
+    @Test
+    public void testReadOnlyMode() {
+
+        ChangeLogStore structStore = new ZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+
+        DataStore store = new DataStore(structStore, null);
+
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+        ztsImpl.readOnlyMode = true;
+
+        PrincipalAuthority authority = new PrincipalAuthority();
+        SimplePrincipal principal = (SimplePrincipal) SimplePrincipal.create("athenz", "readonly",
+                "v=S1;d=athenz;n=readonly;s=signature", 0, authority);
+
+        ResourceContext ctx = createResourceContext(principal);
+
+        try {
+            ztsImpl.postRoleCertificateRequest(ctx, null, null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Read-Only mode"));
+        }
+
+        try {
+            ztsImpl.postInstanceRegisterInformation(ctx, null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Read-Only mode"));
+        }
+
+        try {
+            ztsImpl.postInstanceRefreshInformation(ctx, null, null, null, null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Read-Only mode"));
+        }
+
+        try {
+            ztsImpl.deleteInstanceIdentity(ctx, null, null, null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Read-Only mode"));
+        }
+
+        try {
+            ztsImpl.postInstanceRefreshRequest(ctx, null, null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Read-Only mode"));
+        }
+
+        try {
+            ztsImpl.postOSTKInstanceInformation(ctx, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Read-Only mode"));
+        }
+
+        try {
+            ztsImpl.postOSTKInstanceRefreshRequest(ctx, null, null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Read-Only mode"));
+        }
+
+        try {
+            ztsImpl.postDomainMetrics(ctx, null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Read-Only mode"));
+        }
     }
 }


### PR DESCRIPTION
During certificate refresh operations zts server looks up the original certificate details (serial number, timestamp, etc) to detect compromise. If this database is lost, then server will not be able to refresh any certs, so we provide an option to regenerate the db based on requests rather than rejecting all. So while the certs are refreshed, compromise will not be detected during the first refresh, but during the second one it will be detected. The value of the setting is the number of milliseconds since epoch. Any refresh request where the cert has a timestamp before this date will be handled successfully if the db record is not found.