### PR TITLE
DynamoDB implementation for CertRecordStore interface

### DIFF
--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -404,3 +404,18 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # has a timestamp before this date will be handled successfully
 # if the db record is not found.
 #athenz.zts.cert_refresh_reset_time=0
+
+# If the athenz.zts.cert_record_store_factory_class property is using
+# the dynamodb cert record store factory identified with
+# com.yahoo.athenz.zts.cert.impl.DynamoDBCertRecordStoreFactory, then
+# this setting specifies the table name where the ZTS Server will store
+# certificate records for revocation checks. The table must be created
+# with the following requirements: primary field - instanceId,
+# sort key - provider. Enable TTL and call the attribute as ttl.
+#athenz.zts.cert_dynamodb_table_name=
+
+# When using the DynamoDB certificate record store factory (see
+# property athenz.zts.cert_dynamodb_table_name) this setting specifies
+# the configured number of hours that DynamoDB will purge expired
+# records. Default value is 30 days.
+#athenz.zts.cert_dynamodb_item_ttl_hours=720

--- a/servers/zts/pom.xml
+++ b/servers/zts/pom.xml
@@ -124,6 +124,10 @@
       <artifactId>aws-java-sdk-rds</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-dynamodb</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-client</artifactId>
       <version>${jetty.version}</version>

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -87,6 +87,8 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_CERT_DNS_SUFFIX              = "athenz.zts.cert_dns_suffix";
     public static final String ZTS_PROP_CERT_FILE_STORE_PATH         = "athenz.zts.cert_file_store_path";
     public static final String ZTS_PROP_CERT_FILE_STORE_NAME         = "athenz.zts.cert_file_store_name";
+    public static final String ZTS_PROP_CERT_DYNAMODB_TABLE_NAME     = "athenz.zts.cert_dynamodb_table_name";
+    public static final String ZTS_PROP_CERT_DYNAMODB_ITEM_TTL_HOURS = "athenz.zts.cert_dynamodb_item_ttl_hours";
 
     public static final String ZTS_PROP_PROVIDER_ENDPOINTS      = "athenz.zts.provider_endpoints";
     public static final String ZTS_PROP_INSTANCE_NTOKEN_TIMEOUT = "athenz.zts.instance_token_timeout";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStore.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.yahoo.athenz.zts.ResourceException;
+import com.yahoo.athenz.zts.cert.CertRecordStore;
+import com.yahoo.athenz.zts.cert.CertRecordStoreConnection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DynamoDBCertRecordStore implements CertRecordStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DynamoDBCertRecordStore.class);
+
+    private DynamoDB dynamoDB;
+    private String tableName;
+
+    public DynamoDBCertRecordStore(AmazonDynamoDB client, final String tableName) {
+        dynamoDB = new DynamoDB(client);
+        this.tableName = tableName;
+    }
+
+    @Override
+    public CertRecordStoreConnection getConnection() {
+        try {
+            DynamoDBCertRecordStoreConnection dynamoConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+            return dynamoConn;
+        } catch (Exception ex) {
+            LOG.error("getConnection: {}", ex.getMessage());
+            throw new ResourceException(ResourceException.SERVICE_UNAVAILABLE, ex.getMessage());
+        }
+    }
+    
+    @Override
+    public void setOperationTimeout(int opTimeout) {
+    }
+    
+    @Override
+    public void clearConnections() {
+    }
+}

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnection.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2018 Oath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl;
+
+import java.util.Date;
+
+import com.yahoo.athenz.zts.ZTSConsts;
+import com.yahoo.athenz.zts.cert.CertRecordStoreConnection;
+import com.yahoo.athenz.zts.cert.X509CertRecord;
+
+import com.amazonaws.services.dynamodbv2.document.Item;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.AttributeUpdate;
+import com.amazonaws.services.dynamodbv2.document.spec.DeleteItemSpec;
+import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DynamoDBCertRecordStoreConnection implements CertRecordStoreConnection {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DynamoDBCertRecordStoreConnection.class);
+
+    private static final String KEY_PROVIDER = "provider";
+    private static final String KEY_INSTANCE_ID = "instanceId";
+    private static final String KEY_SERVICE = "service";
+    private static final String KEY_CURRENT_SERIAL = "currentSerial";
+    private static final String KEY_CURRENT_TIME = "currentTime";
+    private static final String KEY_CURRENT_IP = "currentIP";
+    private static final String KEY_PREV_SERIAL = "prevSerial";
+    private static final String KEY_PREV_TIME = "prevTime";
+    private static final String KEY_PREV_IP = "prevIP";
+    private static final String KEY_CLIENT_CERT = "clientCert";
+    private static final String KEY_TTL = "ttl";
+
+    // the configuration setting is in hours so we'll automatically
+    // convert into seconds since that's what dynamoDB needs
+    // we need to expire records in 30 days
+
+    private static long expiryTime = 3660 * Long.parseLong(
+            System.getProperty(ZTSConsts.ZTS_PROP_CERT_DYNAMODB_ITEM_TTL_HOURS, "720"));
+    private Table table;
+
+    public DynamoDBCertRecordStoreConnection(DynamoDB dynamoDB, final String tableName) {
+        table = dynamoDB.getTable(tableName);
+    }
+
+    @Override
+    public void setOperationTimeout(int queryTimeout) {
+    }
+    
+    @Override
+    public void close() {
+    }
+    
+    @Override
+    public X509CertRecord getX509CertRecord(String provider, String instanceId) {
+        
+        try {
+            Item item = table.getItem(KEY_INSTANCE_ID, instanceId, KEY_PROVIDER, provider);
+            X509CertRecord certRecord = new X509CertRecord();
+            certRecord.setProvider(provider);
+            certRecord.setInstanceId(instanceId);
+            certRecord.setService(item.getString(KEY_SERVICE));
+            certRecord.setCurrentSerial(item.getString(KEY_CURRENT_SERIAL));
+            certRecord.setCurrentIP(item.getString(KEY_CURRENT_IP));
+            certRecord.setCurrentTime(new Date(item.getLong(KEY_CURRENT_TIME)));
+            certRecord.setPrevSerial(item.getString(KEY_PREV_SERIAL));
+            certRecord.setPrevIP(item.getString(KEY_PREV_IP));
+            certRecord.setPrevTime(new Date(item.getLong(KEY_PREV_TIME)));
+            certRecord.setClientCert(item.getBoolean(KEY_CLIENT_CERT));
+            return certRecord;
+        } catch (Exception ex) {
+            LOG.error("DynamoDB Get Error for {}/{}: {}/{}", provider, instanceId,
+                    ex.getClass(), ex.getMessage());
+            return null;
+        }
+    }
+    
+    @Override
+    public boolean updateX509CertRecord(X509CertRecord certRecord) {
+
+        try {
+            UpdateItemSpec updateItemSpec = new UpdateItemSpec()
+                    .withPrimaryKey(KEY_INSTANCE_ID, certRecord.getInstanceId(), KEY_PROVIDER, certRecord.getProvider())
+                    .withAttributeUpdate(
+                            new AttributeUpdate(KEY_SERVICE).put(certRecord.getService()),
+                            new AttributeUpdate(KEY_CURRENT_SERIAL).put(certRecord.getCurrentSerial()),
+                            new AttributeUpdate(KEY_CURRENT_IP).put(certRecord.getCurrentIP()),
+                            new AttributeUpdate(KEY_CURRENT_TIME).put(certRecord.getCurrentTime().getTime()),
+                            new AttributeUpdate(KEY_PREV_SERIAL).put(certRecord.getPrevSerial()),
+                            new AttributeUpdate(KEY_PREV_IP).put(certRecord.getPrevIP()),
+                            new AttributeUpdate(KEY_PREV_TIME).put(certRecord.getPrevTime().getTime()),
+                            new AttributeUpdate(KEY_CLIENT_CERT).put(certRecord.getClientCert()),
+                            new AttributeUpdate(KEY_TTL).put(certRecord.getCurrentTime().getTime() / 1000L + expiryTime)
+                    );
+            table.updateItem(updateItemSpec);
+            return true;
+        } catch (Exception ex) {
+            LOG.error("DynamoDB Update Error for {}/{}: {}/{}", certRecord.getProvider(),
+                    certRecord.getInstanceId(), ex.getClass(), ex.getMessage());
+            return false;
+        }
+    }
+    
+    @Override
+    public boolean insertX509CertRecord(X509CertRecord certRecord) {
+
+        try {
+            Item item = new Item()
+                    .withPrimaryKey(KEY_INSTANCE_ID, certRecord.getInstanceId(), KEY_PROVIDER, certRecord.getProvider())
+                    .withString(KEY_SERVICE, certRecord.getService())
+                    .withString(KEY_CURRENT_SERIAL, certRecord.getCurrentSerial())
+                    .withString(KEY_CURRENT_IP, certRecord.getCurrentIP())
+                    .withLong(KEY_CURRENT_TIME, certRecord.getCurrentTime().getTime())
+                    .withString(KEY_PREV_SERIAL, certRecord.getPrevSerial())
+                    .withString(KEY_PREV_IP, certRecord.getPrevIP())
+                    .withLong(KEY_PREV_TIME, certRecord.getPrevTime().getTime())
+                    .withBoolean(KEY_CLIENT_CERT, certRecord.getClientCert())
+                    .withLong(KEY_TTL, certRecord.getCurrentTime().getTime() / 1000L + expiryTime);
+            table.putItem(item);
+            return true;
+        } catch (Exception ex) {
+            LOG.error("DynamoDB Insert Error for {}/{}: {}/{}", certRecord.getProvider(),
+                    certRecord.getInstanceId(), ex.getClass(), ex.getMessage());
+            return false;
+        }
+    }
+    
+    @Override
+    public boolean deleteX509CertRecord(String provider, String instanceId) {
+
+        try {
+            DeleteItemSpec deleteItemSpec = new DeleteItemSpec()
+                    .withPrimaryKey(KEY_INSTANCE_ID, instanceId, KEY_PROVIDER, provider);
+            table.deleteItem(deleteItemSpec);
+            return true;
+        } catch (Exception ex) {
+            LOG.error("DynamoDB Delete Error for {}/{}: {}/{}", provider, instanceId,
+                    ex.getClass(), ex.getMessage());
+            return false;
+        }
+    }
+    
+    @Override
+    public int deleteExpiredX509CertRecords(int expiryTimeMins) {
+
+        // with dynamo db there is no need to manually expunge expired
+        // record since we have the TTL option enabled for our table
+        // and we just need to make sure the attribute is updated with
+        // the epoch time + timeout seconds when it should retire
+
+        return 0;
+    }
+}

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Oath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.zts.ResourceException;
+import com.yahoo.athenz.zts.ZTSConsts;
+import com.yahoo.athenz.zts.cert.CertRecordStore;
+import com.yahoo.athenz.zts.cert.CertRecordStoreFactory;
+
+public class DynamoDBCertRecordStoreFactory implements CertRecordStoreFactory {
+
+    @Override
+    public CertRecordStore create(PrivateKeyStore keyStore) {
+
+        final String tableName = System.getProperty(ZTSConsts.ZTS_PROP_CERT_DYNAMODB_TABLE_NAME);
+        if (tableName == null || tableName.isEmpty()) {
+            throw new ResourceException(ResourceException.SERVICE_UNAVAILABLE, "DynamoDB table name not specified");
+        }
+
+        AmazonDynamoDB client = getDynamoDBClient();
+        return new DynamoDBCertRecordStore(client, tableName);
+    }
+
+    AmazonDynamoDB getDynamoDBClient() {
+        return AmazonDynamoDBClientBuilder.standard().build();
+    }
+}

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl;
+
+import com.amazonaws.services.dynamodbv2.document.*;
+import com.amazonaws.services.dynamodbv2.model.AmazonDynamoDBException;
+import com.yahoo.athenz.zts.cert.X509CertRecord;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.amazonaws.services.dynamodbv2.document.spec.DeleteItemSpec;
+import com.amazonaws.services.dynamodbv2.document.spec.UpdateItemSpec;
+
+import java.util.Date;
+
+import static org.testng.Assert.*;
+
+public class DynamoDBCertRecordStoreConnectionTest {
+
+    private final String tableName = "cert-table";
+
+    @Mock private DynamoDB dynamoDB;
+    @Mock private Table table;
+    @Mock private Item item;
+    @Mock private PutItemOutcome putOutcome;
+    @Mock private DeleteItemOutcome deleteOutcome;
+    @Mock private UpdateItemOutcome updateOutcome;
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        Mockito.doReturn(table).when(dynamoDB).getTable(tableName);
+    }
+
+    @Test
+    public void testGetX509CertRecord() {
+
+        Date now = new Date();
+        long tstamp = now.getTime();
+
+        Mockito.doReturn(item).when(table).getItem("instanceId", "1234", "provider", "athenz.provider");
+
+        Mockito.doReturn("cn").when(item).getString("service");
+        Mockito.doReturn("current-serial").when(item).getString("currentSerial");
+        Mockito.doReturn("current-ip").when(item).getString("currentIP");
+        Mockito.doReturn(tstamp).when(item).getLong("currentTime");
+        Mockito.doReturn("prev-serial").when(item).getString("prevSerial");
+        Mockito.doReturn("prev-ip").when(item).getString("prevIP");
+        Mockito.doReturn(tstamp).when(item).getLong("prevTime");
+        Mockito.doReturn(false).when(item).getBoolean("clientCert");
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+        dbConn.setOperationTimeout(10);
+        X509CertRecord certRecord = dbConn.getX509CertRecord("athenz.provider", "1234");
+
+        assertNotNull(certRecord);
+        assertEquals(certRecord.getService(), "cn");
+        assertEquals(certRecord.getCurrentIP(), "current-ip");
+        assertEquals(certRecord.getCurrentSerial(), "current-serial");
+        assertEquals(certRecord.getCurrentTime(), now);
+        assertEquals(certRecord.getInstanceId(), "1234");
+        assertEquals(certRecord.getPrevIP(), "prev-ip");
+        assertEquals(certRecord.getPrevSerial(), "prev-serial");
+        assertEquals(certRecord.getPrevTime(), now);
+        assertEquals(certRecord.getProvider(), "athenz.provider");
+        assertFalse(certRecord.getClientCert());
+
+        dbConn.close();
+    }
+
+    @Test
+    public void testGetX509CertRecordNotFound() {
+
+        Mockito.doThrow(new AmazonDynamoDBException("item not found"))
+                .when(table).getItem("instanceId", "1234", "provider", "athenz.provider");
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+        X509CertRecord certRecord = dbConn.getX509CertRecord("athenz.provider", "1234");
+        assertNull(certRecord);
+        dbConn.close();
+    }
+
+    @Test
+    public void testInsertX509Record() {
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+
+        X509CertRecord certRecord = new X509CertRecord();
+        Date now = new Date();
+
+        certRecord.setService("cn");
+        certRecord.setProvider("athenz.provider");
+        certRecord.setInstanceId("1234");
+        certRecord.setCurrentIP("current-ip");
+        certRecord.setCurrentSerial("current-serial");
+        certRecord.setCurrentTime(now);
+        certRecord.setPrevIP("prev-ip");
+        certRecord.setPrevSerial("prev-serial");
+        certRecord.setPrevTime(now);
+        certRecord.setClientCert(false);
+
+        Item item = new Item()
+                .withPrimaryKey("instanceId", certRecord.getInstanceId(), "provider", certRecord.getProvider())
+                .withString("service", certRecord.getService())
+                .withString("currentSerial", certRecord.getCurrentSerial())
+                .withString("currentIP", certRecord.getCurrentIP())
+                .withLong("currentTime", certRecord.getCurrentTime().getTime())
+                .withString("prevSerial", certRecord.getPrevSerial())
+                .withString("prevIP", certRecord.getPrevIP())
+                .withLong("prevTime", certRecord.getPrevTime().getTime())
+                .withBoolean("clientCert", certRecord.getClientCert())
+                .withLong("ttl", certRecord.getCurrentTime().getTime() / 1000L + 3660 * 720);
+
+        Mockito.doReturn(putOutcome).when(table).putItem(item);
+        boolean requestSuccess = dbConn.insertX509CertRecord(certRecord);
+        assertTrue(requestSuccess);
+
+        dbConn.close();
+    }
+
+    @Test
+    public void testInsertX509RecordException() {
+
+        X509CertRecord certRecord = new X509CertRecord();
+        Date now = new Date();
+
+        certRecord.setService("cn");
+        certRecord.setProvider("athenz.provider");
+        certRecord.setInstanceId("1234");
+        certRecord.setCurrentIP("current-ip");
+        certRecord.setCurrentSerial("current-serial");
+        certRecord.setCurrentTime(now);
+        certRecord.setPrevIP("prev-ip");
+        certRecord.setPrevSerial("prev-serial");
+        certRecord.setPrevTime(now);
+        certRecord.setClientCert(false);
+
+        Mockito.doThrow(new AmazonDynamoDBException("invalid operation"))
+                .when(table).putItem(ArgumentMatchers.any(Item.class));
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+        boolean requestSuccess = dbConn.insertX509CertRecord(certRecord);
+        assertFalse(requestSuccess);
+
+        dbConn.close();
+    }
+
+    @Test
+    public void testUpdateX509Record() {
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+
+        X509CertRecord certRecord = new X509CertRecord();
+        Date now = new Date();
+
+        certRecord.setService("cn");
+        certRecord.setProvider("athenz.provider");
+        certRecord.setInstanceId("1234");
+        certRecord.setCurrentIP("current-ip");
+        certRecord.setCurrentSerial("current-serial");
+        certRecord.setCurrentTime(now);
+        certRecord.setPrevIP("prev-ip");
+        certRecord.setPrevSerial("prev-serial");
+        certRecord.setPrevTime(now);
+        certRecord.setClientCert(false);
+
+        UpdateItemSpec item = new UpdateItemSpec()
+                .withPrimaryKey("instanceId", certRecord.getInstanceId(), "provider", certRecord.getProvider())
+                .withAttributeUpdate(
+                        new AttributeUpdate("service").put(certRecord.getService()),
+                        new AttributeUpdate("currentSerial").put(certRecord.getCurrentSerial()),
+                        new AttributeUpdate("currentIP").put(certRecord.getCurrentIP()),
+                        new AttributeUpdate("currentTime").put(certRecord.getCurrentTime().getTime()),
+                        new AttributeUpdate("prevSerial").put(certRecord.getPrevSerial()),
+                        new AttributeUpdate("prevIP").put(certRecord.getPrevIP()),
+                        new AttributeUpdate("prevTime").put(certRecord.getPrevTime().getTime()),
+                        new AttributeUpdate("clientCert").put(certRecord.getClientCert()),
+                        new AttributeUpdate("ttl").put(certRecord.getCurrentTime().getTime() / 1000L + 3660 * 720));
+
+        Mockito.doReturn(updateOutcome).when(table).updateItem(item);
+        boolean requestSuccess = dbConn.updateX509CertRecord(certRecord);
+        assertTrue(requestSuccess);
+
+        dbConn.close();
+    }
+
+    @Test
+    public void testUpdateX509RecordException() {
+
+        X509CertRecord certRecord = new X509CertRecord();
+        Date now = new Date();
+
+        certRecord.setService("cn");
+        certRecord.setProvider("athenz.provider");
+        certRecord.setInstanceId("1234");
+        certRecord.setCurrentIP("current-ip");
+        certRecord.setCurrentSerial("current-serial");
+        certRecord.setCurrentTime(now);
+        certRecord.setPrevIP("prev-ip");
+        certRecord.setPrevSerial("prev-serial");
+        certRecord.setPrevTime(now);
+        certRecord.setClientCert(false);
+
+        Mockito.doThrow(new AmazonDynamoDBException("invalid operation"))
+                .when(table).updateItem(ArgumentMatchers.any(UpdateItemSpec.class));
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+        boolean requestSuccess = dbConn.updateX509CertRecord(certRecord);
+        assertFalse(requestSuccess);
+
+        dbConn.close();
+    }
+
+    @Test
+    public void testDeleteX509Record() {
+        DeleteItemSpec deleteItemSpec = new DeleteItemSpec()
+                .withPrimaryKey("instanceId", "12345", "provider", "athenz.provider");
+        Mockito.doReturn(deleteOutcome).when(table).deleteItem(deleteItemSpec);
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+
+        boolean requestSuccess = dbConn.deleteX509CertRecord("athenz.provider", "12345");
+        assertTrue(requestSuccess);
+        dbConn.close();
+    }
+
+    @Test
+    public void testDeleteX509RecordException() {
+
+        Mockito.doThrow(new AmazonDynamoDBException("invalid operation"))
+                .when(table).deleteItem(ArgumentMatchers.any(DeleteItemSpec.class));
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+
+        boolean requestSuccess = dbConn.deleteX509CertRecord("athenz.provider", "12345");
+        assertFalse(requestSuccess);
+        dbConn.close();
+    }
+
+    @Test
+    public void testdeleteExpiredX509CertRecords() {
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+        assertEquals(0, dbConn.deleteExpiredX509CertRecords(100));
+        assertEquals(0, dbConn.deleteExpiredX509CertRecords(100000));
+        dbConn.close();
+    }
+}

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreFactoryTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreFactoryTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl;
+
+import com.amazonaws.services.dynamodbv2.document.DynamoDB;
+import com.amazonaws.services.dynamodbv2.document.Table;
+import com.yahoo.athenz.zts.ResourceException;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.zts.ZTSConsts;
+import com.yahoo.athenz.zts.cert.CertRecordStore;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+public class DynamoDBCertRecordStoreFactoryTest {
+
+    @Mock private AmazonDynamoDB dbClient;
+    @Mock private Table table;
+
+    @Mock private DynamoDB dynamoDB;
+
+    class TestDynamoDBCertRecordStoreFactory extends DynamoDBCertRecordStoreFactory {
+
+        @Override
+        AmazonDynamoDB getDynamoDBClient() {
+            return dbClient;
+        }
+    }
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+        Mockito.doReturn(table).when(dynamoDB).getTable("Athenz-ZTS-Table");
+    }
+
+    @Test
+    public void testCreate() {
+
+        System.setProperty(ZTSConsts.ZTS_PROP_CERT_DYNAMODB_TABLE_NAME, "Athenz-ZTS-Table");
+
+        PrivateKeyStore keyStore = Mockito.mock(PrivateKeyStore.class);
+
+        TestDynamoDBCertRecordStoreFactory factory = new TestDynamoDBCertRecordStoreFactory();
+        CertRecordStore store = factory.create(keyStore);
+        assertNotNull(store);
+    }
+
+    @Test
+    public void testCreateAmzClient() {
+
+        System.setProperty(ZTSConsts.ZTS_PROP_CERT_DYNAMODB_TABLE_NAME, "Athenz-ZTS-Table");
+
+        PrivateKeyStore keyStore = Mockito.mock(PrivateKeyStore.class);
+        DynamoDBCertRecordStoreFactory factory = new DynamoDBCertRecordStoreFactory();
+        try {
+            factory.create(keyStore);
+        } catch (Exception ignored) {
+        }
+    }
+
+    @Test
+    public void testCreateMissingTableName() {
+
+        PrivateKeyStore keyStore = Mockito.mock(PrivateKeyStore.class);
+
+        System.clearProperty(ZTSConsts.ZTS_PROP_CERT_DYNAMODB_TABLE_NAME);
+        DynamoDBCertRecordStoreFactory factory = new DynamoDBCertRecordStoreFactory();
+        try {
+            factory.create(keyStore);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.SERVICE_UNAVAILABLE);
+        }
+
+        System.setProperty(ZTSConsts.ZTS_PROP_CERT_DYNAMODB_TABLE_NAME, "");
+        try {
+            factory.create(keyStore);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.SERVICE_UNAVAILABLE);
+        }
+
+        System.clearProperty(ZTSConsts.ZTS_PROP_CERT_DYNAMODB_TABLE_NAME);
+    }
+}

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.cert.impl;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+
+import com.yahoo.athenz.zts.cert.CertRecordStoreConnection;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class DynamoDBCertRecordStoreTest {
+
+    @Mock private AmazonDynamoDB dbClient;
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testGetConnection() {
+
+        DynamoDBCertRecordStore store = new DynamoDBCertRecordStore(dbClient, "Athenz-ZTS-Table");
+
+        CertRecordStoreConnection dbConn = store.getConnection();
+        assertNotNull(dbConn);
+
+        // empty methods
+        store.setOperationTimeout(10);
+        store.clearConnections();
+    }
+
+    @Test
+    public void testGetConnectionException() {
+
+        // passing null for table name to get exception
+        DynamoDBCertRecordStore store = new DynamoDBCertRecordStore(dbClient, null);
+
+        try {
+            store.getConnection();
+            fail();
+        } catch (Exception ignored) {
+        }
+    }
+}


### PR DESCRIPTION
new AWS dynamodb implementation with factory com.yahoo.athenz.zts.cert.impl.DynamoDBCertRecordStoreFactory for CertRecordStore interface.

The table must be created with the following requirements:

- primary field - instanceId,
- sort key - provider.
- Enable TTL and call the attribute as ttl.