### PR TITLE
ignore full stacktrace when keystore/truststore is not set

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -329,10 +329,20 @@ public class ZTSUtils {
     public static SSLContext createServerClientSSLContext(PrivateKeyStore privateKeyStore) {
 
         final String keyStorePath = System.getProperty(ATHENZ_PROP_KEYSTORE_PATH);
+        if (keyStorePath == null) {
+            LOGGER.error("Unable to create client ssl context: no keystore path specified");
+            return null;
+        }
         final String keyStorePasswordAppName = System.getProperty(ATHENZ_PROP_KEYSTORE_PASSWORD_APPNAME);
         final String keyStorePassword = System.getProperty(ATHENZ_PROP_KEYSTORE_PASSWORD);
         final String keyStoreType = System.getProperty(ATHENZ_PROP_KEYSTORE_TYPE, "PKCS12");
+
         final String trustStorePath = System.getProperty(ATHENZ_PROP_TRUSTSTORE_PATH);
+        if (trustStorePath == null) {
+            LOGGER.error("Unable to create client ssl context: no truststore path specified");
+            return null;
+        }
+
         final String trustStorePassword = System.getProperty(ATHENZ_PROP_TRUSTSTORE_PASSWORD);
         final String trustStorePasswordAppName = System.getProperty(ATHENZ_PROP_TRUSTSTORE_PASSWORD_APPNAME);
         final String trustStoreType = System.getProperty(ATHENZ_PROP_TRUSTSTORE_TYPE, "PKCS12");

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -37,6 +37,7 @@ public class InstanceCertManagerTest {
         ZMSFileChangeLogStore.deleteDirectory(new File("/tmp/zts_server_cert_store"));
         System.setProperty(ZTSConsts.ZTS_PROP_CERT_FILE_STORE_PATH, "/tmp/zts_server_cert_store");
         System.setProperty(ZTSConsts.ZTS_PROP_X509_CA_CERT_FNAME, "src/test/resources/valid_cn_x509.cert");
+        System.setProperty(ZTSConsts.ZTS_PROP_CERTSIGN_BASE_URI, "https://localhost:443/certsign/v2");
     }
     
     @Test


### PR DESCRIPTION
we already catch the exception if keystore/truststore path is null and we debug output with LOGGER.error("....", ex), but this fills up the log file with stracktrace so instead we specifically check for null and just output 1 line errors in those cases.