### PR TITLE
maintain invalid aws creds cache

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -155,6 +155,7 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_AWS_PUBLIC_CERT          = "athenz.zts.aws_public_cert";
     public static final String ZTS_PROP_AWS_BOOT_TIME_OFFSET     = "athenz.zts.aws_boot_time_offset";
     public static final String ZTS_PROP_AWS_CREDS_CACHE_TIMEOUT  = "athenz.zts.aws_creds_cache_timeout";
+    public static final String ZTS_PROP_AWS_CREDS_INVALID_CACHE_TIMEOUT  = "athenz.zts.aws_creds_invalid_cache_timeout";
 
     public static final String ZTS_PROP_METRIC_FACTORY_CLASS             = "athenz.zts.metric_factory_class";
     public static final String ZTS_PROP_CERT_SIGNER_FACTORY_CLASS        = "athenz.zts.cert_signer_factory_class";
@@ -171,6 +172,6 @@ public final class ZTSConsts {
     public static final String ZTS_AUDIT_LOGGER_FACTORY_CLASS      = "com.yahoo.athenz.common.server.log.impl.DefaultAuditLoggerFactory";
     public static final String ZTS_PRINCIPAL_AUTHORITY_CLASS       = "com.yahoo.athenz.auth.impl.PrincipalAuthority";
     public static final String ZTS_CERT_RECORD_STORE_FACTORY_CLASS = "com.yahoo.athenz.zts.cert.impl.FileCertRecordStoreFactory";
-    
+
     public static final String ZTS_JSON_PARSER_ERROR_RESPONSE = "{\"code\":400,\"message\":\"Invalid Object: checkout https://github.com/yahoo/athenz/core/zts for object defintions\"}";
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2482,7 +2482,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
                         caller, domain); 
             }
             if (status != ServiceX509RefreshRequestStatus.SUCCESS) {
-                throw requestError("Request valiation failed: " + status,
+                throw requestError("Request validation failed: " + status,
                         caller, domain); 
             }
         }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509CertRequest.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509CertRequest.java
@@ -109,14 +109,16 @@ public class X509CertRequest {
 
         List<String> certDnsNames = Crypto.extractX509CertDnsNames(cert);
         if (certDnsNames.size() != dnsNames.size()) {
-            LOGGER.error("compareDnsNames - Mismatch of dnsNames in certificate ({}) and CSR ({})",
-                    certDnsNames.size(), dnsNames.size());
+            LOGGER.error("compareDnsNames - Mismatch of dnsNames in certificate ({}: {}) and CSR ({}: {})",
+                    certDnsNames.size(), String.join(", ", certDnsNames),
+                    dnsNames.size(), String.join(", ", dnsNames));
             return false;
         }
         
         for (String dnsName : dnsNames) {
             if (!certDnsNames.contains(dnsName)) {
-                LOGGER.error("compareDnsNames - Unknown dnsName in certificate {}", dnsName);
+                LOGGER.error("compareDnsNames - Unknown dnsName in csr {}, csr-set ({}), certificate-set ({})",
+                        dnsName, String.join(", ", dnsNames), String.join(", ", certDnsNames));
                 return false;
             }
         }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
@@ -94,7 +94,7 @@ public class CloudStore {
 
         awsRegion = System.getProperty(ZTSConsts.ZTS_PROP_AWS_REGION_NAME);
 
-        // get the default cache timeout
+        // get the default cache timeout in seconds
 
         cacheTimeout = Integer.parseInt(
                 System.getProperty(ZTSConsts.ZTS_PROP_AWS_CREDS_CACHE_TIMEOUT, "600"));
@@ -445,7 +445,7 @@ public class CloudStore {
         // entries that have been expired already
 
         long checkTime = System.currentTimeMillis() - invalidCacheTimeout * 1000;
-        return awsInvalidCredsCache.entrySet().removeIf(entry -> entry.getValue() < checkTime);
+        return awsInvalidCredsCache.entrySet().removeIf(entry -> entry.getValue() <= checkTime);
     }
 
     boolean isFailedTempCredsRequest(final String cacheKey) {
@@ -461,7 +461,7 @@ public class CloudStore {
             return false;
         }
 
-        // we're going to cache any creds for configured number of minutes
+        // we're going to cache any creds for configured number of seconds
 
         long diffSeconds = (System.currentTimeMillis() - timeStamp) / 1000;
         return diffSeconds < invalidCacheTimeout;

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
@@ -679,7 +679,7 @@ public class CloudStoreTest {
     }
 
     @Test
-    public void testInitializeAwsSupport()  throws InterruptedException, ExecutionException, TimeoutException {
+    public void testInitializeAwsSupport()  throws ExecutionException, TimeoutException {
 
         CloudStore store = new CloudStore();
         HttpClient httpClient = Mockito.mock(HttpClient.class);
@@ -701,10 +701,22 @@ public class CloudStoreTest {
         Mockito.when(responseCreds.getContentAsString()).thenReturn("{\"AccessKeyId\":\"id\",\"SecretAccessKey\":\"key\",\"Token\":\"token\"}");
 
         store.setHttpClient(httpClient);
-        Mockito.when(httpClient.GET("http://169.254.169.254/latest/dynamic/instance-identity/document")).thenReturn(responseDoc);
-        Mockito.when(httpClient.GET("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")).thenReturn(responseSig);
-        Mockito.when(httpClient.GET("http://169.254.169.254/latest/meta-data/iam/info")).thenReturn(responseInfo);
-        Mockito.when(httpClient.GET("http://169.254.169.254/latest/meta-data/iam/security-credentials/athenz.zts")).thenReturn(responseCreds);
+        try {
+            Mockito.when(httpClient.GET("http://169.254.169.254/latest/dynamic/instance-identity/document")).thenReturn(responseDoc);
+        } catch (InterruptedException ignored) {
+        }
+        try {
+            Mockito.when(httpClient.GET("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")).thenReturn(responseSig);
+        } catch (InterruptedException ignored) {
+        }
+        try {
+            Mockito.when(httpClient.GET("http://169.254.169.254/latest/meta-data/iam/info")).thenReturn(responseInfo);
+        } catch (InterruptedException ignored) {
+        }
+        try {
+            Mockito.when(httpClient.GET("http://169.254.169.254/latest/meta-data/iam/security-credentials/athenz.zts")).thenReturn(responseCreds);
+        } catch (InterruptedException ignored) {
+        }
 
         // set creds update time every second
 
@@ -713,10 +725,13 @@ public class CloudStoreTest {
         store.awsEnabled = true;
         store.initializeAwsSupport();
 
-        // sleep a couple of seconds for the backgroup thread to run
+        // sleep a couple of seconds for the background thread to run
         // before we try to shutting it down
 
-        Thread.sleep(2000);
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException ignored) {
+        }
         store.close();
 
         System.clearProperty(ZTSConsts.ZTS_PROP_AWS_CREDS_UPDATE_TIMEOUT);
@@ -757,7 +772,7 @@ public class CloudStoreTest {
     }
 
     @Test
-    public void testAssumeAWSRoleFailedCreds() throws InterruptedException {
+    public void testAssumeAWSRoleFailedCreds() {
         MockCloudStore cloudStore = new MockCloudStore();
         cloudStore.awsEnabled = true;
         AssumeRoleResult mockResult = Mockito.mock(AssumeRoleResult.class);
@@ -780,14 +795,16 @@ public class CloudStoreTest {
         // that our test case should work as before
 
         cloudStore.invalidCacheTimeout = 1;
-        Thread.sleep(1000);
-
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignored) {
+        }
         assertNotNull(cloudStore.assumeAWSRole("account", "syncer", "athenz.syncer", null, null));
         cloudStore.close();
     }
 
     @Test
-    public void testAssumeAWSRoleFailedCredsCache() throws InterruptedException {
+    public void testAssumeAWSRoleFailedCredsCache() {
         MockCloudStore cloudStore = new MockCloudStore();
         cloudStore.awsEnabled = true;
         cloudStore.setGetServiceClientException(true);
@@ -941,7 +958,7 @@ public class CloudStoreTest {
     }
 
     @Test
-    public void testInvalidCacheCreds() throws InterruptedException {
+    public void testInvalidCacheCreds() {
 
         CloudStore cloudStore = new CloudStore();
         cloudStore.awsEnabled = true;
@@ -956,8 +973,10 @@ public class CloudStoreTest {
         // and sleep so our records are expired
 
         cloudStore.invalidCacheTimeout = 1;
-        Thread.sleep(1000);
-
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignored) {
+        }
         // this time our cache key is no longer considered failed
 
         assertFalse(cloudStore.isFailedTempCredsRequest("cacheKey"));
@@ -981,6 +1000,10 @@ public class CloudStoreTest {
         // now set it to 1 second and it should remove it
 
         cloudStore.invalidCacheTimeout = 1;
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignored) {
+        }
         cloudStore.removeExpiredInvalidCredentials();
         assertEquals(cloudStore.awsInvalidCredsCache.size(), 0);
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/MockCloudStore.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/MockCloudStore.java
@@ -15,13 +15,10 @@
  */
 package com.yahoo.athenz.zts.store;
 
+import com.amazonaws.services.securitytoken.model.*;
 import org.mockito.Mockito;
 
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
-import com.amazonaws.services.securitytoken.model.AssumeRoleRequest;
-import com.amazonaws.services.securitytoken.model.AssumeRoleResult;
-import com.amazonaws.services.securitytoken.model.GetCallerIdentityRequest;
-import com.amazonaws.services.securitytoken.model.GetCallerIdentityResult;
 import com.yahoo.athenz.zts.AWSTemporaryCredentials;
 
 public class MockCloudStore extends CloudStore {
@@ -32,14 +29,14 @@ public class MockCloudStore extends CloudStore {
     private boolean returnSuperAWSRole = false;
     private AssumeRoleResult assumeRoleResult = null;
     private GetCallerIdentityResult callerIdentityResult = null;
-    
+    private boolean getServiceClientException = false;
+
     public MockCloudStore() {
         super();
     }
 
     @Override
-    public
-    boolean isAwsEnabled() {
+    public boolean isAwsEnabled() {
         return true;
     }
     
@@ -59,13 +56,17 @@ public class MockCloudStore extends CloudStore {
 
     @Override
     AWSSecurityTokenServiceClient getTokenServiceClient() {
-        AWSSecurityTokenServiceClient client = Mockito.mock(AWSSecurityTokenServiceClient.class);
-        Mockito.when(client.assumeRole(Mockito.any(AssumeRoleRequest.class))).thenReturn(assumeRoleResult);
-        Mockito.when(client.getCallerIdentity(Mockito.any(GetCallerIdentityRequest.class))).thenReturn(callerIdentityResult);
-        return client;
+        if (getServiceClientException) {
+            throw new AWSSecurityTokenServiceException("invalid client");
+        } else {
+            AWSSecurityTokenServiceClient client = Mockito.mock(AWSSecurityTokenServiceClient.class);
+            Mockito.when(client.assumeRole(Mockito.any(AssumeRoleRequest.class))).thenReturn(assumeRoleResult);
+            Mockito.when(client.getCallerIdentity(Mockito.any(GetCallerIdentityRequest.class))).thenReturn(callerIdentityResult);
+            return client;
+        }
     }
 
-    void setAssumeAWSRole(boolean returnSuperAWSRole) {
+    void setReturnSuperAWSRole(boolean returnSuperAWSRole) {
         this.returnSuperAWSRole = returnSuperAWSRole;
     }
     
@@ -84,5 +85,9 @@ public class MockCloudStore extends CloudStore {
         } else {
             return super.assumeAWSRole(account, roleName, principal, durationSeconds, externalId);
         }
+    }
+
+    public void setGetServiceClientException(boolean getServiceClientException) {
+        this.getServiceClientException = getServiceClientException;
     }
 }


### PR DESCRIPTION
To avoid large load of invalid aws sts assume role requests and possibly get rate limited by aws, zts will now maintain a cache of invalid requests for a default value of 2 mins. So if we get more requests for the same role within those 2 mins, we'll just return the same failure as opposed to contact aws sts for a new set of temporary creds.