### PR TITLE
ignore invalid authorities that provider no header

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/rest/Http.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/rest/Http.java
@@ -68,7 +68,10 @@ public class Http {
 
     private static String authenticatingCredentials(HttpServletRequest request,
             Authority authority) {
-        String header = authority.getHeader();
+        final String header = authority.getHeader();
+        if (header == null) {
+            return null;
+        }
         return header.startsWith("Cookie.") ? getCookieValue(request,
                 header.substring(7)) : request.getHeader(header);
     }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/rest/HttpTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/rest/HttpTest.java
@@ -73,7 +73,22 @@ public class HttpTest {
             assertEquals(expected.getCode(), 401);
         }
     }
-    
+
+    @Test
+    public void testAuthenticateHeaderNull() {
+        HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);
+        Http.AuthorityList authorities = new Http.AuthorityList();
+        Authority authority = Mockito.mock(Authority.class);
+        Mockito.when(authority.getCredSource()).thenReturn(CredSource.HEADER);
+        Mockito.when(authority.getHeader()).thenReturn(null);
+        // we should not get npe - instead standard 401
+        try {
+            Http.authenticate(httpServletRequest, authorities);
+        } catch (ResourceException expected) {
+            assertEquals(expected.getCode(), 401);
+        }
+    }
+
     @Test
     public void testAuthenticatedUserInvalidCredentials() {
         HttpServletRequest httpServletRequest = Mockito.mock(HttpServletRequest.class);


### PR DESCRIPTION
avoid npe when the administrator has implemented an authority based on a specific header but the header method returns null for the header name.