### PR TITLE
Remove redundant log for filter to make it easy to debug

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/filter/impl/NoOpRateLimit.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/filter/impl/NoOpRateLimit.java
@@ -28,9 +28,6 @@ public class NoOpRateLimit implements RateLimit {
 
     @Override
     public boolean filter(ServletRequest servletRequest, ServletResponse servletResponse) {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("NoOpRateLimit called");
-        }
         return false;
     }
 


### PR DESCRIPTION
Remove redundant log, because this debug info will come out for every request and it is not necessary. It will make it easy to debug while turn debug mode on and use this NoOpRateLimit filter
