### PR TITLE
extra fields in service/role certs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ cache:
   directories:
   - "$HOME/.m2"
 before_install:
-- eval "$(gimme 1.7.3)"
+- eval "$(gimme 1.10.4)"
 - nvm install 6
 - npm install -g npm@latest
 - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test

--- a/utils/zts-rolecert/zts-rolecert.go
+++ b/utils/zts-rolecert/zts-rolecert.go
@@ -15,7 +15,9 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"github.com/yahoo/athenz/clients/go/zts"
@@ -30,28 +32,51 @@ func main() {
 
 	var ztsURL, svcKeyFile, svcCertFile, domain, service string
 	var caCertFile, roleCertFile, roleDomain, roleName, dnsDomain string
+	var subjC, subjO, subjOU, ip, uri string
+	var spiffe bool
+
 	flag.StringVar(&roleCertFile, "role-cert-file", "", "output role certificate file")
 	flag.StringVar(&caCertFile, "cacert", "", "CA certificate file")
-	flag.StringVar(&svcKeyFile, "svc-key-file", "", "service identity private key file")
-	flag.StringVar(&svcCertFile, "svc-cert-file", "", "service identity certificate file")
-	flag.StringVar(&domain, "domain", "", "domain of service")
-	flag.StringVar(&service, "service", "", "name of service")
-	flag.StringVar(&ztsURL, "zts", "", "url of the ZTS Service")
-	flag.StringVar(&roleDomain, "role-domain", "", "requested role domain name")
-	flag.StringVar(&roleName, "role-name", "", "requested role name in the role-domain")
-	flag.StringVar(&dnsDomain, "dns-domain", "", "dns domain suffix to be included in the csr")
+	flag.StringVar(&svcKeyFile, "svc-key-file", "", "service identity private key file (required)")
+	flag.StringVar(&svcCertFile, "svc-cert-file", "", "service identity certificate file (required)")
+	flag.StringVar(&domain, "domain", "", "domain of service (required)")
+	flag.StringVar(&service, "service", "", "name of service (required)")
+	flag.StringVar(&ztsURL, "zts", "", "url of the ZTS Service (required)")
+	flag.StringVar(&roleDomain, "role-domain", "", "requested role domain name (required)")
+	flag.StringVar(&roleName, "role-name", "", "requested role name in the role-domain (required)")
+	flag.StringVar(&dnsDomain, "dns-domain", "", "dns domain suffix to be included in the csr (required)")
+	flag.StringVar(&subjC, "subj-c", "US", "Subject C/Country field")
+	flag.StringVar(&subjO, "subj-o", "Oath Inc.", "Subject O/Organization field")
+	flag.StringVar(&subjOU, "subj-ou", "Athenz", "Subject OU/OrganizationalUnit field")
+	flag.StringVar(&ip, "ip", "", "IP address")
+	flag.BoolVar(&spiffe, "spiffe", false, "include spiffe uri in csr")
 	flag.Parse()
 
 	if svcKeyFile == "" || svcCertFile == "" || domain == "" || service == "" ||
 		ztsURL == "" || dnsDomain == "" || roleDomain == "" || roleName == "" {
-		log.Fatalf("usage: zts-rolecert -domain <domain> -service <service> -svc-key-file <key-file> -svc-cert-file <cert-file> -zts <zts-server-url> -role-domain <domain> -role-name <name> -dns-domain <dns-domain> [-role-cert-file <output-cert-file>] [-cacert <ca-certificate-file>]\n")
+		log.Fatalln("Error: missing required attributes. Run with -help for command line arguments")
 	}
 
 	hyphenDomain := strings.Replace(domain, ".", "-", -1)
 	host := fmt.Sprintf("%s.%s.%s", service, hyphenDomain, dnsDomain)
 	rfc822 := fmt.Sprintf("%s.%s@%s", domain, service, dnsDomain)
+	if spiffe {
+		uri = fmt.Sprintf("spiffe://%s/role/%s", roleDomain, roleName)
+	}
 
-	client, err := ztsClient(ztsURL, host, svcKeyFile, svcCertFile, caCertFile)
+	//note: RFC 6125 states that if the SAN (Subject Alternative Name) exists,
+	//it is used, not the CA. So, we will always put the Athens name in the CN
+	//(it is *not* a DNS domain name), and put the host name into the SAN.
+
+	commonName := fmt.Sprintf("%s:role.%s", roleDomain, roleName)
+	subj := pkix.Name{
+		CommonName:         commonName,
+		OrganizationalUnit: []string{subjOU},
+		Organization:       []string{subjO},
+		Country:            []string{subjC},
+	}
+
+	client, err := ztsClient(ztsURL, svcKeyFile, svcCertFile, caCertFile)
 	if err != nil {
 		log.Fatalf("Unable to initialize ZTS Client for %s, err: %v\n", ztsURL, err)
 	}
@@ -68,19 +93,15 @@ func main() {
 		log.Fatalf("Unable to retrieve private key %s, err: %v\n", svcKeyFile, err)
 	}
 
-	getRoleCertificate(client, pkSigner, host, rfc822, roleDomain, roleName, roleCertFile)
+	csr, err := generateCSR(pkSigner, subj, host, rfc822, ip, uri)
+	if err != nil {
+		log.Fatalf("Unable to generate CSR for %s, err: %v\n", roleName, err)
+	}
+
+	getRoleCertificate(client, csr, roleDomain, roleName, roleCertFile)
 }
 
-func generateCSR(keySigner *signer, roleDomain, roleName, host, rfc822 string) (string, error) {
-	//note: RFC 6125 states that if the SAN (Subject Alternative Name) exists,
-	//it is used, not the CA. So, we will always put the Athens name in the CN
-	//(it is *not* a DNS domain name), and put the host name into the SAN.
-	commonName := fmt.Sprintf("%s:role.%s", roleDomain, roleName)
-	subj := pkix.Name{CommonName: commonName}
-	subj.Country = []string{"US"}
-	subj.Province = []string{"CA"}
-	subj.Organization = []string{"Oath"}
-	subj.OrganizationalUnit = []string{"Athenz"}
+func generateCSR(keySigner *signer, subj pkix.Name, host, rfc822, ip, uri string) (string, error) {
 
 	template := x509.CertificateRequest{
 		Subject:            subj,
@@ -91,6 +112,15 @@ func generateCSR(keySigner *signer, roleDomain, roleName, host, rfc822 string) (
 	}
 	if rfc822 != "" {
 		template.EmailAddresses = []string{rfc822}
+	}
+	if ip != "" {
+		template.IPAddresses = []net.IP{net.ParseIP(ip)}
+	}
+	if uri != "" {
+		uriptr, err := url.Parse(uri)
+		if err == nil {
+			template.URIs = []*url.URL{uriptr}
+		}
 	}
 	csr, err := x509.CreateCertificateRequest(rand.Reader, &template, keySigner.key)
 	if err != nil {
@@ -108,14 +138,9 @@ func generateCSR(keySigner *signer, roleDomain, roleName, host, rfc822 string) (
 	return buf.String(), nil
 }
 
-func getRoleCertificate(client *zts.ZTSClient, keySigner *signer, host, rfc822, roleDomain, roleName, roleCertFile string) {
+func getRoleCertificate(client *zts.ZTSClient, csr, roleDomain, roleName, roleCertFile string) {
 
 	var roleRequest = new(zts.RoleCertificateRequest)
-	csr, err := generateCSR(keySigner, roleDomain, roleName, host, rfc822)
-	if err != nil {
-		log.Fatalf("Unable to generate CSR for %s, err: %v\n", roleName, err)
-	}
-
 	roleRequest.Csr = csr
 	roleToken, err := client.PostRoleCertificateRequest(zts.DomainName(roleDomain), zts.EntityName(roleName), roleRequest)
 	if err != nil {
@@ -132,7 +157,7 @@ func getRoleCertificate(client *zts.ZTSClient, keySigner *signer, host, rfc822, 
 	}
 }
 
-func ztsClient(ztsURL, ztsHostName, keyFile, certFile, caFile string) (*zts.ZTSClient, error) {
+func ztsClient(ztsURL, keyFile, certFile, caFile string) (*zts.ZTSClient, error) {
 	config, err := tlsConfiguration(keyFile, certFile, caFile)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Provide the following extra fields:

a) command line arguments to provide c/o/ou fields in role/cservice certs
b) provide option to specify ip field in the cert. zts server will validate and reject the request if the ip address does not match to the incoming ip address
c) provide option to include spiffe uri in the request