### PR TITLE
dependency package update

### DIFF
--- a/clients/java/zts/shade/pom.xml
+++ b/clients/java/zts/shade/pom.xml
@@ -165,7 +165,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1</version>
         <executions>
           <execution>
             <id>shade-jar</id>

--- a/containers/jetty/pom.xml
+++ b/containers/jetty/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>commons-daemon</groupId>
       <artifactId>commons-daemon</artifactId>
-      <version>1.1.0</version>
+      <version>${commons.daemon.version}</version>
     </dependency>
     <dependency>
       <groupId>org.glassfish.jersey.containers</groupId>

--- a/libs/java/cert_refresher/pom.xml
+++ b/libs/java/cert_refresher/pom.xml
@@ -30,7 +30,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <jmockit.version>1.46</jmockit.version>
+    <jmockit.version>1.47</jmockit.version>
   </properties>
 
   <dependencies>

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyManagerProxyTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyManagerProxyTest.java
@@ -15,7 +15,6 @@
  */
 package com.oath.auth;
 
-import mockit.Deencapsulation;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Test;
@@ -64,24 +63,6 @@ public class KeyManagerProxyTest {
                 return null;
             }
         };
-    }
-
-    @Test
-    public void testKeyManagerProxySetKeyManger() {
-        KeyManager[] keyManagers = new KeyManager[] { generateNewKeyManger() };
-
-        KeyManagerProxy keyManagerProxy = new KeyManagerProxy(keyManagers);
-        X509ExtendedKeyManager keyManagerFirst = Deencapsulation.getField(keyManagerProxy, "keyManager");
-
-        assertNotNull(keyManagerFirst);
-
-
-        keyManagerProxy.setKeyManager(new KeyManager[] { generateNewKeyManger() });
-
-        X509ExtendedKeyManager keyManagerSecond = Deencapsulation.getField(keyManagerProxy, "keyManager");
-        assertNotNull(keyManagerSecond);
-
-        assertNotSame(keyManagerFirst, keyManagerSecond);
     }
 
     @Test

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/TrustManagerProxyTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/TrustManagerProxyTest.java
@@ -15,7 +15,6 @@
  */
 package com.oath.auth;
 
-import mockit.Deencapsulation;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.Test;
@@ -31,80 +30,6 @@ import java.security.cert.X509Certificate;
 import static org.junit.Assert.*;
 
 public class TrustManagerProxyTest {
-
-    @Test
-    public void testTrustManagerProxySetTrustManger() {
-        TrustManager[] trustManagers = new TrustManager[] { new X509ExtendedTrustManager() {
-            @Override
-            public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
-            }
-
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return new X509Certificate[0];
-            }
-
-            @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {
-            }
-
-            @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
-            }
-        }};
-
-        TrustManagerProxy trustManagerProxy = new TrustManagerProxy(trustManagers);
-        X509ExtendedTrustManager trustManagerFirst = Deencapsulation.getField(trustManagerProxy, "trustManager");
-
-        assertNotNull(trustManagerFirst);
-
-        trustManagerProxy.setTrustManager(new TrustManager[] { new X509ExtendedTrustManager() {
-            @Override
-            public void checkClientTrusted(X509Certificate[] x509Certificates, String s) {
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] x509Certificates, String s) {
-            }
-
-            @Override
-            public X509Certificate[] getAcceptedIssuers() {
-                return new X509Certificate[0];
-            }
-
-            @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) {
-            }
-
-            @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) {
-            }
-
-            @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) {
-            }
-        }});
-
-        X509ExtendedTrustManager trustManagerSecond = Deencapsulation.getField(trustManagerProxy, "trustManager");
-        assertNotNull(trustManagerSecond);
-        assertNotSame(trustManagerFirst, trustManagerSecond);
-    }
 
     @Test
     public void testTrustManagerProxyCheckClientTrusted(@Mocked X509ExtendedTrustManager mockedTrustManager) throws CertificateException {

--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -116,7 +116,7 @@
     <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.16</version>
+      <version>8.0.17</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,19 +69,20 @@
   </ciManagement>
 
   <properties>
-    <jetty.version>9.4.18.v20190429</jetty.version>
-    <jersey.version>2.28</jersey.version>
+    <jetty.version>9.4.19.v20190610</jetty.version>
+    <jersey.version>2.29</jersey.version>
     <jackson.version>2.9.9</jackson.version>
     <maven-surefire-plugin.version>2.22.0</maven-surefire-plugin.version>
     <rdl.version>1.5.2</rdl.version>
-    <bouncycastle.version>1.61</bouncycastle.version>
-    <aws.version>1.11.560</aws.version>
-    <guava.version>27.1-jre</guava.version>
+    <bouncycastle.version>1.62</bouncycastle.version>
+    <aws.version>1.11.597</aws.version>
+    <guava.version>28.0-jre</guava.version>
     <logback.version>1.2.3</logback.version>
     <javax.version>3.1.0</javax.version>
     <javax.ws.version>2.1.1</javax.ws.version>
-    <mockito.version>2.27.0</mockito.version>
+    <mockito.version>3.0.0</mockito.version>
     <jjwt.version>0.9.1</jjwt.version>
+    <commons.daemon.version>1.2.0</commons.daemon.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>

--- a/servers/zts/pom.xml
+++ b/servers/zts/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>commons-daemon</groupId>
       <artifactId>commons-daemon</artifactId>
-      <version>1.1.0</version>
+      <version>${commons.daemon.version}</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -167,7 +167,7 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.5.8</version>
+      <version>4.5.9</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
removed a couple of test cases with Decapsulation class of jmockit that was deprecated and removed in the latest release.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.