### PR TITLE
Make setEnablePrefetch public

### DIFF
--- a/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -473,7 +473,11 @@ public class ZTSClient implements Closeable {
         ztsClient.close();
     }
 
-    void setEnablePrefetch(boolean state) {
+    /**
+     * Call to enable/disable prefetch for the current ZTSClient.
+     * @param state whether prefetch is enabled or not
+     */
+    public void setEnablePrefetch(boolean state) {
         enablePrefetch = state;
     }
 


### PR DESCRIPTION
Making this method public allow users to disable prefetch at the client level (currently, it can only be disabled globally by a system property/static method).

@havetisyan 