### PR TITLE
update authority interface to provide isValidUser method

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/Authority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/Authority.java
@@ -84,7 +84,18 @@ public interface Authority {
     default String getUserDomainName(String userName) {
         return userName;
     }
-    
+
+    /**
+     * If the authority is handling user principals, then this method will be
+     * called when users are added as members so the authority can validate
+     * that the role member is valid. If the member is not valid, the request
+     * (e.g. putRole, putMembership) will be rejected as invalid.
+     */
+
+    default boolean isValidUser(String username) {
+        return true;
+    }
+
     /**
      * Verify the credentials and if valid return the corresponding Principal, null otherwise.
      * @param creds the credentials (i.e. cookie, token, secret) that will identify the principal.

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/UserAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/UserAuthorityTest.java
@@ -17,6 +17,7 @@ package com.yahoo.athenz.auth.impl;
 
 import static org.testng.Assert.*;
 
+import com.yahoo.athenz.auth.Authority;
 import org.jvnet.libpam.PAM;
 import org.jvnet.libpam.PAMException;
 import org.jvnet.libpam.UnixUser;
@@ -39,6 +40,7 @@ public class UserAuthorityTest {
         assertEquals(userAuthority.getDomain(), expectedDomain);
         String expectedHeader = "Authorization";
         assertEquals(userAuthority.getHeader(), expectedHeader);
+        assertTrue(userAuthority.isValidUser("user1"));
 
         StringBuilder errMsg = new StringBuilder();
         String testToken = "Basic dGVzdHVzZXI6dGVzdHB3ZA==";
@@ -50,6 +52,7 @@ public class UserAuthorityTest {
         assertEquals(principal.getDomain(), expectedDomain);
         String expectedUserId = "testuser";
         assertEquals(principal.getName(), expectedUserId);
+        assertTrue(userAuthority.isValidUser("user1"));
     }
     
     @Test
@@ -88,5 +91,39 @@ public class UserAuthorityTest {
     public void testGetAuthenticateChallenge() {
         UserAuthority userAuthority = new UserAuthority();
         assertEquals(userAuthority.getAuthenticateChallenge(), "Basic realm=\"athenz\"");
+    }
+
+    @Test
+    public void testIsValidUser() {
+
+        Authority userAuthortiy = new Authority() {
+
+            @Override
+            public void initialize() {
+            }
+
+            @Override
+            public String getDomain() {
+                return null;
+            }
+
+            @Override
+            public String getHeader() {
+                return null;
+            }
+
+            @Override
+            public Principal authenticate(String creds, String remoteAddr, String httpMethod, StringBuilder errMsg) {
+                return null;
+            }
+
+            @Override
+            public boolean isValidUser(String username) {
+                return username.equals("validuser");
+            }
+        };
+
+        assertFalse(userAuthortiy.isValidUser("invaliduser"));
+        assertTrue(userAuthortiy.isValidUser("validuser"));
     }
 }


### PR DESCRIPTION
If the ZMS configured with a user_authority class then this method will be called when users are added as members or when a new role is created with user members so the authority can validate that the role member is valid. If the member is not valid, the request (e.g. putRole, putMembership) will be rejected as invalid.

this is the first part - just update the authority with a default implementation.