### PR TITLE
Using mapper directly + increase test coverage

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/FilesHelper.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/FilesHelper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts.utils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+public class FilesHelper {
+
+    public Path write(File file, byte[] data) throws IOException {
+        return Files.write(file.toPath(), data);
+    }
+
+    public void delete(File file) throws IOException {
+        Files.delete(file.toPath());
+    }
+
+    public Path setPosixFilePermissions(File file, Set<PosixFilePermission> perms)
+            throws IOException {
+        return Files.setPosixFilePermissions(file.toPath(), perms);
+    }
+
+    public void createEmptyFile(File file) throws IOException {
+        new FileOutputStream(file).close();
+        //noinspection ResultOfMethodCallIgnored
+        file.setLastModified(System.currentTimeMillis());
+    }
+}

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/IPBlock.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/IPBlock.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.yahoo.athenz.zts.utils;
 
 import java.net.InetAddress;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -353,7 +353,7 @@ public class ZTSUtils {
             try (FileInputStream instream = new FileInputStream(new File(trustStorePath))) {
                 KeyStore trustStore = KeyStore.getInstance(trustStoreType);
                 final String password = getApplicationSecret(privateKeyStore, trustStorePasswordAppName, trustStorePassword);
-                trustStore.load(instream, password != null ? password.toCharArray() : EMPTY_PASSWORD);
+                trustStore.load(instream, getPasswordChars(password));
                 tmfactory.init(trustStore);
             }
 
@@ -361,8 +361,8 @@ public class ZTSUtils {
             try (FileInputStream instream = new FileInputStream(new File(keyStorePath))) {
                 KeyStore keyStore = KeyStore.getInstance(keyStoreType);
                 final String password = getApplicationSecret(privateKeyStore, keyStorePasswordAppName, keyStorePassword);
-                keyStore.load(instream, password != null ? password.toCharArray() : EMPTY_PASSWORD);
-                kmfactory.init(keyStore, password != null ? password.toCharArray() : EMPTY_PASSWORD);
+                keyStore.load(instream, getPasswordChars(password));
+                kmfactory.init(keyStore, getPasswordChars(password));
             }
 
             KeyManager[] keymanagers = kmfactory.getKeyManagers();
@@ -375,5 +375,9 @@ public class ZTSUtils {
         }
 
         return sslcontext;
+    }
+
+    static char[] getPasswordChars(final String password) {
+        return password != null ? password.toCharArray() : EMPTY_PASSWORD;
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/InstanceProviderManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/InstanceProviderManagerTest.java
@@ -74,7 +74,7 @@ public class InstanceProviderManagerTest {
 
         // we want to make sure we start we clean dir structure
 
-        ZMSFileChangeLogStore.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
+        ZTSTestUtils.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
 
         File privKeyFile = new File(ZTS_PRIVATE_KEY);
         String privKey = Crypto.encodedFile(privKeyFile);
@@ -91,7 +91,7 @@ public class InstanceProviderManagerTest {
 
     @AfterMethod
     public void shutdown() {
-        ZMSFileChangeLogStore.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
+        ZTSTestUtils.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
         System.clearProperty(ZTSConsts.ZTS_PROP_PROVIDER_ENDPOINTS);
     }
     

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -169,7 +169,7 @@ public class ZTSImplTest {
 
         // we want to make sure we start we clean dir structure
 
-        ZMSFileChangeLogStore.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
+        ZTSTestUtils.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
         
         String privKeyName = System.getProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY);
         File privKeyFile = new File(privKeyName);
@@ -200,7 +200,7 @@ public class ZTSImplTest {
                 "src/test/resources/private_encrypted.key");
         System.setProperty(ZTSConsts.ZTS_PROP_SELF_SIGNER_PRIVATE_KEY_PASSWORD, "athenz");
         
-        ZMSFileChangeLogStore.deleteDirectory(new File("/tmp/zts_server_cert_store"));
+        ZTSTestUtils.deleteDirectory(new File("/tmp/zts_server_cert_store"));
         System.setProperty(ZTSConsts.ZTS_PROP_CERT_FILE_STORE_PATH, "/tmp/zts_server_cert_store");
         
         store = new DataStore(structStore, cloudStore);
@@ -213,7 +213,7 @@ public class ZTSImplTest {
     @AfterMethod
     public void shutdown() {
         cloudStore.close();
-        ZMSFileChangeLogStore.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
+        ZTSTestUtils.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
         System.clearProperty(ZTSConsts.ZTS_PROP_ROLE_TOKEN_MAX_TIMEOUT);
         System.clearProperty(ZTSConsts.ZTS_PROP_ROLE_TOKEN_DEFAULT_TIMEOUT);
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSTestUtils.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSTestUtils.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Oath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zts;
+
+import java.io.File;
+
+public class ZTSTestUtils {
+
+    public static void deleteDirectory(File file) {
+        if (!file.exists()) {
+            return;
+        }
+
+        if (file.isDirectory()) {
+
+            File[] fileList = file.listFiles();
+            if (fileList != null) {
+                for (File ff : fileList) {
+                    deleteDirectory(ff);
+                }
+            }
+        }
+        if (!file.delete()) {
+            throw new RuntimeException("cannot delete file: {}" + file.getAbsolutePath());
+        }
+    }
+}

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -33,7 +33,7 @@ public class InstanceCertManagerTest {
 
     @BeforeMethod
     public void setup() {
-        ZMSFileChangeLogStore.deleteDirectory(new File("/tmp/zts_server_cert_store"));
+        ZTSTestUtils.deleteDirectory(new File("/tmp/zts_server_cert_store"));
         System.setProperty(ZTSConsts.ZTS_PROP_CERT_FILE_STORE_PATH, "/tmp/zts_server_cert_store");
         System.setProperty(ZTSConsts.ZTS_PROP_X509_CA_CERT_FNAME, "src/test/resources/valid_cn_x509.cert");
         System.setProperty(ZTSConsts.ZTS_PROP_CERTSIGN_BASE_URI, "https://localhost:443/certsign/v2");

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnectionTest.java
@@ -3,6 +3,7 @@ package com.yahoo.athenz.zts.cert.impl;
 import java.io.File;
 import java.util.Date;
 
+import com.yahoo.athenz.zts.ZTSTestUtils;
 import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
@@ -15,8 +16,8 @@ public class FileCertRecordStoreConnectionTest {
     public void testX509CertOperations() {
         
         // make sure the directory does not exist
-        
-        ZMSFileChangeLogStore.deleteDirectory(new File("/tmp/zts-cert-tests"));
+
+        ZTSTestUtils.deleteDirectory(new File("/tmp/zts-cert-tests"));
 
         FileCertRecordStore store = new FileCertRecordStore(new File("/tmp/zts-cert-tests"));
         FileCertRecordStoreConnection con = (FileCertRecordStoreConnection) store.getConnection();
@@ -95,8 +96,8 @@ public class FileCertRecordStoreConnectionTest {
     public void testX509CertOperationsNullValues() {
         
         // make sure the directory does not exist
-        
-        ZMSFileChangeLogStore.deleteDirectory(new File("/tmp/zts-cert-tests"));
+
+        ZTSTestUtils.deleteDirectory(new File("/tmp/zts-cert-tests"));
 
         FileCertRecordStore store = new FileCertRecordStore(new File("/tmp/zts-cert-tests"));
         FileCertRecordStoreConnection con = (FileCertRecordStoreConnection) store.getConnection();
@@ -116,8 +117,8 @@ public class FileCertRecordStoreConnectionTest {
     public void testdeleteExpiredX509CertRecords() throws Exception {
         
         // make sure the directory does not exist
-        
-        ZMSFileChangeLogStore.deleteDirectory(new File("/tmp/zts-cert-tests"));
+
+        ZTSTestUtils.deleteDirectory(new File("/tmp/zts-cert-tests"));
 
         FileCertRecordStore store = new FileCertRecordStore(new File("/tmp/zts-cert-tests"));
         FileCertRecordStoreConnection con = (FileCertRecordStoreConnection) store.getConnection();

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.yahoo.athenz.zts.ZTSTestUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -123,7 +124,7 @@ public class DataStoreTest {
 
         // we want to make sure we start we clean dir structure
 
-        ZMSFileChangeLogStore.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
+        ZTSTestUtils.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
         
         String privKeyName = System.getProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY);
         File privKeyFile = new File(privKeyName);
@@ -136,7 +137,7 @@ public class DataStoreTest {
     
     @AfterMethod
     public void cleanup() {
-        ZMSFileChangeLogStore.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
+        ZTSTestUtils.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
     }
     
     private void setServicePublicKey(ServiceIdentity service, String id, String key) {
@@ -3333,7 +3334,7 @@ public class DataStoreTest {
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
         ((MockZMSFileChangeLogStore) store.changeLogStore).lastModTime = "2014-01-01T12:00:00";
-        ((MockZMSFileChangeLogStore) store.changeLogStore).setSignedDomains(null);
+        ((MockZMSFileChangeLogStore) store.changeLogStore).setSignedDomainsExc();
         
         boolean result = store.processDomainUpdates();
         assertFalse(result);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/MockS3ChangeLogStore.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/MockS3ChangeLogStore.java
@@ -27,9 +27,16 @@ class MockS3ChangeLogStore extends S3ChangeLogStore {
         super(cloudStore);
         awsS3Client = mock(AmazonS3.class);
     }
-    
+
+    void resetAWSS3Client() {
+        awsS3Client = null;
+    }
+
     @Override
     AmazonS3 getS3Client() {
+        if (awsS3Client == null) {
+            awsS3Client = mock(AmazonS3.class);
+        }
         return awsS3Client;
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/MockZMSFileChangeLogStore.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/MockZMSFileChangeLogStore.java
@@ -80,13 +80,16 @@ public class MockZMSFileChangeLogStore extends ZMSFileChangeLogStore {
     
     @SuppressWarnings("unchecked")
     public void setSignedDomains(SignedDomains signedDomains) {
-        if (signedDomains != null) {
-            when(zms.getSignedDomains(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.<Map>any())).thenReturn(signedDomains);
-        } else {
-            when(zms.getSignedDomains(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.<Map>any())).thenThrow(new ZMSClientException(500, "Invalid request"));
-        }
+        when(zms.getSignedDomains(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.<Map>any()))
+                .thenReturn(signedDomains);
     }
-    
+
+    @SuppressWarnings("unchecked")
+    public void setSignedDomainsExc() {
+        when(zms.getSignedDomains(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.<Map>any()))
+                .thenThrow(new ZMSClientException(500, "Invalid request"));
+    }
+
     public void setTagHeader(String tagHeader) {
         this.tagHeader = tagHeader;
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/ZMSFileChangeLogStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/ZMSFileChangeLogStoreTest.java
@@ -20,11 +20,20 @@ import static org.testng.Assert.*;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.security.PrivateKey;
+import java.util.Set;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.zts.ZTSTestUtils;
+import com.yahoo.athenz.zts.utils.FilesHelper;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -57,23 +66,23 @@ public class ZMSFileChangeLogStoreTest {
     
     @BeforeMethod
     public void setup() {
-        ZMSFileChangeLogStore.deleteDirectory(new File(FSTORE_PATH));
+        ZTSTestUtils.deleteDirectory(new File(FSTORE_PATH));
     }
     
     @AfterMethod
     public void shutdown() {
-        ZMSFileChangeLogStore.deleteDirectory(new File(FSTORE_PATH));
+        ZTSTestUtils.deleteDirectory(new File(FSTORE_PATH));
     }
  
     @Test
-    public void FileStructStoreValidDir() {
+    public void testFileStructStoreValidDir() {
         
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         assertNotNull(fstore);
     }
     
     @Test
-    public void FileStructStoreInvalid() {
+    public void testFileStructStoreInvalid() {
         
         try {
             File rootDir = new File(FSTORE_PATH);
@@ -92,7 +101,19 @@ public class ZMSFileChangeLogStoreTest {
     }
 
     @Test
-    public void getNonExistent() {
+    public void testInvalidFileMkdirFail() {
+
+        try {
+            @SuppressWarnings("unused")
+            ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore("/usr\ninvaliddir", null, null);
+            fail();
+        } catch (RuntimeException ex) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testGetNonExistent() {
 
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         Struct st = fstore.get("NotExistent", Struct.class);
@@ -100,7 +121,7 @@ public class ZMSFileChangeLogStoreTest {
     }
 
     @Test
-    public void getExistent() {
+    public void testGetExistent() {
 
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         Struct data = new Struct();
@@ -113,7 +134,7 @@ public class ZMSFileChangeLogStoreTest {
     }
     
     @Test
-    public void deleteExistent() {
+    public void testDeleteExistent() {
         
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         Struct data = new Struct();
@@ -126,7 +147,7 @@ public class ZMSFileChangeLogStoreTest {
     }
     
     @Test
-    public void deleteNonExistent() {
+    public void testDeleteNonExistent() {
         
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         
@@ -135,26 +156,48 @@ public class ZMSFileChangeLogStoreTest {
     }
     
     @Test
-    public void scanEmpty() {
+    public void testGetLocalDomainListEmpty() {
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
-        List<String> ls = fstore.scan();
+        List<String> ls = fstore.getLocalDomainList();
         assertEquals(ls.size(), 0);
     }
-    
+
     @Test
-    public void scanSingle() {
+    public void testGetLocalDomainListError() {
+        ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
+
+        File dir = Mockito.spy(fstore.rootDir);
+        Mockito.when(dir.list()).thenReturn(null);
+        fstore.rootDir = dir;
+
+        List<String> ls = fstore.getLocalDomainList();
+        assertEquals(ls.size(), 0);
+    }
+
+    @Test
+    public void testGetLocalDomainListSingle() throws IOException {
+
+        File rootDir = new File(FSTORE_PATH);
+        //noinspection ResultOfMethodCallIgnored
+        rootDir.mkdirs();
+        Struct lastModStruct = new Struct();
+        lastModStruct.put("lastModTime", 1001);
+        File file = new File(FSTORE_PATH, ".lastModTime");
+        Path path = Paths.get(file.toURI());
+        Files.write(path, JSON.bytes(lastModStruct));
+
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         Struct data = new Struct();
         data.put("key", "val1");
         fstore.put("test1", JSON.bytes(data));
         
-        List<String> ls = fstore.scan();
+        List<String> ls = fstore.getLocalDomainList();
         assertEquals(ls.size(), 1);
         assertTrue(ls.contains("test1"));
     }
 
     @Test
-    public void scanMultiple() {
+    public void testGetLocalDomainListMultiple() {
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         
         Struct data = new Struct();
@@ -169,7 +212,7 @@ public class ZMSFileChangeLogStoreTest {
         data.put("key", "val1");
         fstore.put("test3", JSON.bytes(data));
         
-        List<String> ls = fstore.scan();
+        List<String> ls = fstore.getLocalDomainList();
         assertEquals(ls.size(), 3);
         assertTrue(ls.contains("test1"));
         assertTrue(ls.contains("test2"));
@@ -177,7 +220,7 @@ public class ZMSFileChangeLogStoreTest {
     }
     
     @Test
-    public void scanHidden() {
+    public void testGetLocalDomainListHidden() {
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         
         Struct data = new Struct();
@@ -192,13 +235,13 @@ public class ZMSFileChangeLogStoreTest {
         data.put("key", "val1");
         fstore.put(".test3", JSON.bytes(data));
         
-        List<String> ls = fstore.scan();
+        List<String> ls = fstore.getLocalDomainList();
         assertEquals(ls.size(), 1);
         assertTrue(ls.contains("test1"));
     }
     
     @Test
-    public void scanDelete() {
+    public void testGetLocalDomainListDelete() {
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         
         Struct data = new Struct();
@@ -215,7 +258,7 @@ public class ZMSFileChangeLogStoreTest {
         
         fstore.delete("test2");
         
-        List<String> ls = fstore.scan();
+        List<String> ls = fstore.getLocalDomainList();
         assertEquals(ls.size(), 2);
         assertTrue(ls.contains("test1"));
         assertTrue(ls.contains("test3"));
@@ -229,7 +272,7 @@ public class ZMSFileChangeLogStoreTest {
     }
     
     @Test
-    public void getSignedDomainList() {
+    public void testGetSignedDomainList() {
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         ZMSClient zmsClient = Mockito.mock(ZMSClient.class);
         
@@ -247,7 +290,7 @@ public class ZMSFileChangeLogStoreTest {
     }
 
     @Test
-    public void getSignedDomainListNonRateFailure() {
+    public void testGetSignedDomainListNonRateFailure() {
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         ZMSClient zmsClient = Mockito.mock(ZMSClient.class);
 
@@ -265,7 +308,7 @@ public class ZMSFileChangeLogStoreTest {
     }
 
     @Test
-    public void getSignedDomainListRateFailure() {
+    public void testGetSignedDomainListRateFailure() {
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         ZMSClient zmsClient = Mockito.mock(ZMSClient.class);
 
@@ -285,7 +328,7 @@ public class ZMSFileChangeLogStoreTest {
     }
 
     @Test
-    public void getSignedDomainListOneBadDomain() {
+    public void testGetSignedDomainListOneBadDomain() {
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
         ZMSClient zmsClient = Mockito.mock(ZMSClient.class);
         
@@ -314,7 +357,7 @@ public class ZMSFileChangeLogStoreTest {
     }
 
     @Test
-    public void getZMSClient() {
+    public void testGetZMSClient() {
 
         File privKeyFile = new File("src/test/resources/zts_private.pem");
         final String privKey = Crypto.encodedFile(privKeyFile);
@@ -322,5 +365,131 @@ public class ZMSFileChangeLogStoreTest {
         ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, privateKey, "0");
         ZMSClient zmsClient = fstore.getZMSClient();
         assertNotNull(zmsClient);
+    }
+
+    @Test
+    public void testGetUpdatedSignedDomainsNull() {
+        MockZMSFileChangeLogStore store = new MockZMSFileChangeLogStore(FSTORE_PATH, null, "0");
+        store.setSignedDomainsExc();
+        StringBuilder str = new StringBuilder();
+        assertNull(store.getUpdatedSignedDomains(str));
+    }
+
+    @Test
+    public void testGetUpdatedSignedDomainsNullDomains() {
+        MockZMSFileChangeLogStore store = new MockZMSFileChangeLogStore(FSTORE_PATH, null, "0");
+        SignedDomains domains = new SignedDomains();
+        store.setSignedDomains(domains);
+        StringBuilder str = new StringBuilder();
+        assertNull(store.getUpdatedSignedDomains(str));
+    }
+
+    @Test
+    public void testJsonValueAsBytes() {
+
+        ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
+        ObjectMapper mapper = Mockito.mock(ObjectMapper.class);
+        Mockito.when(mapper.writerWithView(Struct.class)).thenThrow(new RuntimeException("invalid class"));
+        fstore.jsonMapper = mapper;
+        Struct testStruct = new Struct();
+        testStruct.putIfAbsent("key", "value");
+        assertNull(fstore.jsonValueAsBytes(testStruct, Struct.class));
+    }
+
+    @Test
+    public void testGetJsonException() throws IOException {
+
+        ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
+        Struct data = new Struct();
+        data.put("key", "val1");
+        fstore.put("test1", JSON.bytes(data));
+
+        ObjectMapper mapper = Mockito.mock(ObjectMapper.class);
+        File file = new File(FSTORE_PATH, "test1");
+        Mockito.when(mapper.readValue(file, Struct.class)).thenThrow(new RuntimeException("invalid class"));
+        fstore.jsonMapper = mapper;
+
+        assertNull(fstore.get("test1", Struct.class));
+    }
+
+    @Test
+    public void testPutException() throws IOException {
+
+        ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
+        FilesHelper helper = Mockito.mock(FilesHelper.class);
+        Mockito.when(helper.write(Mockito.any(), Mockito.any()))
+                .thenThrow(new IOException("io exception"));
+        fstore.filesHelper = helper;
+
+        Struct data = new Struct();
+        data.put("key", "val1");
+        try {
+            fstore.put("test1", JSON.bytes(data));
+            fail();
+        } catch (Exception ex) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testDeleteException() throws IOException {
+
+        ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
+
+        // create the file
+
+        Struct data = new Struct();
+        data.put("key", "val1");
+        fstore.put("test1", JSON.bytes(data));
+
+        // update the helper to be our mock
+
+        FilesHelper helper = Mockito.mock(FilesHelper.class);
+        Mockito.doThrow(new IOException("io exception")).when(helper).delete(Mockito.any());
+        fstore.filesHelper = helper;
+
+        try {
+            fstore.delete("test1");
+            fail();
+        } catch (Exception ex) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testSetupDomainFileException() throws IOException {
+
+        ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
+        FilesHelper helper = Mockito.mock(FilesHelper.class);
+        Mockito.doThrow(new IOException("io exception")).when(helper).createEmptyFile(Mockito.any());
+        fstore.filesHelper = helper;
+
+        try {
+            File file = new File(FSTORE_PATH, "domain");
+            fstore.setupDomainFile(file);
+            fail();
+        } catch (Exception ex) {
+            assertTrue(true);
+        }
+    }
+
+    @Test
+    public void testSetFilePermissionsException() throws IOException {
+
+        ZMSFileChangeLogStore fstore = new ZMSFileChangeLogStore(FSTORE_PATH, null, null);
+        FilesHelper helper = Mockito.mock(FilesHelper.class);
+        Mockito.when(helper.setPosixFilePermissions(Mockito.any(), Mockito.any()))
+                .thenThrow(new IOException("io exception"));
+        fstore.filesHelper = helper;
+
+        try {
+            File file = new File(FSTORE_PATH, "domain");
+            Set<PosixFilePermission> perms = EnumSet.of(PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_EXECUTE);
+            fstore.setupFilePermissions(file, perms);
+            fail();
+        } catch (Exception ex) {
+            assertTrue(true);
+        }
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
@@ -461,4 +461,14 @@ public class ZTSUtilsTest {
         SSLContext sslContext = ZTSUtils.createServerClientSSLContext(null);
         assertNull(sslContext);
     }
+
+    @Test
+    public void testGetPasswordChars() {
+        char [] emptyValue = new char[0];
+        char [] passValue = {'p', 'a', 's', 's'};
+
+        assertEquals(emptyValue, ZTSUtils.getPasswordChars(null));
+        assertEquals(emptyValue, ZTSUtils.getPasswordChars(""));
+        assertEquals(passValue, ZTSUtils.getPasswordChars("pass"));
+    }
 }


### PR DESCRIPTION
Rather than using JSON class which requires us to read the full data (either file or inputstream) before calling the jackson's object mapper, we can use the object mapper directly passing the stream and file handles.

Updated the code plus update the unit test cases for S3 and ZMS storage classes to have 100% unit test coverage.