### PR TITLE
adding feature to ignore unknown properties in zms & zts clients

### DIFF
--- a/clients/java/zms/examples/tls-support/README.md
+++ b/clients/java/zms/examples/tls-support/README.md
@@ -22,6 +22,8 @@ usage: zms-tls-client
  -a,--action <arg>               action value
  -r,--resource <arg>             resource value
  -u,--principal <arg>            principal to authorize
+ -ro,--role <arg>                role name
+ -m,--method <arg>               ZMS API method name to call
 ```
 
 First build the example by executing `mvn clean package` and then run

--- a/clients/java/zms/examples/tls-support/src/main/java/com/yahoo/athenz/example/zms/tls/client/ZMSTLSClient.java
+++ b/clients/java/zms/examples/tls-support/src/main/java/com/yahoo/athenz/example/zms/tls/client/ZMSTLSClient.java
@@ -52,6 +52,7 @@ public class ZMSTLSClient {
         final String certPath = cmd.getOptionValue("cert");
         final String trustStorePath = cmd.getOptionValue("trustStorePath");
         final String trustStorePassword = cmd.getOptionValue("trustStorePassword");
+        final String roleName = cmd.getOptionValue("role");
 
         // we are going to setup our service private key and
         // certificate into a ssl context that we can use with
@@ -79,6 +80,10 @@ public class ZMSTLSClient {
                         case "access":
                             Access access = zmsClient.getAccess(action, resource, null, principal);
                             System.out.println("Access: " + access.getGranted());
+                            break;
+                        case "getrole":
+                            Role sampleRole = zmsClient.getRole(domain, roleName);
+                            System.out.println("Role: " + sampleRole.getName());
                             break;
                     }
                 } catch (ZMSClientException ex) {
@@ -136,6 +141,10 @@ public class ZMSTLSClient {
         Option zmsUrl = new Option("z", "zmsurl", true, "ZMS Server url");
         zmsUrl.setRequired(true);
         options.addOption(zmsUrl);
+
+        Option role = new Option("ro", "role", true, "name of the role");
+        role.setRequired(false);
+        options.addOption(role);
         
         CommandLineParser parser = new DefaultParser();
         HelpFormatter formatter = new HelpFormatter();

--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
@@ -29,7 +29,11 @@ import javax.net.ssl.SSLContext;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -358,8 +362,13 @@ public class ZMSClient implements Closeable {
         if (sslContext != null) {
             builder = builder.sslContext(sslContext);
         }
+
+        final JacksonJsonProvider jacksonJsonProvider = new JacksonJaxbJsonProvider().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        ClientConfig clientConfig = new ClientConfig(jacksonJsonProvider);
+
         Client rsClient = builder.property(ClientProperties.CONNECT_TIMEOUT, connectTimeout)
             .property(ClientProperties.READ_TIMEOUT, readTimeout)
+            .withConfig(clientConfig)
             .build();
         client = new ZMSRDLGeneratedClient(zmsUrl, rsClient);
     }

--- a/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
+++ b/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
@@ -15,7 +15,6 @@
  */
 package com.yahoo.athenz.zms;
 
-import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.*;
 
@@ -30,7 +29,6 @@ import com.yahoo.rdl.Timestamp;
 import static org.testng.Assert.*;
 
 import org.mockito.Mockito;
-import org.mockito.internal.matchers.Null;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -95,7 +93,6 @@ public class ZMSClientTest {
     private ZMSClient createClient(String userName) {
         ZMSClient client = new ZMSClient(getZMSUrl());
         client.addCredentials(createPrincipal(userName));
-        
         if (printURL) {
             System.out.println("ZMS Url set to: " + client.getZmsUrl());
             printURL = false;
@@ -3005,6 +3002,19 @@ public class ZMSClientTest {
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), 400);
+        }
+    }
+    @Test
+    public void testGetRole() {
+        ZMSClient client = createClient(systemAdminUser);
+        ZMSRDLGeneratedClient c = Mockito.mock(ZMSRDLGeneratedClient.class);
+        client.setZMSRDLGeneratedClient(c);
+        try {
+            Mockito.when(c.getRole("domain1", "role1", true, false)).thenThrow(new ResourceException(400));
+            client.getRole("domain1", "role1", true, false);
+            fail();
+        } catch (ResourceException ex) {
+            assertTrue(true);
         }
     }
 }

--- a/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -40,12 +40,15 @@ import javax.net.ssl.SSLSession;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.bouncycastle.asn1.DERIA5String;
 import org.bouncycastle.asn1.x509.GeneralName;
 import org.bouncycastle.operator.OperatorCreationException;
 import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJsonProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -627,8 +630,9 @@ public class ZTSClient implements Closeable {
         }
         
         // setup our client config object with timeouts
-        
-        final ClientConfig config = new ClientConfig();
+
+        final JacksonJsonProvider jacksonJsonProvider = new JacksonJaxbJsonProvider().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        final ClientConfig config = new ClientConfig(jacksonJsonProvider);
         config.property(ClientProperties.CONNECT_TIMEOUT, reqConnectTimeout);
         config.property(ClientProperties.READ_TIMEOUT, reqReadTimeout);
         config.connectorProvider(new ApacheConnectorProvider());

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
@@ -1050,14 +1050,11 @@ public class JDBCConnection implements ObjectStoreConnection {
             ps.setString(2, roleName);
             try (ResultSet rs = executeQuery(ps, caller)) {
                 if (rs.next()) {
-                    Role r = new Role();
-                    r.setName(ZMSUtils.roleResourceName(domainName, roleName))
+                    return new Role().setName(ZMSUtils.roleResourceName(domainName, roleName))
                      .setModified(Timestamp.fromMillis(rs.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED).getTime()))
-                     .setTrust(saveValue(rs.getString(ZMSConsts.DB_COLUMN_TRUST)));
-                    if (rs.getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED)) {
-                        r.setAuditEnabled(rs.getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED));
-                    }
-                     return r;
+                     .setTrust(saveValue(rs.getString(ZMSConsts.DB_COLUMN_TRUST)))
+                     .setAuditEnabled(nullIfDefaultValue(rs.getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED), false));
+
                 }
             }
         } catch (SQLException ex) {
@@ -3403,5 +3400,8 @@ public class JDBCConnection implements ObjectStoreConnection {
         }
         rollbackChanges();
         return ZMSUtils.error(code, msg, caller);
+    }
+    Boolean nullIfDefaultValue(boolean flag, boolean defaultValue) {
+        return flag == defaultValue ? null : flag;
     }
 }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
@@ -1050,10 +1050,14 @@ public class JDBCConnection implements ObjectStoreConnection {
             ps.setString(2, roleName);
             try (ResultSet rs = executeQuery(ps, caller)) {
                 if (rs.next()) {
-                    return new Role().setName(ZMSUtils.roleResourceName(domainName, roleName))
-                            .setModified(Timestamp.fromMillis(rs.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED).getTime()))
-                            .setTrust(saveValue(rs.getString(ZMSConsts.DB_COLUMN_TRUST)))
-                            .setAuditEnabled(rs.getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED));
+                    Role r = new Role();
+                    r.setName(ZMSUtils.roleResourceName(domainName, roleName))
+                     .setModified(Timestamp.fromMillis(rs.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED).getTime()))
+                     .setTrust(saveValue(rs.getString(ZMSConsts.DB_COLUMN_TRUST)));
+                    if (rs.getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED)) {
+                        r.setAuditEnabled(rs.getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED));
+                    }
+                     return r;
                 }
             }
         } catch (SQLException ex) {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
@@ -6801,4 +6801,11 @@ public class JDBCConnectionTest {
         Mockito.verify(mockPrepStmt, times(1)).setString(2, "role1");
         jdbcConn.close();
     }
+    @Test
+    public void testNullIfDefaultValue() throws Exception {
+        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        assertNull(jdbcConn.nullIfDefaultValue(false, false));
+        assertTrue(jdbcConn.nullIfDefaultValue(true, false));
+        jdbcConn.close();
+    }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
@@ -6781,4 +6781,24 @@ public class JDBCConnectionTest {
 
         jdbcConn.close();
     }
+
+    @Test
+    public void testGetRoleDefaultAuditEnabledAsNull() throws Exception {
+
+        Mockito.when(mockResultSet.next()).thenReturn(true);
+        Mockito.doReturn("role1").when(mockResultSet).getString(ZMSConsts.DB_COLUMN_NAME);
+        Mockito.doReturn("").when(mockResultSet).getString(ZMSConsts.DB_COLUMN_TRUST);
+        Mockito.doReturn(false).when(mockResultSet).getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED);
+        Mockito.doReturn(new java.sql.Timestamp(1454358916)).when(mockResultSet).getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED);
+
+        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        Role role = jdbcConn.getRole("my-domain", "role1");
+        assertNotNull(role);
+        assertEquals("my-domain:role.role1", role.getName());
+        assertNull(role.getAuditEnabled());
+
+        Mockito.verify(mockPrepStmt, times(1)).setString(1, "my-domain");
+        Mockito.verify(mockPrepStmt, times(1)).setString(2, "role1");
+        jdbcConn.close();
+    }
 }


### PR DESCRIPTION
only setting auditEnabled on Role object when DB returns true

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
