### PR TITLE
maintain invalid aws creds cache for the AccessDenied error case

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -155,6 +155,7 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_AWS_PUBLIC_CERT          = "athenz.zts.aws_public_cert";
     public static final String ZTS_PROP_AWS_BOOT_TIME_OFFSET     = "athenz.zts.aws_boot_time_offset";
     public static final String ZTS_PROP_AWS_CREDS_CACHE_TIMEOUT  = "athenz.zts.aws_creds_cache_timeout";
+    public static final String ZTS_PROP_AWS_CREDS_INVALID_CACHE_TIMEOUT  = "athenz.zts.aws_creds_invalid_cache_timeout";
 
     public static final String ZTS_PROP_METRIC_FACTORY_CLASS             = "athenz.zts.metric_factory_class";
     public static final String ZTS_PROP_CERT_SIGNER_FACTORY_CLASS        = "athenz.zts.cert_signer_factory_class";
@@ -171,6 +172,6 @@ public final class ZTSConsts {
     public static final String ZTS_AUDIT_LOGGER_FACTORY_CLASS      = "com.yahoo.athenz.common.server.log.impl.DefaultAuditLoggerFactory";
     public static final String ZTS_PRINCIPAL_AUTHORITY_CLASS       = "com.yahoo.athenz.auth.impl.PrincipalAuthority";
     public static final String ZTS_CERT_RECORD_STORE_FACTORY_CLASS = "com.yahoo.athenz.zts.cert.impl.FileCertRecordStoreFactory";
-    
+
     public static final String ZTS_JSON_PARSER_ERROR_RESPONSE = "{\"code\":400,\"message\":\"Invalid Object: checkout https://github.com/yahoo/athenz/core/zts for object defintions\"}";
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2482,7 +2482,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
                         caller, domain); 
             }
             if (status != ServiceX509RefreshRequestStatus.SUCCESS) {
-                throw requestError("Request valiation failed: " + status,
+                throw requestError("Request validation failed: " + status,
                         caller, domain); 
             }
         }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509CertRequest.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509CertRequest.java
@@ -109,14 +109,16 @@ public class X509CertRequest {
 
         List<String> certDnsNames = Crypto.extractX509CertDnsNames(cert);
         if (certDnsNames.size() != dnsNames.size()) {
-            LOGGER.error("compareDnsNames - Mismatch of dnsNames in certificate ({}) and CSR ({})",
-                    certDnsNames.size(), dnsNames.size());
+            LOGGER.error("compareDnsNames - Mismatch of dnsNames in certificate ({}: {}) and CSR ({}: {})",
+                    certDnsNames.size(), String.join(", ", certDnsNames),
+                    dnsNames.size(), String.join(", ", dnsNames));
             return false;
         }
         
         for (String dnsName : dnsNames) {
             if (!certDnsNames.contains(dnsName)) {
-                LOGGER.error("compareDnsNames - Unknown dnsName in certificate {}", dnsName);
+                LOGGER.error("compareDnsNames - Unknown dnsName in csr {}, csr-set ({}), certificate-set ({})",
+                        dnsName, String.join(", ", dnsNames), String.join(", ", certDnsNames));
                 return false;
             }
         }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/CloudStore.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.amazonaws.AmazonServiceException;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.api.ContentResponse;
 import org.slf4j.Logger;
@@ -59,10 +60,12 @@ public class CloudStore {
     String awsRole = null;
     String awsRegion;
     boolean awsEnabled;
-    private int cacheTimeout;
+    int cacheTimeout;
+    int invalidCacheTimeout;
     BasicSessionCredentials credentials;
     private Map<String, String> cloudAccountCache;
-    private ConcurrentHashMap<String, AWSTemporaryCredentials> awsCredsCache;
+    ConcurrentHashMap<String, AWSTemporaryCredentials> awsCredsCache;
+    ConcurrentHashMap<String, Long> awsInvalidCredsCache;
     private HttpClient httpClient;
 
     private ScheduledExecutorService scheduledThreadPool = null;
@@ -73,6 +76,7 @@ public class CloudStore {
 
         cloudAccountCache = new HashMap<>();
         awsCredsCache = new ConcurrentHashMap<>();
+        awsInvalidCredsCache = new ConcurrentHashMap<>();
 
         // Instantiate and start our HttpClient
 
@@ -91,10 +95,13 @@ public class CloudStore {
 
         awsRegion = System.getProperty(ZTSConsts.ZTS_PROP_AWS_REGION_NAME);
 
-        // get the default cache timeout
+        // get the default cache timeout in seconds
 
         cacheTimeout = Integer.parseInt(
                 System.getProperty(ZTSConsts.ZTS_PROP_AWS_CREDS_CACHE_TIMEOUT, "600"));
+
+        invalidCacheTimeout = Integer.parseInt(
+                System.getProperty(ZTSConsts.ZTS_PROP_AWS_CREDS_INVALID_CACHE_TIMEOUT, "120"));
 
         // initialize aws support
 
@@ -189,13 +196,8 @@ public class CloudStore {
             return false;
         }
 
-        try {
-            if (!parseInstanceInfo(document)) {
-                return false;
-            }
-        } catch (Exception ex) {
-            LOGGER.error("CloudStore: unable to parse instance identity document: {}, error: {}",
-                    document, ex.getMessage());
+        if (!parseInstanceInfo(document)) {
+            LOGGER.error("CloudStore: unable to parse instance identity document: {}", document);
             return false;
         }
 
@@ -217,20 +219,15 @@ public class CloudStore {
         // all possible index out of bounds exceptions here and just
         // report the error and return false
 
-        try {
-            if (!parseIamRoleInfo(iamRole)) {
-                return false;
-            }
-        } catch (Exception ex) {
-            LOGGER.error("CloudStore: unable to parse iam role data: {}, error: {}",
-                    iamRole, ex.getMessage());
+        if (!parseIamRoleInfo(iamRole)) {
+            LOGGER.error("CloudStore: unable to parse iam role data: {}", iamRole);
             return false;
         }
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("CloudStore: service meta information:");
-            LOGGER.debug("CloudStore:   role:   {}", awsRole);
-            LOGGER.debug("CloudStore:   region: {}", awsRegion);
+            LOGGER.debug("CloudStore: role:   {}", awsRole);
+            LOGGER.debug("CloudStore: region: {}", awsRegion);
         }
         return true;
     }
@@ -439,6 +436,49 @@ public class CloudStore {
         return awsCredsCache.entrySet().removeIf(entry -> entry.getValue().getExpiration().millis() < now);
     }
 
+    boolean removeExpiredInvalidCredentials() {
+
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Checking for expired invalid cached credentials in {} entries", awsInvalidCredsCache.size());
+        }
+
+        // iterate through all entries in the map and remove any
+        // entries that have been expired already
+
+        long checkTime = System.currentTimeMillis() - invalidCacheTimeout * 1000;
+        return awsInvalidCredsCache.entrySet().removeIf(entry -> entry.getValue() <= checkTime);
+    }
+
+    boolean isFailedTempCredsRequest(final String cacheKey) {
+
+        // if our cache is disabled there is no need for a lookup
+
+        if (invalidCacheTimeout == 0) {
+            return false;
+        }
+
+        Long timeStamp = awsInvalidCredsCache.get(cacheKey);
+        if (timeStamp == null) {
+            return false;
+        }
+
+        // we're going to cache any creds for configured number of seconds
+
+        long diffSeconds = (System.currentTimeMillis() - timeStamp) / 1000;
+        return diffSeconds < invalidCacheTimeout;
+    }
+
+    void putInvalidCacheCreds(final String key) {
+
+        // if our cache is disabled we do nothing
+
+        if (invalidCacheTimeout == 0) {
+            return;
+        }
+
+        awsInvalidCredsCache.put(key, System.currentTimeMillis());
+    }
+
     AWSTemporaryCredentials getCachedCreds(final String cacheKey, Integer durationSeconds) {
 
         // if our cache is disabled there is no need for a lookup
@@ -484,11 +524,23 @@ public class CloudStore {
                     "AWS Support not enabled");
         }
 
+        // first check to see if we already have the temp creds cached
+
         final String cacheKey = getCacheKey(account, roleName, principal,
                 durationSeconds, externalId);
         AWSTemporaryCredentials tempCreds = getCachedCreds(cacheKey, durationSeconds);
         if (tempCreds != null) {
             return tempCreds;
+        }
+
+        // before going to AWS STS, check if we have the request in our failed
+        // cache since we don't want to generate too many requests AWS STS
+        // and eventually become rate limited
+
+        if (isFailedTempCredsRequest(cacheKey)) {
+            LOGGER.error("CloudStore: assumeAWSRole - failed cached request for account {} with role: {}",
+                    account, roleName);
+            return null;
         }
 
         AssumeRoleRequest req = getAssumeRoleRequest(account, roleName, principal,
@@ -500,14 +552,30 @@ public class CloudStore {
 
             Credentials awsCreds = res.getCredentials();
             tempCreds = new AWSTemporaryCredentials()
-                .setAccessKeyId(awsCreds.getAccessKeyId())
-                .setSecretAccessKey(awsCreds.getSecretAccessKey())
-                .setSessionToken(awsCreds.getSessionToken())
-                .setExpiration(Timestamp.fromMillis(awsCreds.getExpiration().getTime()));
+                    .setAccessKeyId(awsCreds.getAccessKeyId())
+                    .setSecretAccessKey(awsCreds.getSecretAccessKey())
+                    .setSessionToken(awsCreds.getSessionToken())
+                    .setExpiration(Timestamp.fromMillis(awsCreds.getExpiration().getTime()));
+
+        } catch (AmazonServiceException ex) {
+
+            LOGGER.error("CloudStore: assumeAWSRole - unable to assume role: {}, error: {}, status code: {}",
+                    req.getRoleArn(), ex.getMessage(), ex.getStatusCode());
+
+            // if this is access denied then we're going to cache
+            // the failed results
+
+            if (ex.getStatusCode() == ResourceException.FORBIDDEN) {
+                putInvalidCacheCreds(cacheKey);
+            }
+
+            return null;
 
         } catch (Exception ex) {
+
             LOGGER.error("CloudStore: assumeAWSRole - unable to assume role: {}, error: {}",
                     req.getRoleArn(), ex.getMessage());
+
             return null;
         }
 
@@ -533,6 +601,7 @@ public class CloudStore {
         }
     }
 
+    ///CLOVER:OFF
     public boolean verifyInstanceDocument(OSTKInstanceInformation info, String publicKey) {
 
         // for now we're only validating the document signature
@@ -550,6 +619,7 @@ public class CloudStore {
         }
         return verified;
     }
+    ///CLOVER:ON
 
     class AWSCredentialsUpdater implements Runnable {
 
@@ -571,6 +641,13 @@ public class CloudStore {
                 removeExpiredCredentials();
             } catch (Exception ex) {
                 LOGGER.error("AWSCredentialsUpdater: unable to remove expired aws credentials: {}",
+                        ex.getMessage());
+            }
+
+            try {
+                removeExpiredInvalidCredentials();
+            } catch (Exception ex) {
+                LOGGER.error("AWSCredentialsUpdater: unable to remove expired invalid aws credentials: {}",
                         ex.getMessage());
             }
         }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/CloudStoreTest.java
@@ -598,7 +598,25 @@ public class CloudStoreTest {
         assertFalse(store.fetchRoleCredentials());
         store.close();
     }
-    
+
+    @Test
+    public void testFetchRoleCredential() throws InterruptedException, ExecutionException, TimeoutException {
+
+        CloudStore store = new CloudStore();
+        store.awsRole = "athenz.zts";
+
+        HttpClient httpClient = Mockito.mock(HttpClient.class);
+        ContentResponse response = Mockito.mock(ContentResponse.class);
+        Mockito.when(response.getStatus()).thenReturn(200);
+        Mockito.when(response.getContentAsString()).thenReturn("{\"AccessKeyId\":\"id\",\"SecretAccessKey\":\"key\",\"Token\":\"token\"}");
+
+        store.setHttpClient(httpClient);
+        Mockito.when(httpClient.GET("http://169.254.169.254/latest/meta-data/iam/security-credentials/athenz.zts")).thenReturn(response);
+
+        assertTrue(store.fetchRoleCredentials());
+        store.close();
+    }
+
     @Test
     public void testInitializeAwsSupportInvalidDocument()  throws InterruptedException, ExecutionException, TimeoutException {
         
@@ -659,7 +677,66 @@ public class CloudStoreTest {
         }
         store.close();
     }
-    
+
+    @Test
+    public void testInitializeAwsSupport()  throws ExecutionException, TimeoutException {
+
+        CloudStore store = new CloudStore();
+        HttpClient httpClient = Mockito.mock(HttpClient.class);
+
+        ContentResponse responseDoc = Mockito.mock(ContentResponse.class);
+        Mockito.when(responseDoc.getStatus()).thenReturn(200);
+        Mockito.when(responseDoc.getContentAsString()).thenReturn(AWS_INSTANCE_DOCUMENT);
+
+        ContentResponse responseSig = Mockito.mock(ContentResponse.class);
+        Mockito.when(responseSig.getStatus()).thenReturn(200);
+        Mockito.when(responseSig.getContentAsString()).thenReturn("pkcs7-signature");
+
+        ContentResponse responseInfo = Mockito.mock(ContentResponse.class);
+        Mockito.when(responseInfo.getStatus()).thenReturn(200);
+        Mockito.when(responseInfo.getContentAsString()).thenReturn(AWS_IAM_ROLE_INFO);
+
+        ContentResponse responseCreds = Mockito.mock(ContentResponse.class);
+        Mockito.when(responseCreds.getStatus()).thenReturn(200);
+        Mockito.when(responseCreds.getContentAsString()).thenReturn("{\"AccessKeyId\":\"id\",\"SecretAccessKey\":\"key\",\"Token\":\"token\"}");
+
+        store.setHttpClient(httpClient);
+        try {
+            Mockito.when(httpClient.GET("http://169.254.169.254/latest/dynamic/instance-identity/document")).thenReturn(responseDoc);
+        } catch (InterruptedException ignored) {
+        }
+        try {
+            Mockito.when(httpClient.GET("http://169.254.169.254/latest/dynamic/instance-identity/pkcs7")).thenReturn(responseSig);
+        } catch (InterruptedException ignored) {
+        }
+        try {
+            Mockito.when(httpClient.GET("http://169.254.169.254/latest/meta-data/iam/info")).thenReturn(responseInfo);
+        } catch (InterruptedException ignored) {
+        }
+        try {
+            Mockito.when(httpClient.GET("http://169.254.169.254/latest/meta-data/iam/security-credentials/athenz.zts")).thenReturn(responseCreds);
+        } catch (InterruptedException ignored) {
+        }
+
+        // set creds update time every second
+
+        System.setProperty(ZTSConsts.ZTS_PROP_AWS_CREDS_UPDATE_TIMEOUT, "1");
+
+        store.awsEnabled = true;
+        store.initializeAwsSupport();
+
+        // sleep a couple of seconds for the background thread to run
+        // before we try to shutting it down
+
+        try {
+            Thread.sleep(2000);
+        } catch (InterruptedException ignored) {
+        }
+        store.close();
+
+        System.clearProperty(ZTSConsts.ZTS_PROP_AWS_CREDS_UPDATE_TIMEOUT);
+    }
+
     @Test
     public void testAssumeAWSRoleAWSNotEnabled() {
         CloudStore cloudStore = new CloudStore();
@@ -684,7 +761,7 @@ public class CloudStoreTest {
         Mockito.when(creds.getExpiration()).thenReturn(new Date());
         Mockito.when(mockResult.getCredentials()).thenReturn(creds);
         cloudStore.setAssumeRoleResult(mockResult);
-        cloudStore.setAssumeAWSRole(true);
+        cloudStore.setReturnSuperAWSRole(true);
 
         AWSTemporaryCredentials awsCreds = cloudStore.assumeAWSRole("account", "syncer", "athenz.syncer", null, null);
         assertNotNull(awsCreds);
@@ -693,7 +770,71 @@ public class CloudStoreTest {
         assertEquals(awsCreds.getSecretAccessKey(), "secretaccesskey");
         cloudStore.close();
     }
-    
+
+    @Test
+    public void testAssumeAWSRoleFailedCreds() {
+        MockCloudStore cloudStore = new MockCloudStore();
+        cloudStore.awsEnabled = true;
+        AssumeRoleResult mockResult = Mockito.mock(AssumeRoleResult.class);
+        Credentials creds = Mockito.mock(Credentials.class);
+        Mockito.when(creds.getAccessKeyId()).thenReturn("accesskeyid");
+        Mockito.when(creds.getSecretAccessKey()).thenReturn("secretaccesskey");
+        Mockito.when(creds.getSessionToken()).thenReturn("sessiontoken");
+        Mockito.when(creds.getExpiration()).thenReturn(new Date());
+        Mockito.when(mockResult.getCredentials()).thenReturn(creds);
+        cloudStore.setAssumeRoleResult(mockResult);
+        cloudStore.setReturnSuperAWSRole(true);
+
+        // add our key to the invalid cache
+
+        cloudStore.putInvalidCacheCreds(cloudStore.getCacheKey("account", "syncer", "athenz.syncer", null, null));
+        assertNull(cloudStore.assumeAWSRole("account", "syncer", "athenz.syncer", null, null));
+        assertNull(cloudStore.assumeAWSRole("account", "syncer", "athenz.syncer", null, null));
+
+        // now set the timeout to 1 second and sleep that long and after
+        // that our test case should work as before
+
+        cloudStore.invalidCacheTimeout = 1;
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignored) {
+        }
+        assertNotNull(cloudStore.assumeAWSRole("account", "syncer", "athenz.syncer", null, null));
+        cloudStore.close();
+    }
+
+    @Test
+    public void testAssumeAWSRoleFailedCredsCache() {
+        MockCloudStore cloudStore = new MockCloudStore();
+        cloudStore.awsEnabled = true;
+        cloudStore.setReturnSuperAWSRole(true);
+        cloudStore.invalidCacheTimeout = 120;
+
+        // first we're going to return a regular exception
+        // in which case we won't cache the failed creds
+
+        cloudStore.setGetServiceException(403, false);
+        assertNull(cloudStore.assumeAWSRole("account", "syncer", "athenz.syncer", null, null));
+        assertNull(cloudStore.awsInvalidCredsCache.get(cloudStore.getCacheKey("account", "syncer", "athenz.syncer", null, null)));
+
+        // now we're going to return aamazon service exception
+        // but with 401 error code which means against no
+        // caching of failed credentials
+
+        cloudStore.setGetServiceException(401, true);
+        assertNull(cloudStore.assumeAWSRole("account", "syncer", "athenz.syncer", null, null));
+        assertNull(cloudStore.awsInvalidCredsCache.get(cloudStore.getCacheKey("account", "syncer", "athenz.syncer", null, null)));
+
+        // finally we're going to return access denied - 403
+        // amazon exception and we should cache the failed creds
+
+        cloudStore.setGetServiceException(403, true);
+        assertNull(cloudStore.assumeAWSRole("account", "syncer", "athenz.syncer", null, null));
+        assertNotNull(cloudStore.awsInvalidCredsCache.get(cloudStore.getCacheKey("account", "syncer", "athenz.syncer", null, null)));
+
+        cloudStore.close();
+    }
+
     @Test
     public void testGetSshKeyReqType() {
         CloudStore cloudStore = new CloudStore();
@@ -831,6 +972,59 @@ public class CloudStoreTest {
         assertEquals(testCreds.getAccessKeyId(), "keyid");
         assertEquals(testCreds.getSecretAccessKey(), "accesskey");
         assertEquals(testCreds.getSessionToken(), "token");
+        cloudStore.close();
+    }
+
+    @Test
+    public void testInvalidCacheCreds() {
+
+        CloudStore cloudStore = new CloudStore();
+        cloudStore.awsEnabled = true;
+
+        // standard checks
+
+        cloudStore.putInvalidCacheCreds("cacheKey");
+        assertTrue(cloudStore.isFailedTempCredsRequest("cacheKey"));
+        assertFalse(cloudStore.isFailedTempCredsRequest("unknown-key"));
+
+        // now set the timeout to only 1 second
+        // and sleep so our records are expired
+
+        cloudStore.invalidCacheTimeout = 1;
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignored) {
+        }
+        // this time our cache key is no longer considered failed
+
+        assertFalse(cloudStore.isFailedTempCredsRequest("cacheKey"));
+
+        // set the timeout to 0 value which should disable
+        // cache functionality thus our put does nothing
+
+        cloudStore.invalidCacheTimeout = 0;
+        cloudStore.putInvalidCacheCreds("newKey");
+        assertFalse(cloudStore.isFailedTempCredsRequest("newKey"));
+
+        // set the timeout back to 2 mins and verify
+        // expired check does not remove any entries
+
+        cloudStore.invalidCacheTimeout = 120;
+        assertEquals(cloudStore.awsInvalidCredsCache.size(), 1);
+
+        cloudStore.removeExpiredInvalidCredentials();
+        assertEquals(cloudStore.awsInvalidCredsCache.size(), 1);
+
+        // now set it to 1 second and it should remove it
+
+        cloudStore.invalidCacheTimeout = 1;
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException ignored) {
+        }
+        cloudStore.removeExpiredInvalidCredentials();
+        assertEquals(cloudStore.awsInvalidCredsCache.size(), 0);
+
         cloudStore.close();
     }
 }


### PR DESCRIPTION
To avoid large load of invalid aws sts assume role requests and possibly get rate limited by aws, zts will now maintain a cache of invalid requests for a default value of 2 mins whenever it receives access denied response from sts. So if we get more requests for the same role within those 2 mins, we'll just return the same failure as opposed to contact aws sts for a new set of temporary creds.