### PR TITLE
Add additional counters for cert and auth operations

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
@@ -19,6 +19,7 @@ import com.yahoo.athenz.auth.Authorizer;
 import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.auth.impl.KerberosAuthority;
 import com.yahoo.athenz.common.server.rest.Http;
+import com.yahoo.athenz.common.metrics.Metric;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -32,10 +33,13 @@ public class RsrcCtxWrapper implements ResourceContext {
 
     com.yahoo.athenz.common.server.rest.ResourceContext ctx;
     boolean optionalAuth;
+    Metric metric;
 
     public RsrcCtxWrapper(HttpServletRequest request, HttpServletResponse response,
-            Http.AuthorityList authList,  boolean optionalAuth, Authorizer authorizer) {
+            Http.AuthorityList authList,  boolean optionalAuth, Authorizer authorizer,
+            Metric metric) {
         this.optionalAuth = optionalAuth;
+        this.metric = metric;
         ctx = new com.yahoo.athenz.common.server.rest.ResourceContext(request, response,
                 authList, authorizer);
     }
@@ -116,6 +120,9 @@ public class RsrcCtxWrapper implements ResourceContext {
     }
     
     public void throwZtsException(com.yahoo.athenz.common.server.rest.ResourceException restExc) {
+
+        metric.increment("authfailure");
+
         String msg = null;
         Object data = restExc.getData();
         if (data instanceof String) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
+import com.yahoo.athenz.common.metrics.Metric;
 
 import com.yahoo.athenz.common.server.rest.Http.AuthorityList;
 
@@ -39,7 +40,7 @@ public class RsrcCtxWrapperTest {
         AuthorityList authListMock = new AuthorityList();
         Authorizer authorizerMock = Mockito.mock(Authorizer.class);
         Authority authMock = Mockito.mock(Authority.class);
-
+        Metric metricMock = Mockito.mock(Metric.class);
         Principal prin = Mockito.mock(Principal.class);
 
         Mockito.when(authMock.getHeader()).thenReturn("testheader");
@@ -51,7 +52,7 @@ public class RsrcCtxWrapperTest {
         Mockito.when(reqMock.getMethod()).thenReturn("POST");
         authListMock.add(authMock);
 
-        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(reqMock, resMock, authListMock, false, authorizerMock);
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(reqMock, resMock, authListMock, false, authorizerMock, metricMock);
 
         assertNotNull(wrapper.context());
 
@@ -83,7 +84,7 @@ public class RsrcCtxWrapperTest {
         AuthorityList authListMock = new AuthorityList();
         Authorizer authorizerMock = Mockito.mock(Authorizer.class);
         Authority authMock = Mockito.mock(Authority.class);
-
+        Metric metricMock = Mockito.mock(Metric.class);
         Principal prin = Mockito.mock(Principal.class);
 
         Mockito.when(authMock.getHeader()).thenReturn("testheader");
@@ -99,7 +100,7 @@ public class RsrcCtxWrapperTest {
         Mockito.when(authorizerMock.access(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(true);
 
-        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(reqMock, resMock, authListMock, false, authorizerMock);
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(reqMock, resMock, authListMock, false, authorizerMock, metricMock);
 
         wrapper.authorize("add-domain", "test", "test");
 
@@ -114,6 +115,7 @@ public class RsrcCtxWrapperTest {
 
         AuthorityList authListMock = new AuthorityList();
         Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Metric metricMock = Mockito.mock(Metric.class);
 
         Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
         Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
@@ -123,7 +125,7 @@ public class RsrcCtxWrapperTest {
         Mockito.when(authorizerMock.access(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
                 .thenReturn(true);
 
-        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(reqMock, resMock, authListMock, false, authorizerMock);
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(reqMock, resMock, authListMock, false, authorizerMock, metricMock);
 
         // when not set authority
         wrapper.authorize("add-domain", "test", "test");


### PR DESCRIPTION
keep track of additional counters for provider register and refresh operation along with certificate sign requests. also keep track of any auth n/z failures since those are not reflected in the server get/post request/method counters.