### PR TITLE
extra options for meta only signed domain list

### DIFF
--- a/clients/go/zms/client.go
+++ b/clients/go/zms/client.go
@@ -2210,12 +2210,12 @@ func (client ZMSClient) GetResourceAccessList(principal EntityName, action Actio
 	}
 }
 
-func (client ZMSClient) GetSignedDomains(domain DomainName, metaOnly string, matchingTag string) (*SignedDomains, string, error) {
+func (client ZMSClient) GetSignedDomains(domain DomainName, metaOnly string, metaAttr SimpleName, matchingTag string) (*SignedDomains, string, error) {
 	var data *SignedDomains
 	headers := map[string]string{
 		"If-None-Match": matchingTag,
 	}
-	url := client.URL + "/sys/modified_domains" + encodeParams(encodeStringParam("domain", string(domain), ""), encodeStringParam("metaonly", string(metaOnly), ""))
+	url := client.URL + "/sys/modified_domains" + encodeParams(encodeStringParam("domain", string(domain), ""), encodeStringParam("metaonly", string(metaOnly), ""), encodeStringParam("metaattr", string(metaAttr), ""))
 	resp, err := client.httpGet(url, headers)
 	if err != nil {
 		return nil, "", err

--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -3153,6 +3153,16 @@ type DomainModified struct {
 	// last modified timestamp of the domain
 	//
 	Modified int64 `json:"modified"`
+
+	//
+	// associated cloud (i.e. aws) account id
+	//
+	Account string `json:"account,omitempty" rdl:"optional"`
+
+	//
+	// associated product id
+	//
+	YpmId *int32 `json:"ypmId,omitempty" rdl:"optional"`
 }
 
 //

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -350,6 +350,8 @@ func init() {
 	tDomainModified.Comment("Tuple of domain-name and modification time-stamps. This object is returned when the caller has requested list of domains modified since a specific timestamp.")
 	tDomainModified.Field("name", "DomainName", false, nil, "name of the domain")
 	tDomainModified.Field("modified", "Int64", false, nil, "last modified timestamp of the domain")
+	tDomainModified.Field("account", "String", true, nil, "associated cloud (i.e. aws) account id")
+	tDomainModified.Field("ypmId", "Int32", true, nil, "associated product id")
 	sb.AddType(tDomainModified.Build())
 
 	tDomainModifiedList := rdl.NewStructTypeBuilder("Struct", "DomainModifiedList")
@@ -1204,6 +1206,7 @@ func init() {
 	mGetSignedDomains.Comment("Retrieve the list of modified domains since the specified timestamp. The server will return the list of all modified domains and the latest modification timestamp as the value of the ETag header. The client will need to use this value during its next call to request the changes since the previous request. When metaonly set to true, dont add roles, policies or services, dont sign")
 	mGetSignedDomains.Input("domain", "DomainName", false, "domain", "", true, nil, "filter the domain list only to the specified name")
 	mGetSignedDomains.Input("metaOnly", "String", false, "metaonly", "", true, nil, "valid values are \"true\" or \"false\"")
+	mGetSignedDomains.Input("metaAttr", "SimpleName", false, "metaattr", "", true, nil, "domain meta attribute to filter/return, valid values \"account\", \"ypmId\", or \"all\"")
 	mGetSignedDomains.Input("matchingTag", "String", false, "", "If-None-Match", false, nil, "Retrieved from the previous request, this timestamp specifies to the server to return any domains modified since this time")
 	mGetSignedDomains.Output("tag", "String", "ETag", false, "The current latest modification timestamp is returned in this header")
 	mGetSignedDomains.Auth("", "", true, "")

--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
@@ -1544,16 +1544,47 @@ public class ZMSClient implements Closeable {
      */
     public SignedDomains getSignedDomains(String domainName, String metaOnly, String matchingTag,
             Map<String, List<String>> responseHeaders) {
+        return getSignedDomains(domainName, metaOnly, null, matchingTag, responseHeaders);
+    }
+
+    /**
+     * Retrieve the list of all domain data from the ZMS Server that
+     * is signed with ZMS's private key. It will pass an optional matchingTag
+     * so that ZMS can skip returning domains if no changes have taken
+     * place since that tag was issued.
+     * @param domainName name of the domain. if specified, the server will
+     *        only return this domain in the result set
+     * @param metaOnly (can be null) must have value of true or false (default).
+     *        if set to true, zms server will only return meta information
+     *        about each domain (description, last modified timestamp, etc) and
+     *        no role/policy/service details will be returned.
+     * @param metaAttr (can be null) if metaOnly option is set to true, this
+     *        parameter can filter the results based on the presence of the
+     *        requested attribute. Allowed values are: account, ypmid, and all.
+     *        account - only return domains that have the account value set
+     *        ypmid - only return domains that have the ypmid value set
+     *        all - return all domains (no filtering).
+     * @param matchingTag (can be null) contains modified timestamp received
+     *        with last request. If null, then return all domains.
+     * @param responseHeaders contains the "tag" returned for modification
+     *        time of the domains, map key = "tag", List should
+     *        contain a single value timestamp String to be used
+     *        with subsequent call as matchingTag to this API
+     * @return list of domains signed by ZMS Server
+     * @throws ZMSClientException in case of failure
+     */
+    public SignedDomains getSignedDomains(String domainName, String metaOnly, String metaAttr,
+            String matchingTag, Map<String, List<String>> responseHeaders) {
         updatePrincipal();
         try {
-            return client.getSignedDomains(domainName, metaOnly, matchingTag, responseHeaders);
+            return client.getSignedDomains(domainName, metaOnly, metaAttr, matchingTag, responseHeaders);
         } catch (ResourceException ex) {
             throw new ZMSClientException(ex.getCode(), ex.getData());
         } catch (Exception ex) {
             throw new ZMSClientException(ZMSClientException.BAD_REQUEST, ex.getMessage());
         }
     }
-    
+
     /**
      * For the specified user credentials return the corresponding User Token that
      * can be used for authenticating other ZMS operations. The client internally

--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSRDLGeneratedClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSRDLGeneratedClient.java
@@ -1301,13 +1301,16 @@ public class ZMSRDLGeneratedClient {
 
     }
 
-    public SignedDomains getSignedDomains(String domain, String metaOnly, String matchingTag, java.util.Map<String, java.util.List<String>> headers) {
+    public SignedDomains getSignedDomains(String domain, String metaOnly, String metaAttr, String matchingTag, java.util.Map<String, java.util.List<String>> headers) {
         WebTarget target = base.path("/sys/modified_domains");
         if (domain != null) {
             target = target.queryParam("domain", domain);
         }
         if (metaOnly != null) {
             target = target.queryParam("metaonly", metaOnly);
+        }
+        if (metaAttr != null) {
+            target = target.queryParam("metaattr", metaAttr);
         }
         Invocation.Builder invocationBuilder = target.request("application/json");
         if (credsHeader != null) {

--- a/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
+++ b/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
@@ -1543,7 +1543,7 @@ public class ZMSClientTest {
         client.setZMSRDLGeneratedClient(c);
         Map<String, List<String>> respHdrs = new HashMap<>();
         SignedDomains signedDomain1 = Mockito.mock(SignedDomains.class);
-        Mockito.when(c.getSignedDomains("dom1", "meta1", "tag1", respHdrs)).thenReturn(signedDomain1).thenThrow(new ZMSClientException(400,"Audit reference required"));
+        Mockito.when(c.getSignedDomains("dom1", "meta1", null, "tag1", respHdrs)).thenReturn(signedDomain1).thenThrow(new ZMSClientException(400,"Audit reference required"));
         client.getSignedDomains("dom1", "meta1", "tag1", respHdrs);
         try {
             client.getSignedDomains("dom1", "meta1", "tag1", respHdrs);

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/DomainModified.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/DomainModified.java
@@ -3,6 +3,7 @@
 //
 
 package com.yahoo.athenz.zms;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.yahoo.rdl.*;
 
 //
@@ -13,6 +14,12 @@ import com.yahoo.rdl.*;
 public class DomainModified {
     public String name;
     public long modified;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String account;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Integer ypmId;
 
     public DomainModified setName(String name) {
         this.name = name;
@@ -28,6 +35,20 @@ public class DomainModified {
     public long getModified() {
         return modified;
     }
+    public DomainModified setAccount(String account) {
+        this.account = account;
+        return this;
+    }
+    public String getAccount() {
+        return account;
+    }
+    public DomainModified setYpmId(Integer ypmId) {
+        this.ypmId = ypmId;
+        return this;
+    }
+    public Integer getYpmId() {
+        return ypmId;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -40,6 +61,12 @@ public class DomainModified {
                 return false;
             }
             if (modified != a.modified) {
+                return false;
+            }
+            if (account == null ? a.account != null : !account.equals(a.account)) {
+                return false;
+            }
+            if (ypmId == null ? a.ypmId != null : !ypmId.equals(a.ypmId)) {
                 return false;
             }
         }

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -297,7 +297,9 @@ public class ZMSSchema {
         sb.structType("DomainModified")
             .comment("Tuple of domain-name and modification time-stamps. This object is returned when the caller has requested list of domains modified since a specific timestamp.")
             .field("name", "DomainName", false, "name of the domain")
-            .field("modified", "Int64", false, "last modified timestamp of the domain");
+            .field("modified", "Int64", false, "last modified timestamp of the domain")
+            .field("account", "String", true, "associated cloud (i.e. aws) account id")
+            .field("ypmId", "Int32", true, "associated product id");
 
         sb.structType("DomainModifiedList")
             .comment("A list of {domain, modified-timestamp} tuples.")
@@ -1399,6 +1401,7 @@ public class ZMSSchema {
             .comment("Retrieve the list of modified domains since the specified timestamp. The server will return the list of all modified domains and the latest modification timestamp as the value of the ETag header. The client will need to use this value during its next call to request the changes since the previous request. When metaonly set to true, dont add roles, policies or services, dont sign")
             .queryParam("domain", "domain", "DomainName", null, "filter the domain list only to the specified name")
             .queryParam("metaonly", "metaOnly", "String", null, "valid values are \"true\" or \"false\"")
+            .queryParam("metaattr", "metaAttr", "SimpleName", null, "domain meta attribute to filter/return, valid values \"account\", \"ypmId\", or \"all\"")
             .headerParam("If-None-Match", "matchingTag", "String", null, "Retrieved from the previous request, this timestamp specifies to the server to return any domains modified since this time")
             .output("ETag", "tag", "String", "The current latest modification timestamp is returned in this header")
             .auth("", "", true)

--- a/core/zms/src/main/rdl/SignedDomains.rdli
+++ b/core/zms/src/main/rdl/SignedDomains.rdli
@@ -11,6 +11,8 @@ include "Entity.tdl";
 type DomainModified Struct {
     DomainName name; //name of the domain
     Int64 modified; //last modified timestamp of the domain
+    String account (optional); //associated cloud (i.e. aws) account id
+    Int32 ypmId (optional); //associated product id
 }
 
 //A list of {domain, modified-timestamp} tuples.
@@ -68,9 +70,10 @@ type SignedDomains Struct {
 //timestamp as the value of the ETag header. The client will need to use this
 //value during its next call to request the changes since the previous request.
 // When metaonly set to true, dont add roles, policies or services, dont sign
-resource SignedDomains GET "/sys/modified_domains?domain={domain}&metaonly={metaOnly}" {
+resource SignedDomains GET "/sys/modified_domains?domain={domain}&metaonly={metaOnly}&metaattr={metaAttr}" {
     DomainName domain (optional); //filter the domain list only to the specified name
     String metaOnly (optional); // valid values are "true" or "false"
+    SimpleName metaAttr (optional); // domain meta attribute to filter/return, valid values "account", "ypmId", or "all"
     String matchingTag (header="If-None-Match"); //Retrieved from the previous request, this timestamp specifies to the server to return any domains modified since this time
     String tag (header="ETag", out); //The current latest modification timestamp is returned in this header
     authenticate;

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
@@ -889,26 +889,179 @@ public class ZMSCoreTest {
     }
 
     @Test
+    public void testRoleMember() {
+
+        Schema schema = ZMSSchema.instance();
+        Validator validator = new Validator(schema);
+
+        RoleMember rm = new RoleMember().setMemberName("user.test1").setExpiration(Timestamp.fromMillis(123456789123L));
+        assertTrue(rm.equals(rm));
+
+        Result result = validator.validate(rm, "RoleMember");
+        assertTrue(result.valid);
+
+        assertEquals(rm.getMemberName(), "user.test1");
+        assertEquals(rm.getExpiration().millis(), 123456789123L);
+
+        RoleMember rm2 = new RoleMember().setMemberName("user.test2");
+        assertFalse(rm2.equals(rm));
+
+        rm2.setMemberName("user.test1");
+        assertFalse(rm2.equals(rm));
+
+        rm2.setExpiration(Timestamp.fromMillis(123456789124L));
+        assertFalse(rm2.equals(rm));
+        rm2.setExpiration(Timestamp.fromMillis(123456789123L));
+        assertTrue(rm2.equals(rm));
+
+        assertFalse(rm2.equals(null));
+    }
+
+    @Test
+    public void testStatus() {
+
+        Schema schema = ZMSSchema.instance();
+        Validator validator = new Validator(schema);
+
+        Status st = new Status().setCode(101).setMessage("ok");
+        assertTrue(st.equals(st));
+
+        Result result = validator.validate(st, "Status");
+        assertTrue(result.valid);
+
+        assertEquals(st.getCode(), 101);
+        assertEquals(st.getMessage(), "ok");
+
+        Status st2 = new Status().setCode(1020);
+        assertFalse(st2.equals(st));
+
+        st2.setCode(101);
+        assertFalse(st2.equals(st));
+
+        st2.setMessage("failed");
+        assertFalse(st2.equals(st));
+        st2.setMessage("ok");
+        assertTrue(st2.equals(st));
+
+        assertFalse(st2.equals(null));
+    }
+
+    @Test
+    public void testTemplateParam() {
+
+        Schema schema = ZMSSchema.instance();
+        Validator validator = new Validator(schema);
+
+        TemplateParam tp = new TemplateParam().setName("name").setValue("service");
+        assertTrue(tp.equals(tp));
+
+        Result result = validator.validate(tp, "TemplateParam");
+        assertTrue(result.valid);
+
+        assertEquals(tp.getName(), "name");
+        assertEquals(tp.getValue(), "service");
+
+        TemplateParam tp2 = new TemplateParam().setName("name2");
+        assertFalse(tp2.equals(tp));
+
+        tp2.setName("name");
+        assertFalse(tp2.equals(tp));
+
+        tp2.setValue("value2");
+        assertFalse(tp2.equals(tp));
+        tp2.setValue("service");
+        assertTrue(tp2.equals(tp));
+
+        assertFalse(tp2.equals(null));
+    }
+
+    @Test
+    public void testTenancyResourceGroup() {
+
+        Schema schema = ZMSSchema.instance();
+        Validator validator = new Validator(schema);
+
+        TenancyResourceGroup tp = new TenancyResourceGroup().setDomain("dom1")
+                .setResourceGroup("rg1").setService("svc1");
+        assertTrue(tp.equals(tp));
+
+        assertEquals(tp.getDomain(), "dom1");
+        assertEquals(tp.getResourceGroup(), "rg1");
+        assertEquals(tp.getService(), "svc1");
+
+        TenancyResourceGroup tp2 = new TenancyResourceGroup().setDomain("dom2");
+        assertFalse(tp2.equals(tp));
+
+        tp2.setDomain("dom1");
+        assertFalse(tp2.equals(tp));
+
+        tp2.setService("svc2");
+        assertFalse(tp2.equals(tp));
+        tp2.setService("svc1");
+        assertFalse(tp2.equals(tp));
+
+        tp2.setResourceGroup("rg2");
+        assertFalse(tp2.equals(tp));
+        tp2.setResourceGroup("rg1");
+        assertTrue((tp2.equals(tp)));
+
+        assertFalse(tp2.equals(null));
+    }
+
+    @Test
+    public void testUserMeta() {
+
+        UserMeta um = new UserMeta().setEnabled(false);
+        assertTrue(um.equals(um));
+
+        assertEquals(um.getEnabled(), Boolean.FALSE);
+
+        UserMeta um2 = new UserMeta().init();
+        assertFalse(um2.equals(um));
+
+        um2.setEnabled(false);
+        assertEquals(um2, um);
+        assertFalse(um2.equals(null));
+    }
+
+    @Test
     public void testDomainModifiedListMethod() {
         Schema schema = ZMSSchema.instance();
         Validator validator = new Validator(schema);
 
         // DomainModified test
-        DomainModified dm = new DomainModified().setName("test.domain").setModified(123456789123L);
+        DomainModified dm = new DomainModified().setName("test.domain")
+                .setModified(123456789123L)
+                .setAccount("1234")
+                .setYpmId(1001);
+        assertTrue(dm.equals(dm));
 
         Result result = validator.validate(dm, "DomainModified");
         assertTrue(result.valid);
 
         assertEquals(dm.getName(), "test.domain");
         assertEquals(dm.getModified(), 123456789123L);
+        assertEquals(dm.getAccount(), "1234");
+        assertEquals(dm.getYpmId().intValue(), 1001);
 
         DomainModified dm2 = new DomainModified().setName("test.domain");
-        assertTrue(dm.equals(dm));
-        
+        assertFalse(dm2.equals(dm));
+
         dm2.setModified(123456789124L);
         assertFalse(dm2.equals(dm));
-        dm2.setName(null);
+        dm2.setModified(123456789123L);
         assertFalse(dm2.equals(dm));
+
+        dm2.setAccount("1235");
+        assertFalse(dm2.equals(dm));
+        dm2.setAccount("1234");
+        assertFalse(dm2.equals(dm));
+
+        dm2.setYpmId(1002);
+        assertFalse(dm2.equals(dm));
+        dm2.setYpmId(1001);
+        assertTrue(dm2.equals(dm));
+
         assertFalse(dm2.equals(null));
 
         // DomainModifiedList test

--- a/libs/go/zmscli/domain.go
+++ b/libs/go/zmscli/domain.go
@@ -341,7 +341,7 @@ func (cli Zms) ListDomains(limit *int32, skip string, prefix string, depth *int3
 
 func (cli Zms) GetSignedDomains(dn string, matchingTag string) (*string, error) {
 	var buf bytes.Buffer
-	res, etag, err := cli.Zms.GetSignedDomains(zms.DomainName(dn), "false", matchingTag)
+	res, etag, err := cli.Zms.GetSignedDomains(zms.DomainName(dn), "false", "", matchingTag)
 	if err != nil {
 		return nil, err
 	}
@@ -366,7 +366,7 @@ func (cli Zms) ShowDomain(dn string) (*string, error) {
 	cli.dumpDomain(&buf, domain)
 
 	// now retrieve the full domain in one call
-	res, _, err := cli.Zms.GetSignedDomains(zms.DomainName(dn), "false", "")
+	res, _, err := cli.Zms.GetSignedDomains(zms.DomainName(dn), "false", "", "")
 	if err != nil {
 		return nil, err
 	}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSHandler.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSHandler.java
@@ -66,7 +66,7 @@ public interface ZMSHandler {
     Access getAccess(ResourceContext context, String action, String resource, String domain, String checkPrincipal);
     Access getAccessExt(ResourceContext context, String action, String resource, String domain, String checkPrincipal);
     ResourceAccessList getResourceAccessList(ResourceContext context, String principal, String action);
-    Response getSignedDomains(ResourceContext context, String domain, String metaOnly, String matchingTag);
+    Response getSignedDomains(ResourceContext context, String domain, String metaOnly, String metaAttr, String matchingTag);
     UserToken getUserToken(ResourceContext context, String userName, String serviceNames, Boolean header);
     UserToken optionsUserToken(ResourceContext context, String userName, String serviceNames);
     ServicePrincipal getServicePrincipal(ResourceContext context);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
@@ -1573,11 +1573,11 @@ public class ZMSResources {
     @GET
     @Path("/sys/modified_domains")
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getSignedDomains(@QueryParam("domain") String domain, @QueryParam("metaonly") String metaOnly, @HeaderParam("If-None-Match") String matchingTag) {
+    public Response getSignedDomains(@QueryParam("domain") String domain, @QueryParam("metaonly") String metaOnly, @QueryParam("metaattr") String metaAttr, @HeaderParam("If-None-Match") String matchingTag) {
         try {
             ResourceContext context = this.delegate.newResourceContext(this.request, this.response);
             context.authenticate();
-            return this.delegate.getSignedDomains(context, domain, metaOnly, matchingTag);
+            return this.delegate.getSignedDomains(context, domain, metaOnly, metaAttr, matchingTag);
         } catch (ResourceException e) {
             int code = e.getCode();
             switch (code) {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/file/FileConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/file/FileConnection.java
@@ -357,20 +357,19 @@ public class FileConnection implements ObjectStoreConnection {
 
         // Now set the dest for the returned domain names
 
-        String dirName = rootDir.getAbsolutePath() + File.separator;
         for (String dname : domainList) {
-            long ts = 0;
-            try {
-                File dfile = new File(dirName + dname);
-                ts = dfile.lastModified();
-                if (ts <= modifiedSince) {
-                    continue;
-                }
-            } catch (Exception exc) {
-                LOG.error("FileStructStore: FAILED to get timestamp for file "
-                        + dname + ", error: " + exc.getMessage());
+            DomainStruct domainStruct = getDomainStruct(dname);
+            if (domainStruct == null) {
+                return null;
             }
-            DomainModified dm = new DomainModified().setName(dname).setModified(ts);
+            long ts = domainStruct.getModified().millis();
+            if (ts <= modifiedSince) {
+                continue;
+            }
+            DomainModified dm = new DomainModified().setName(dname)
+                    .setModified(ts)
+                    .setYpmId(domainStruct.getMeta().getYpmId())
+                    .setAccount(domainStruct.getMeta().getAccount());
             nameMods.add(dm);
         }
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
@@ -81,9 +81,9 @@ public class JDBCConnection implements ObjectStoreConnection {
     private static final String SQL_UPDATE_DOMAIN_MOD_TIMESTAMP = "UPDATE domain "
             + "SET modified=CURRENT_TIMESTAMP(3) WHERE name=?;";
     private static final String SQL_GET_DOMAIN_MOD_TIMESTAMP = "SELECT modified FROM domain WHERE name=?;";
-    private static final String SQL_LIST_DOMAIN = "SELECT name, modified FROM domain;";
+    private static final String SQL_LIST_DOMAIN = "SELECT name, modified, account, ypm_id FROM domain;";
     private static final String SQL_LIST_DOMAIN_PREFIX = "SELECT name, modified FROM domain WHERE name>=? AND name<?;";
-    private static final String SQL_LIST_DOMAIN_MODIFIED = "SELECT name, modified FROM domain WHERE modified>?;";
+    private static final String SQL_LIST_DOMAIN_MODIFIED = "SELECT name, modified, account, ypm_id FROM domain WHERE modified>?;";
     private static final String SQL_LIST_DOMAIN_PREFIX_MODIFIED = "SELECT name, modified FROM domain "
             + "WHERE name>=? AND name<? AND modified>?;";
     private static final String SQL_LIST_DOMAIN_ROLE_NAME_MEMBER = "SELECT domain.name FROM domain "
@@ -2728,7 +2728,9 @@ public class JDBCConnection implements ObjectStoreConnection {
                 while (rs.next()) {
                     DomainModified dm = new DomainModified()
                             .setName(rs.getString(ZMSConsts.DB_COLUMN_NAME))
-                            .setModified(rs.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED).getTime());
+                            .setModified(rs.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED).getTime())
+                            .setAccount(saveValue(rs.getString(ZMSConsts.DB_COLUMN_ACCOUNT)))
+                            .setYpmId(rs.getInt(ZMSConsts.DB_COLUMN_PRODUCT_ID));
                     nameMods.add(dm);
                 }
             }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -340,4 +340,12 @@ public class ZMSUtils {
         } catch (InterruptedException ignored) {
         }
     }
+
+    public static boolean parseBoolean(final String value, boolean defaultValue) {
+        boolean boolVal = defaultValue;
+        if (value != null && !value.isEmpty()) {
+            boolVal = Boolean.parseBoolean(value.trim());
+        }
+        return boolVal;
+    }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ExceptionMapperTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ExceptionMapperTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Oath, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms;
+
+import org.testng.annotations.Test;
+
+import javax.ws.rs.core.Response;
+
+import static org.testng.Assert.assertEquals;
+
+public class ExceptionMapperTest {
+
+    @Test
+    public void testExceptionMappers() {
+
+        JsonGeneralExceptionMapper mapper1 = new JsonGeneralExceptionMapper();
+        Response response = mapper1.toResponse(null);
+        assertEquals(400, response.getStatus());
+
+        JsonMappingExceptionMapper mapper2 = new JsonMappingExceptionMapper();
+        response = mapper2.toResponse(null);
+        assertEquals(400, response.getStatus());
+
+        JsonParseExceptionMapper mapper3 = new JsonParseExceptionMapper();
+        response = mapper3.toResponse(null);
+        assertEquals(400, response.getStatus());
+
+        JsonProcessingExceptionMapper mapper4 = new JsonProcessingExceptionMapper();
+        response = mapper4.toResponse(null);
+        assertEquals(400, response.getStatus());
+    }
+}

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/JDBCCertRecordStoreFactoryTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/JDBCCertRecordStoreFactoryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018 Oath Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms.store.impl;
+
+import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.zms.ZMSConsts;
+import com.yahoo.athenz.zms.store.ObjectStore;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+
+public class JDBCCertRecordStoreFactoryTest {
+
+    @Test
+    public void testCreate() {
+        
+        System.setProperty(ZMSConsts.ZMS_PROP_JDBC_RW_STORE, "jdbc:mysql://localhost");
+        System.setProperty(ZMSConsts.ZMS_PROP_JDBC_RW_USER, "user");
+        System.setProperty(ZMSConsts.ZMS_PROP_JDBC_RW_PASSWORD, "password");
+        
+        PrivateKeyStore keyStore = Mockito.mock(PrivateKeyStore.class);
+        Mockito.doReturn("password").when(keyStore).getApplicationSecret("jdbc", "password");
+
+        JDBCObjectStoreFactory factory = new JDBCObjectStoreFactory();
+        ObjectStore store = factory.create(keyStore);
+        assertNotNull(store);
+    }
+}

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
@@ -4676,6 +4676,10 @@ public class JDBCConnectionTest {
             .thenReturn(true).thenReturn(true).thenReturn(false);
         Mockito.when(mockResultSet.getString(ZMSConsts.DB_COLUMN_NAME))
             .thenReturn("domain1").thenReturn("domain2").thenReturn("domain3"); // 3 domains
+        Mockito.when(mockResultSet.getString(ZMSConsts.DB_COLUMN_ACCOUNT))
+                .thenReturn("acct1").thenReturn("acct2").thenReturn("acct3"); // 3 domains
+        Mockito.when(mockResultSet.getString(ZMSConsts.DB_COLUMN_PRODUCT_ID))
+                .thenReturn("1234").thenReturn("1235").thenReturn("1236"); // 3 domains
         Mockito.doReturn(new java.sql.Timestamp(1454358916)).when(mockResultSet).getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED);
 
         DomainModifiedList list = jdbcConn.listModifiedDomains(1454358900);

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -250,4 +250,15 @@ public class ZMSUtilsTest {
         assertEquals(list.size(), 1);
         assertEquals(list.get(0).getMemberName(), "member1");
     }
+
+    @Test
+    public void testParseBoolean() {
+        assertEquals(true, ZMSUtils.parseBoolean(null, true));
+        assertEquals(false, ZMSUtils.parseBoolean(null, false));
+        assertEquals(true, ZMSUtils.parseBoolean("", true));
+        assertEquals(false, ZMSUtils.parseBoolean("", false));
+        assertEquals(true, ZMSUtils.parseBoolean("true", false));
+        assertEquals(false, ZMSUtils.parseBoolean("false", true));
+        assertEquals(false, ZMSUtils.parseBoolean("unknown", false));
+    }
 }


### PR DESCRIPTION
New metaAttr attribute if metaOnly option is set to true when requesting list of signed domains from ZMS Server. This parameter can filter the results based on the presence of the requested attribute. Allowed values are: account, ypmid, and all.
     *        account - only return domains that have the account value set
     *        ypmid - only return domains that have the ypmid value set
     *        all - return all domains (no filtering).
any invalid value will be ignored.