### PR TITLE
remove update-domain command line help

### DIFF
--- a/libs/go/zmscli/cli.go
+++ b/libs/go/zmscli/cli.go
@@ -674,14 +674,6 @@ func (cli Zms) HelpSpecificCommand(interactive bool, cmd string) string {
 		buf.WriteString("   admin     : additional list of administrators to be added to the domain\n")
 		buf.WriteString(" examples:\n")
 		buf.WriteString("   import-domain coretech coretech.yaml " + cli.UserDomain + ".john\n")
-	case "update-domain":
-		buf.WriteString(" syntax:\n")
-		buf.WriteString("   update-domain domain [file.yaml] - no file means stdin\n")
-		buf.WriteString(" parameters:\n")
-		buf.WriteString("   domain    : name of the domain being updated\n")
-		buf.WriteString("   file.yaml : file that contains domain contents in yaml format\n")
-		buf.WriteString(" examples:\n")
-		buf.WriteString("   update-domain coretech coretech.yaml\n")
 	case "export-domain":
 		buf.WriteString(" syntax:\n")
 		buf.WriteString("   export-domain domain [file.yaml] - no file means stdout\n")
@@ -1523,7 +1515,6 @@ func (cli Zms) HelpListCommand() string {
 	buf.WriteString("   set-application-id application-id\n")
 	buf.WriteString("   import-domain domain [file.yaml [admin ...]] - no file means stdin\n")
 	buf.WriteString("   export-domain domain [file.yaml] - no file means stdout\n")
-	buf.WriteString("   update-domain domain [file.yaml] - no file means stdin\n")
 	buf.WriteString("   delete-domain domain\n")
 	buf.WriteString("   get-signed-domains [matching_tag]\n")
 	buf.WriteString("   use-domain [domain]\n")

--- a/libs/go/zmscli/dump.go
+++ b/libs/go/zmscli/dump.go
@@ -38,9 +38,9 @@ func (cli Zms) dumpDomain(buf *bytes.Buffer, domain *zms.Domain) {
 	}
 	if domain.Account != "" {
 		buf.WriteString(indent_level1)
-		buf.WriteString("aws_account: ")
+		buf.WriteString("aws_account: '")
 		buf.WriteString(domain.Account)
-		buf.WriteString("\n")
+		buf.WriteString("'\n")
 	}
 	productID := int(*domain.YpmId)
 	if productID != 0 {


### PR DESCRIPTION
for the account - we need to specify it in quotes to support account numbers such as 0000123434. yaml go parser treats them as octal numbers with incorrect results: https://github.com/go-yaml/yaml/issues/157