### PR TITLE
provide config option to return WWW-Authenticate values as one or multiple headers

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/rest/Http.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/rest/Http.java
@@ -169,10 +169,7 @@ public class Http {
         // attribute and let the caller decide if they want to add it to the
         // response as a header in its context handler
 
-        if (authChallenges != null) {
-            request.setAttribute(AUTH_CHALLENGES,  String.join(", ", authChallenges));
-        }
-
+        request.setAttribute(AUTH_CHALLENGES, authChallenges);
         throw new ResourceException(ResourceException.UNAUTHORIZED, "Invalid credentials");
     }
 

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/CertSignerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/CertSignerTest.java
@@ -34,6 +34,18 @@ public class CertSignerTest {
     }
 
     @Test
+    public void testCertSignerDefaultMethods() {
+
+        CertSigner signer = new CertSigner() {
+        };
+
+        assertNull(signer.generateX509Certificate("csr", "client", 60));
+        assertNull(signer.getCACertificate());
+        assertEquals(signer.getMaxCertExpiryTimeMins(), 0);
+        signer.close();
+    }
+
+    @Test
     public void testCertSigner() {
 
         CertSigner signer = Mockito.mock(CertSigner.class);

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/rest/HttpTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/rest/HttpTest.java
@@ -31,6 +31,8 @@ import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.auth.Authority.CredSource;
 
 import java.security.cert.X509Certificate;
+import java.util.HashSet;
+import java.util.Set;
 
 public class HttpTest {
 
@@ -107,8 +109,10 @@ public class HttpTest {
         } catch (ResourceException expected) {
             assertEquals(expected.getCode(), 401);
         }
+        Set<String> challenges = new HashSet<>();
+        challenges.add("Basic realm=\"athenz\"");
         Mockito.verify(httpServletRequest, times(1))
-                .setAttribute("com.yahoo.athenz.auth.credential.challenges", "Basic realm=\"athenz\"");
+                .setAttribute("com.yahoo.athenz.auth.credential.challenges", challenges);
     }
 
     @Test
@@ -125,8 +129,10 @@ public class HttpTest {
         } catch (ResourceException expected) {
             assertEquals(expected.getCode(), 401);
         }
-        Mockito.verify(httpServletRequest, times(2))
+        Mockito.verify(httpServletRequest, times(1))
                 .setAttribute(ArgumentMatchers.anyString(), ArgumentMatchers.anyString());
+        Mockito.verify(httpServletRequest, times(1))
+                .setAttribute(ArgumentMatchers.anyString(), ArgumentMatchers.anyIterable());
     }
 
     @Test
@@ -147,8 +153,11 @@ public class HttpTest {
         } catch (ResourceException expected) {
             assertEquals(expected.getCode(), 401);
         }
+        Set<String> challenges = new HashSet<>();
+        challenges.add("Basic realm=\"athenz\"");
+        challenges.add("AthenzRequest realm=\"athenz\"");
         Mockito.verify(httpServletRequest, times(1))
-                .setAttribute("com.yahoo.athenz.auth.credential.challenges", "Basic realm=\"athenz\", AthenzRequest realm=\"athenz\"");
+                .setAttribute("com.yahoo.athenz.auth.credential.challenges", challenges);
     }
 
     @Test

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/ssh/SSHSignerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/ssh/SSHSignerTest.java
@@ -36,6 +36,18 @@ public class SSHSignerTest {
     }
 
     @Test
+    public void testSSHSignerDefaultMethods() {
+
+        SSHSigner signer = new SSHSigner() {
+        };
+
+        assertNull(signer.generateCertificate(null, null, "client"));
+        assertNull(signer.getSignerCertificate("host"));
+        signer.setAuthorizer(null);
+        signer.close();
+    }
+
+    @Test
     public void testSSHSigner() {
 
         SSHSigner signer = Mockito.mock(SSHSigner.class);


### PR DESCRIPTION
Default is now sending multiple WWW-Authenticate headers since that seems like what curl is able to handle.

Property name: athenz.http.www-authenticate.multiple-headers
Default value: true

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.