### PR TITLE
browser and UI server can access ZMS by different hostname

### DIFF
--- a/ui/config/default-config.js
+++ b/ui/config/default-config.js
@@ -91,7 +91,8 @@ module.exports = function() {
   let c = config[process.env.SERVICE_NAME || 'development'];
 
   c.zmshost = c.zmshost || 'localhost';
-  c.zms = process.env.ZMS_SERVER_URL || 'https://' + c.zmshost + ':4443/zms/v1/',
+  c.zms = process.env.ZMS_SERVER_URL || 'https://' + c.zmshost + ':4443/zms/v1/';
+  c.zms_ajax = process.env.ZMS_AJAX_URL || c.zms;
   c.userDomain = c.userDomain || 'user';
   c.authHeader = c.authHeader || 'Athenz-Principal-Auth';
   c.strictSSL = c.strictSSL || false;

--- a/ui/index.js
+++ b/ui/index.js
@@ -115,7 +115,7 @@ app.use(function(req, res, next) {
   };
   res.locals.originalUrl = pageUtils.cleanupOriginalUrl(req.originalUrl || '');
   res.locals.msg = [];
-  res.locals.zms = req.config.zms;
+  res.locals.zms = req.config.zms_ajax || req.config.zms;
   res.locals.serviceFQN = req.config.serviceFQN;
   res.locals.athenzScript = req.config.athenzScript;
   res.locals.headerLinks = req.config.headerLinks;

--- a/ui/views/layouts/main.handlebars
+++ b/ui/views/layouts/main.handlebars
@@ -29,7 +29,7 @@
         <script type="text/javascript" src="/assets/js/bundle.js"></script>
         <script type="text/javascript">
           if (!window.athenzScriptsLoaded) {
-            alert('Athenz Javascript scripts failed to load. Plese check your network connection or settings');
+            alert('Athenz Javascript scripts failed to load. Please check your network connection or settings');
             document.body.classList.add('no-js');
             /* Reset form input elements so that they are usable */
             var nodes = document.body.querySelectorAll('form input[disabled], form textarea[disabled]');


### PR DESCRIPTION
Add new `ZMS_AJAX_URL` env. variable for UI,
so that the web browser can use a different host name to access the ZMS server.

use case: UI server and browser are on different networks and access ZMS via different DNS.

> I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
