### PR TITLE
query argument for jwk list api to only use ec curve names defined in RFC

### DIFF
--- a/clients/go/zts/client.go
+++ b/clients/go/zts/client.go
@@ -1023,9 +1023,9 @@ func (client ZTSClient) PostSSHCertRequest(certRequest *SSHCertRequest) (*SSHCer
 	}
 }
 
-func (client ZTSClient) GetJWKList() (*JWKList, error) {
+func (client ZTSClient) GetJWKList(rfc *bool) (*JWKList, error) {
 	var data *JWKList
-	url := client.URL + "/oauth2/keys"
+	url := client.URL + "/oauth2/keys" + encodeParams(encodeOptionalBoolParam("rfc", rfc))
 	resp, err := client.httpGet(url, nil)
 	if err != nil {
 		return data, err

--- a/clients/go/zts/zts_schema.go
+++ b/clients/go/zts/zts_schema.go
@@ -633,6 +633,7 @@ func init() {
 	sb.AddResource(mPostSSHCertRequest.Build())
 
 	mGetJWKList := rdl.NewResourceBuilder("JWKList", "GET", "/oauth2/keys")
+	mGetJWKList.Input("rfc", "Bool", false, "rfc", "", true, false, "flag to indicate ec curve names are restricted to RFC values")
 	mGetJWKList.Auth("", "", true, "")
 	mGetJWKList.Exception("BAD_REQUEST", "ResourceError", "")
 	mGetJWKList.Exception("NOT_FOUND", "ResourceError", "")

--- a/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -808,17 +808,26 @@ public class ZTSClient implements Closeable {
 
     /**
      * Retrieve list of ZTS Server public keys in Json WEB Key (JWK) format
+     * @param rfcCurveNames EC curve names - use values defined in RFC only
      * @return list of public keys (JWKs) on success. ZTSClientException will be thrown in case of failure
      */
-    public JWKList getJWKList() {
+    public JWKList getJWKList(boolean rfcCurveNames) {
         updateServicePrincipal();
         try {
-            return ztsClient.getJWKList();
+            return ztsClient.getJWKList(rfcCurveNames);
         } catch (ResourceException ex) {
             throw new ZTSClientException(ex.getCode(), ex.getData());
         } catch (Exception ex) {
             throw new ZTSClientException(ZTSClientException.BAD_REQUEST, ex.getMessage());
         }
+    }
+
+    /**
+     * Retrieve list of ZTS Server public keys in Json WEB Key (JWK) format
+     * @return list of public keys (JWKs) on success. ZTSClientException will be thrown in case of failure
+     */
+    public JWKList getJWKList() {
+        return getJWKList(false);
     }
 
     /**

--- a/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSRDLGeneratedClient.java
+++ b/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSRDLGeneratedClient.java
@@ -524,8 +524,11 @@ public class ZTSRDLGeneratedClient {
 
     }
 
-    public JWKList getJWKList() {
+    public JWKList getJWKList(Boolean rfc) {
         WebTarget target = base.path("/oauth2/keys");
+        if (rfc != null) {
+            target = target.queryParam("rfc", rfc);
+        }
         Invocation.Builder invocationBuilder = target.request("application/json");
         if (credsHeader != null) {
             invocationBuilder = credsHeader.startsWith("Cookie.") ? invocationBuilder.cookie(credsHeader.substring(7),

--- a/clients/java/zts/core/src/test/java/com/yahoo/athenz/zts/ZTSRDLClientMock.java
+++ b/clients/java/zts/core/src/test/java/com/yahoo/athenz/zts/ZTSRDLClientMock.java
@@ -34,7 +34,7 @@ public class ZTSRDLClientMock extends ZTSRDLGeneratedClient implements java.io.C
     private String roleName   = null;
     private String policyName = null;
     private List<String> tenantDomains = null;
-    private boolean jwkFailure = false;
+    private int jwkExcCode = 0;
 
     Map<String, AWSTemporaryCredentials> credsMap = new HashMap<>();
     
@@ -70,20 +70,28 @@ public class ZTSRDLClientMock extends ZTSRDLGeneratedClient implements java.io.C
                 .setNames(Arrays.asList("service1", "service2"));
     }
 
-    public void setJwkFailure(boolean jwkFailure) {
-        this.jwkFailure = jwkFailure;
+    public void setJwkFailure(int jwkExcCode) {
+        this.jwkExcCode = jwkExcCode;
     }
 
     @Override
-    public JWKList getJWKList() {
+    public JWKList getJWKList(Boolean rfc) {
 
-        if (jwkFailure) {
-            throw new ResourceException(500, "unable to retrieve jwk list");
+        if (jwkExcCode != 0) {
+            if (jwkExcCode < 500) {
+                throw new ResourceException(jwkExcCode, "unable to retrieve jwk list");
+            } else {
+                throw new IllegalArgumentException();
+            }
         }
 
         JWKList jwkList = new JWKList();
         List<JWK> list = new ArrayList<>();
-        list.add(new JWK().setKid("id1").setKty("RSA").setN("n").setE("e"));
+        if (rfc) {
+            list.add(new JWK().setKid("id1").setKty("EC").setX("x").setY("y").setCrv("P-256"));
+        } else {
+            list.add(new JWK().setKid("id1").setKty("RSA").setN("n").setE("e"));
+        }
         jwkList.setKeys(list);
 
         return jwkList;

--- a/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
+++ b/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
@@ -657,6 +657,7 @@ public class ZTSSchema {
 ;
 
         sb.resource("JWKList", "GET", "/oauth2/keys")
+            .queryParam("rfc", "rfc", "Bool", false, "flag to indicate ec curve names are restricted to RFC values")
             .auth("", "", true)
             .expected("OK")
             .exception("BAD_REQUEST", "ResourceError", "")

--- a/core/zts/src/main/rdl/OAauth.rdli
+++ b/core/zts/src/main/rdl/OAauth.rdli
@@ -30,7 +30,8 @@ type JWKList Struct {
     Array<JWK> keys; //array of JWKs
 }
 
-resource JWKList GET "/oauth2/keys" {
+resource JWKList GET "/oauth2/keys?rfc={rfc}" {
+    Bool rfc (optional, default=false); //flag to indicate ec curve names are restricted to RFC values
     authenticate;
     expected OK;
     exceptions {

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSHandler.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSHandler.java
@@ -34,7 +34,7 @@ public interface ZTSHandler {
     DomainMetrics postDomainMetrics(ResourceContext context, String domainName, DomainMetrics req);
     Status getStatus(ResourceContext context);
     Response postSSHCertRequest(ResourceContext context, SSHCertRequest certRequest);
-    JWKList getJWKList(ResourceContext context);
+    JWKList getJWKList(ResourceContext context, Boolean rfc);
     AccessTokenResponse postAccessTokenRequest(ResourceContext context, String request);
     RoleCertificate postRoleCertificateRequestExt(ResourceContext context, RoleCertificateRequest req);
     Schema getRdlSchema(ResourceContext context);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -3232,7 +3232,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
     }
 
     @Override
-    public JWKList getJWKList(ResourceContext ctx) {
+    public JWKList getJWKList(ResourceContext ctx, Boolean rfc) {
 
         final String caller = "getjwklist";
         final String callerTiming = "getjwklist_timing";
@@ -3247,7 +3247,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
 
         validateRequest(ctx.request(), caller);
 
-        final JWKList jwkList = dataStore.getZtsJWKList();
+        final JWKList jwkList = dataStore.getZtsJWKList(rfc);
 
         metric.stopTiming(timerMetric, null, principalDomain);
         return jwkList;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java
@@ -580,11 +580,11 @@ public class ZTSResources {
     @GET
     @Path("/oauth2/keys")
     @Produces(MediaType.APPLICATION_JSON)
-    public JWKList getJWKList() {
+    public JWKList getJWKList(@QueryParam("rfc") @DefaultValue("false") Boolean rfc) {
         try {
             ResourceContext context = this.delegate.newResourceContext(this.request, this.response);
             context.authenticate();
-            return this.delegate.getJWKList(context);
+            return this.delegate.getJWKList(context, rfc);
         } catch (ResourceException e) {
             int code = e.getCode();
             switch (code) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -1145,7 +1145,7 @@ public class ZTSImplTest {
                 "v=U1;d=user_domain;n=user;s=signature", 0, null);
         ResourceContext context = createResourceContext(principal);
 
-        JWKList list = zts.getJWKList(context);
+        JWKList list = zts.getJWKList(context, false);
         assertNotNull(list);
         List<JWK> keys = list.getKeys();
         assertEquals(keys.size(), 2);
@@ -1155,8 +1155,43 @@ public class ZTSImplTest {
         assertEquals(key1.getKid(), "0", key1.getKid());
 
         JWK key2 = keys.get(1);
-        assertEquals(key2.getKty(), "EC", key1.getKty());
-        assertEquals(key2.getKid(), "ec.0", key1.getKid());
+        assertEquals(key2.getKty(), "EC", key2.getKty());
+        assertEquals(key2.getKid(), "ec.0", key2.getKid());
+        assertEquals(key2.getCrv(), "prime256v1", key2.getCrv());
+
+        // execute the same test with argument passed as null
+        // for the Boolean rfc object so it should be same result
+
+        list = zts.getJWKList(context, null);
+        assertNotNull(list);
+        keys = list.getKeys();
+        assertEquals(keys.size(), 2);
+
+        key1 = keys.get(0);
+        assertEquals(key1.getKty(), "RSA", key1.getKty());
+        assertEquals(key1.getKid(), "0", key1.getKid());
+
+        key2 = keys.get(1);
+        assertEquals(key2.getKty(), "EC", key2.getKty());
+        assertEquals(key2.getKid(), "ec.0", key2.getKid());
+        assertEquals(key2.getCrv(), "prime256v1", key2.getCrv());
+
+        // now let's try with rfc option on in which case
+        // we'll get the curve name as P-256
+
+        list = zts.getJWKList(context, true);
+        assertNotNull(list);
+        keys = list.getKeys();
+        assertEquals(keys.size(), 2);
+
+        key1 = keys.get(0);
+        assertEquals(key1.getKty(), "RSA", key1.getKty());
+        assertEquals(key1.getKid(), "0", key1.getKid());
+
+        key2 = keys.get(1);
+        assertEquals(key2.getKty(), "EC", key2.getKty());
+        assertEquals(key2.getKid(), "ec.0", key2.getKid());
+        assertEquals(key2.getCrv(), "P-256", key2.getCrv());
     }
 
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/DataStoreTest.java
@@ -278,7 +278,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
         PublicKey zmsKey = store.zmsPublicKeyCache.getIfPresent("0");
         assertNotNull(zmsKey);
         assertNull(store.zmsPublicKeyCache.getIfPresent("1"));
@@ -1717,7 +1717,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         assertTrue(store.validateSignedDomain(signedDomain));
@@ -1733,7 +1733,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = new SignedDomain();
         
@@ -1759,7 +1759,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = new SignedDomain();
         
@@ -1785,7 +1785,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = new SignedDomain();
         
@@ -1902,7 +1902,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -1920,7 +1920,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomainWildCardMembers("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -1984,7 +1984,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -2003,7 +2003,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -2020,7 +2020,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -2124,7 +2124,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore setupStore = new DataStore(clogStore, null);
-        setupStore.loadZMSPublicKeys();
+        setupStore.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         setupStore.processDomain(signedDomain, true);
@@ -2679,7 +2679,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -2699,7 +2699,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, false);
@@ -2716,7 +2716,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -2743,7 +2743,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore setupStore = new DataStore(clogStore, null);
-        setupStore.loadZMSPublicKeys();
+        setupStore.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         setupStore.processDomain(signedDomain, true);
@@ -2770,7 +2770,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore setupStore = new DataStore(clogStore, null);
-        setupStore.loadZMSPublicKeys();
+        setupStore.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         setupStore.processDomain(signedDomain, true);
@@ -2794,7 +2794,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore setupStore = new DataStore(clogStore, null);
-        setupStore.loadZMSPublicKeys();
+        setupStore.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         setupStore.processDomain(signedDomain, true);
@@ -2825,7 +2825,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore setupStore = new DataStore(clogStore, null);
-        setupStore.loadZMSPublicKeys();
+        setupStore.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         setupStore.processDomain(signedDomain, true);
@@ -3342,7 +3342,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -3365,7 +3365,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -3390,7 +3390,7 @@ public class DataStoreTest {
         ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -3470,7 +3470,7 @@ public class DataStoreTest {
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
         ((MockZMSFileChangeLogStore) store.changeLogStore).setTagHeader("2014-01-01T12:00:00");
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -3531,7 +3531,7 @@ public class DataStoreTest {
                 pkey, "0");
         DataStore store = new DataStore(clogStore, null);
         ((MockZMSFileChangeLogStore) store.changeLogStore).setTagHeader("2014-01-01T12:00:00");
-        store.loadZMSPublicKeys();
+        store.loadAthenzPublicKeys();
 
         SignedDomain signedDomain = createSignedDomain("coretech", "weather");
         store.processDomain(signedDomain, true);
@@ -3795,6 +3795,25 @@ public class DataStoreTest {
         when(spec.getG()).thenReturn(null);
         when(spec.getH()).thenReturn(new BigInteger("100"));
         when(spec.getN()).thenReturn(new BigInteger("100"));
-        assertNull(store.getCurveName(spec));
+        assertNull(store.getCurveName(spec, false));
+    }
+
+    @Test
+    public void testRfcEllipticCurveName() {
+        ChangeLogStore clogStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                pkey, "0");
+        DataStore store = new DataStore(clogStore, null);
+
+        assertNull(store.rfcEllipticCurveName(null));
+        assertEquals(store.rfcEllipticCurveName("prime256v1"), "P-256");
+        assertEquals(store.rfcEllipticCurveName("secp256r1"), "P-256");
+        assertEquals(store.rfcEllipticCurveName("secp384r1"), "P-384");
+        assertEquals(store.rfcEllipticCurveName("secp521r1"), "P-521");
+
+        // not defined in the spec thus considered as unknown so
+        // we keep the name as is
+
+        assertEquals(store.rfcEllipticCurveName("prime192v1"), "prime192v1");
+        assertEquals(store.rfcEllipticCurveName("newcurve"), "newcurve");
     }
 }


### PR DESCRIPTION


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
