### PR TITLE
Primary AWS auth is IAM creds

### DIFF
--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSLambdaProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSLambdaProvider.java
@@ -24,7 +24,8 @@ public class InstanceAWSLambdaProvider extends InstanceAWSProvider {
 
     @Override
     boolean validateAWSDocument(final String provider, AWSAttestationData info,
-            final String awsAccount, final String instanceId, StringBuilder errMsg) {
+            final String awsAccount, final String instanceId, boolean checkTime,
+            StringBuilder errMsg) {
         
         // for lambda we don't have an instance document so we
         // are going to trust based on temporary credentials only
@@ -33,12 +34,14 @@ public class InstanceAWSLambdaProvider extends InstanceAWSProvider {
     }
     
     @Override
-    void setConfirmationAttributes(InstanceConfirmation confirmation) {
+    void setConfirmationAttributes(InstanceConfirmation confirmation, boolean sshCert) {
         
         // for lambda we can only issue client certificates
+        // and we always do not allow ssh certs
         
         Map<String, String> attributes = new HashMap<>();
         attributes.put(ZTS_CERT_USAGE, ZTS_CERT_USAGE_CLIENT);
+        attributes.put(ZTS_CERT_SSH, "false");
         confirmation.setAttributes(attributes);
     }
 }

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSECSProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceAWSECSProviderTest.java
@@ -65,7 +65,7 @@ public class InstanceAWSECSProviderTest {
                 + bootTime + "\",\"region\": \"us-west-2\",\"instanceId\": \"i-1234\"}");
         data.setSignature("signature");
         assertTrue(provider.validateAWSDocument("athenz.aws-ecs.us-west-2", data,
-                "1234", "i-1234", errMsg));
+                "1234", "i-1234", true, errMsg));
     }
     
     @Test

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -129,6 +129,7 @@ public final class ZTSConsts {
     public static final String ZTS_CERT_EXPIRY_TIME  = "certExpiryTime";
     public static final String ZTS_CERT_REFRESH      = "certRefresh";
     public static final String ZTS_CERT_SUBJECT_OU   = "certSubjectOU";
+    public static final String ZTS_CERT_SSH          = "certSSH";
 
     public static final String ZTS_CERT_USAGE_CLIENT = "client";
     public static final String ZTS_CERT_USAGE_SERVER = "server";
@@ -143,7 +144,8 @@ public final class ZTSConsts {
     public static final String ZTS_INSTANCE_SAN_IP        = "sanIP";
     public static final String ZTS_INSTANCE_CLIENT_IP     = "clientIP";
     public static final String ZTS_INSTANCE_CLOUD_ACCOUNT = "cloudAccount";
-    
+    public static final String ZTS_INSTANCE_ID            = "instanceId";
+
     public static final String ZTS_PROP_AWS_ENABLED              = "athenz.zts.aws_enabled";
     public static final String ZTS_PROP_AWS_BUCKET_NAME          = "athenz.zts.aws_bucket_name";
     public static final String ZTS_PROP_AWS_CREDS_UPDATE_TIMEOUT = "athenz.zts.aws_creds_update_timeout";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -381,8 +381,8 @@ public class ZTSUtils {
         return password != null ? password.toCharArray() : EMPTY_PASSWORD;
     }
 
-    public static int parseInt(final String value) {
-        int intVal = 0;
+    public static int parseInt(final String value, int defaultValue) {
+        int intVal = defaultValue;
         if (value != null && !value.isEmpty()) {
             try {
                 intVal = Integer.parseInt(value);
@@ -391,5 +391,13 @@ public class ZTSUtils {
             }
         }
         return intVal;
+    }
+
+    public static boolean parseBoolean(final String value, boolean defaultValue) {
+        boolean boolVal = defaultValue;
+        if (value != null && !value.isEmpty()) {
+            boolVal = Boolean.parseBoolean(value);
+        }
+        return boolVal;
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
@@ -474,9 +474,20 @@ public class ZTSUtilsTest {
 
     @Test
     public void testParseInt() {
-        assertEquals(0, ZTSUtils.parseInt(null));
-        assertEquals(0, ZTSUtils.parseInt(""));
-        assertEquals(100, ZTSUtils.parseInt("100"));
-        assertEquals(0, ZTSUtils.parseInt("abc"));
+        assertEquals(0, ZTSUtils.parseInt(null, 0));
+        assertEquals(-1, ZTSUtils.parseInt("", -1));
+        assertEquals(100, ZTSUtils.parseInt("100", 1));
+        assertEquals(0, ZTSUtils.parseInt("abc", 0));
+    }
+
+    @Test
+    public void testParseBoolean() {
+        assertEquals(true, ZTSUtils.parseBoolean(null, true));
+        assertEquals(false, ZTSUtils.parseBoolean(null, false));
+        assertEquals(true, ZTSUtils.parseBoolean("", true));
+        assertEquals(false, ZTSUtils.parseBoolean("", false));
+        assertEquals(true, ZTSUtils.parseBoolean("true", false));
+        assertEquals(false, ZTSUtils.parseBoolean("false", true));
+        assertEquals(false, ZTSUtils.parseBoolean("unknown", false));
     }
 }


### PR DESCRIPTION
Make SSH certs false by default and let the provider tell ZTS if ssh certs should be allowed or not. 

AWS provider will only allow host ssh certs if identity document is provided as part of attestation data.