### PR TITLE
syncer update to include auditEnabled flag for domain and roles

### DIFF
--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -4012,6 +4012,12 @@ type DomainData struct {
 	// domain certificate dns domain
 	//
 	CertDnsDomain string `json:"certDnsDomain,omitempty" rdl:"optional"`
+
+	//
+	// Flag indicates whether or not domain modifications should be logged for
+	// SOX+Auditing.
+	//
+	AuditEnabled *bool `json:"auditEnabled,omitempty" rdl:"optional"`
 }
 
 //
@@ -4042,6 +4048,10 @@ func (self *DomainData) Init() *DomainData {
 	}
 	if self.Entities == nil {
 		self.Entities = make([]*Entity, 0)
+	}
+	if self.AuditEnabled == nil {
+		d := false
+		self.AuditEnabled = &d
 	}
 	return self
 }

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -400,6 +400,7 @@ func init() {
 	tDomainData.Field("modified", "Timestamp", false, nil, "last modification timestamp")
 	tDomainData.Field("applicationId", "String", true, nil, "associated application id")
 	tDomainData.Field("certDnsDomain", "String", true, nil, "domain certificate dns domain")
+	tDomainData.Field("auditEnabled", "Bool", true, false, "Flag indicates whether or not domain modifications should be logged for SOX+Auditing.")
 	sb.AddType(tDomainData.Build())
 
 	tSignedDomain := rdl.NewStructTypeBuilder("Struct", "SignedDomain")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/DomainData.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/DomainData.java
@@ -32,6 +32,9 @@ public class DomainData {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String certDnsDomain;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public Boolean auditEnabled;
 
     public DomainData setName(String name) {
         this.name = name;
@@ -110,6 +113,13 @@ public class DomainData {
     public String getCertDnsDomain() {
         return certDnsDomain;
     }
+    public DomainData setAuditEnabled(Boolean auditEnabled) {
+        this.auditEnabled = auditEnabled;
+        return this;
+    }
+    public Boolean getAuditEnabled() {
+        return auditEnabled;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -149,6 +159,9 @@ public class DomainData {
                 return false;
             }
             if (certDnsDomain == null ? a.certDnsDomain != null : !certDnsDomain.equals(a.certDnsDomain)) {
+                return false;
+            }
+            if (auditEnabled == null ? a.auditEnabled != null : !auditEnabled.equals(a.auditEnabled)) {
                 return false;
             }
         }

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -339,7 +339,8 @@ public class ZMSSchema {
             .arrayField("entities", "Entity", false, "list of entities in the domain")
             .field("modified", "Timestamp", false, "last modification timestamp")
             .field("applicationId", "String", true, "associated application id")
-            .field("certDnsDomain", "String", true, "domain certificate dns domain");
+            .field("certDnsDomain", "String", true, "domain certificate dns domain")
+            .field("auditEnabled", "Bool", true, "Flag indicates whether or not domain modifications should be logged for SOX+Auditing.", false);
 
         sb.structType("SignedDomain")
             .comment("A domain object signed with server's private key. The signature and keyid are optional if the metaonly flag is set to true in the getSignedDomains api call")

--- a/core/zms/src/main/rdl/SignedDomains.rdli
+++ b/core/zms/src/main/rdl/SignedDomains.rdli
@@ -50,6 +50,7 @@ type DomainData Struct {
     Timestamp modified; //last modification timestamp
     String applicationId (optional); //associated application id
     String certDnsDomain (optional); //domain certificate dns domain
+    Bool auditEnabled (optional, default=false); //Flag indicates whether or not domain modifications should be logged for SOX+Auditing.
 }
 
 //A domain object signed with server's private key. The signature

--- a/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
+++ b/core/zms/src/test/java/com/yahoo/athenz/zms/ZMSCoreTest.java
@@ -490,18 +490,26 @@ public class ZMSCoreTest {
         assertEquals("101", dd.getApplicationId());
         assertTrue(dd.getEnabled());
         assertEquals(dd.getCertDnsDomain(), "athenz.cloud");
+        assertFalse(dd.getAuditEnabled());
 
         DomainData dd2 = new DomainData().setName("test.domain").setAccount("user.test").setYpmId(1).setRoles(rl)
                 .setPolicies(sp).setServices(sil).setEntities(elist).setModified(Timestamp.fromMillis(123456789123L))
-                .setEnabled(true).setApplicationId("101").setCertDnsDomain("athenz.cloud");
+                .setEnabled(true).setApplicationId("101").setCertDnsDomain("athenz.cloud").setAuditEnabled(false);
+
         assertTrue(dd.equals(dd2));
 
+        dd2.setAuditEnabled(true);
+        assertFalse(dd2.equals(dd));
+
+        dd2.setAuditEnabled(false);
         dd2.setCertDnsDomain(null);
         assertFalse(dd2.equals(dd));
 
+        dd2.setCertDnsDomain("athenz.cloud");
         dd2.setApplicationId(null);
         assertFalse(dd2.equals(dd));
 
+        dd2.setApplicationId("101");
         dd2.setModified(null);
         assertFalse(dd2.equals(dd));
         

--- a/libs/java/client_common/src/main/java/com/yahoo/athenz/common/utils/SignUtils.java
+++ b/libs/java/client_common/src/main/java/com/yahoo/athenz/common/utils/SignUtils.java
@@ -69,6 +69,7 @@ public class SignUtils {
     private static final String ATTR_KEYID = "keyId";
     private static final String ATTR_CONTENTS = "contents";
     private static final String ATTR_CERT_DNS_DOMAIN = "certDnsDomain";
+    private static final String ATTR_AUDIT_ENABLED = "auditEnabled";
 
     private static Struct asStruct(DomainPolicies domainPolicies) {
         // all of our fields are in canonical order based
@@ -131,6 +132,7 @@ public class SignUtils {
         // all of our fields are in canonical order based
         // on their attribute name
         Struct struct = new Struct();
+        appendObject(struct, ATTR_AUDIT_ENABLED, role.getAuditEnabled());
         appendList(struct, ATTR_MEMBERS, role.getMembers());
         appendObject(struct, ATTR_MODIFIED, role.getModified());
         appendObject(struct, ATTR_NAME, role.getName());
@@ -238,6 +240,7 @@ public class SignUtils {
         // on their attribute name
         Struct struct = new Struct();
         appendObject(struct, ATTR_ACCOUNT, domainData.getAccount());
+        appendObject(struct, ATTR_AUDIT_ENABLED, domainData.getAuditEnabled());
         appendObject(struct, ATTR_CERT_DNS_DOMAIN, domainData.getCertDnsDomain());
         appendObject(struct, ATTR_ENABLED, domainData.getEnabled());
         appendObject(struct, ATTR_MODIFIED, domainData.getModified());

--- a/libs/java/client_common/src/test/java/com/yahoo/athenz/common/utils/SignUtilsTest.java
+++ b/libs/java/client_common/src/test/java/com/yahoo/athenz/common/utils/SignUtilsTest.java
@@ -44,6 +44,7 @@ public class SignUtilsTest {
     
     @Test
     public void testAsCanonicalStringDomainData() {
+        Mockito.when(mockDomain.getAuditEnabled()).thenReturn(null);
         Mockito.when(mockDomain.getEnabled()).thenReturn(null);
         Mockito.when(mockDomain.getRoles()).thenReturn(null);
         Mockito.when(mockDomain.getServices()).thenReturn(null);
@@ -121,6 +122,7 @@ public class SignUtilsTest {
     public void testAsStructRoleService() {
         List<Role> roles = new ArrayList<>();
         Role mRole = Mockito.mock(Role.class);
+        Mockito.when(mRole.getAuditEnabled()).thenReturn(null);
         roles.add(mRole);
         
         List<String> items = new ArrayList<>();
@@ -136,7 +138,8 @@ public class SignUtilsTest {
         publicKeys.add(mPublicKey);
         
         SignedPolicies signedPolicies = Mockito.mock(SignedPolicies.class);
-        
+
+        Mockito.when(mockDomain.getAuditEnabled()).thenReturn(null);
         Mockito.when(mockDomain.getEnabled()).thenReturn(null);
         Mockito.when(mockDomain.getAccount()).thenReturn("chk_string");
         Mockito.when(mockDomain.getRoles()).thenReturn(roles);
@@ -193,6 +196,32 @@ public class SignUtilsTest {
 
         final String check = SignUtils.asCanonicalString(struct);
         final String expected = "{\"float\":100.0,\"long\":100}";
+        assertEquals(check, expected);
+    }
+
+    @Test
+    public void testAsStructRoleDomainWithAuditEnabled() {
+
+        List<RoleMember> roleMembers1 = new ArrayList<>();
+        Role role1 = new Role().setName("role1").setRoleMembers(roleMembers1).setAuditEnabled(true);
+
+        List<RoleMember> roleMembers2 = new ArrayList<>();
+        roleMembers2.add(new RoleMember().setMemberName("user.joe").setExpiration(Timestamp.fromMillis(0)));
+        roleMembers2.add(new RoleMember().setMemberName("user.jane").setExpiration(Timestamp.fromMillis(0)));
+        Role role2 = new Role().setName("role2").setRoleMembers(roleMembers2);
+
+        List<Role> roles = new ArrayList<>();
+        roles.add(role1);
+        roles.add(role2);
+        roles.add(new Role().setName("role3"));
+        DomainData data = new DomainData().setRoles(roles).setYpmId(100)
+                .setEnabled(Boolean.TRUE).setAuditEnabled(true);
+
+        final String check = SignUtils.asCanonicalString(data);
+        final String expected = "{\"auditEnabled\":true,\"enabled\":true,\"roles\":[{\"auditEnabled\":true,\"name\":\"role1\",\"roleMembers\":[]},"
+                +"{\"name\":\"role2\",\"roleMembers\":[{\"expiration\":\"1970-01-01T00:00:00.000Z\","
+                +"\"memberName\":\"user.joe\"},{\"expiration\":\"1970-01-01T00:00:00.000Z\","
+                +"\"memberName\":\"user.jane\"}]},{\"name\":\"role3\"}],\"services\":[],\"ypmId\":100}";
         assertEquals(check, expected);
     }
 }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -4363,6 +4363,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         if (enabled == Boolean.FALSE) {
             domainData.setEnabled(enabled);
         }
+        // TODO: to be un-commented after dependent components are updated to not break backward compatibility
+        // domainData.setAuditEnabled(athenzDomain.getDomain().getAuditEnabled());
         domainData.setAccount(athenzDomain.getDomain().getAccount());
         domainData.setYpmId(athenzDomain.getDomain().getYpmId());
         domainData.setRoles(athenzDomain.getRoles());

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
@@ -360,7 +360,7 @@ public class JDBCConnection implements ObjectStoreConnection {
     Domain saveDomainSettings(String domainName, ResultSet rs, String caller) {
         try {
             return new Domain().setName(domainName)
-                    .setAuditEnabled(rs.getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED))
+                    .setAuditEnabled(nullIfDefaultValue(rs.getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED), false))
                     .setEnabled(rs.getBoolean(ZMSConsts.DB_COLUMN_ENABLED))
                     .setModified(Timestamp.fromMillis(rs.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED).getTime()))
                     .setDescription(saveValue(rs.getString(ZMSConsts.DB_COLUMN_DESCRIPTION)))
@@ -2584,7 +2584,8 @@ public class JDBCConnection implements ObjectStoreConnection {
                     String roleName = rs.getString(ZMSConsts.DB_COLUMN_NAME);
                     Role role = new Role().setName(ZMSUtils.roleResourceName(domainName, roleName))
                             .setModified(Timestamp.fromMillis(rs.getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED).getTime()))
-                            .setTrust(saveValue(rs.getString(ZMSConsts.DB_COLUMN_TRUST)));
+                            .setTrust(saveValue(rs.getString(ZMSConsts.DB_COLUMN_TRUST)))
+                            .setAuditEnabled(nullIfDefaultValue(rs.getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED), false));
                     roleMap.put(roleName, role);
                 }
             }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnectionTest.java
@@ -85,7 +85,33 @@ public class JDBCConnectionTest {
         assertNotNull(domain);
         assertEquals("my-domain", domain.getName());
         assertTrue(domain.getEnabled());
-        assertFalse(domain.getAuditEnabled());
+        assertNull(domain.getAuditEnabled());
+        assertNull(domain.getDescription());
+        assertNull(domain.getOrg());
+        assertNull(domain.getId());
+        jdbcConn.close();
+    }
+
+    @Test
+    public void testGetDomainWithAuditEnabled() throws Exception {
+
+        Mockito.when(mockResultSet.next()).thenReturn(true);
+        Mockito.doReturn("my-domain").when(mockResultSet).getString(ZMSConsts.DB_COLUMN_NAME);
+        Mockito.doReturn(new java.sql.Timestamp(1454358916)).when(mockResultSet).getTimestamp(ZMSConsts.DB_COLUMN_MODIFIED);
+        Mockito.doReturn(true).when(mockResultSet).getBoolean(ZMSConsts.DB_COLUMN_ENABLED);
+        Mockito.doReturn(true).when(mockResultSet).getBoolean(ZMSConsts.DB_COLUMN_AUDIT_ENABLED);
+        Mockito.doReturn("").when(mockResultSet).getString(ZMSConsts.DB_COLUMN_DESCRIPTION);
+        Mockito.doReturn("").when(mockResultSet).getString(ZMSConsts.DB_COLUMN_ORG);
+        Mockito.doReturn("").when(mockResultSet).getString(ZMSConsts.DB_COLUMN_UUID);
+        Mockito.doReturn("12345").when(mockResultSet).getString(ZMSConsts.DB_COLUMN_ACCOUNT);
+        Mockito.doReturn(1001).when(mockResultSet).getInt(ZMSConsts.DB_COLUMN_PRODUCT_ID);
+
+        JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
+        Domain domain = jdbcConn.getDomain("my-domain");
+        assertNotNull(domain);
+        assertEquals("my-domain", domain.getName());
+        assertTrue(domain.getEnabled());
+        assertTrue(domain.getAuditEnabled());
         assertNull(domain.getDescription());
         assertNull(domain.getOrg());
         assertNull(domain.getId());


### PR DESCRIPTION
updated domaindata rdli to add the new attribute auditEnabled
updated signutils to add canonical auditEnabled attribute to domain and role
modified domain query for signeddomains to use nullifdefault

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
