### PR TITLE
use athenz-zts-service for session name

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
@@ -54,6 +54,7 @@ import com.yahoo.rdl.Timestamp;
 public class CloudStore {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CloudStore.class);
+    private static final String AWS_ROLE_SESSION_NAME = "athenz-zts-service";
 
     String awsRole = null;
     String awsRegion;
@@ -371,7 +372,7 @@ public class CloudStore {
     }
 
     AssumeRoleRequest getAssumeRoleRequest(String account, String roleName, String principal,
-                                           Integer durationSeconds, String externalId) {
+            Integer durationSeconds, String externalId) {
 
         // assume the target role to get the credentials for the client
         // aws format is arn:aws:iam::<account-id>:role/<role-name>
@@ -380,7 +381,11 @@ public class CloudStore {
 
         AssumeRoleRequest req = new AssumeRoleRequest();
         req.setRoleArn(arn);
-        req.setRoleSessionName(principal);
+
+        // for role session name AWS has a limit on length: 64
+        // so we need to make sure our session is shorter than that
+
+        req.setRoleSessionName(AWS_ROLE_SESSION_NAME);
         if (durationSeconds != null && durationSeconds > 0) {
             req.setDurationSeconds(durationSeconds);
         }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
@@ -163,13 +163,13 @@ public class CloudStoreTest {
         CloudStore store = new CloudStore();
         AssumeRoleRequest req = store.getAssumeRoleRequest("1234", "admin", "sys.auth.zts", null, null);
         assertEquals("arn:aws:iam::1234:role/admin", req.getRoleArn());
-        assertEquals("sys.auth.zts", req.getRoleSessionName());
+        assertEquals("athenz-zts-service", req.getRoleSessionName());
         assertNull(req.getDurationSeconds());
         assertNull(req.getExternalId());
 
         req = store.getAssumeRoleRequest("12345", "adminuser", "athenz.zts", 101, "external");
         assertEquals("arn:aws:iam::12345:role/adminuser", req.getRoleArn());
-        assertEquals("athenz.zts", req.getRoleSessionName());
+        assertEquals("athenz-zts-service", req.getRoleSessionName());
         assertEquals(Integer.valueOf(101), req.getDurationSeconds());
         assertEquals("external", req.getExternalId());
         store.close();


### PR DESCRIPTION
two benefits:

a) assume role session has 64 limit so with athenz service names this is violated sometimes

b) since the session name is logged in the role owner's account logs, it shows that zts was the one who assumed the role