### PR TITLE
enable authenticate for /instance endpoint

### DIFF
--- a/clients/go/zts/zts_schema.go
+++ b/clients/go/zts/zts_schema.go
@@ -564,8 +564,10 @@ func init() {
 	sb.AddResource(mPostOSTKInstanceRefreshRequest.Build())
 
 	mPostInstanceRegisterInformation := rdl.NewResourceBuilder("InstanceIdentity", "POST", "/instance")
+	mPostInstanceRegisterInformation.Comment("we have an authenticate enabled for this endpoint but in most cases the service owner might need to make it optional by setting the zts servers no_auth_uri list to include this endpoint. We need the authenticate in case the request comes with a client certificate and the provider needs to know who that principal was in the client certificate")
 	mPostInstanceRegisterInformation.Input("info", "InstanceRegisterInformation", false, "", "", false, nil, "")
 	mPostInstanceRegisterInformation.Output("location", "String", "Location", false, "return location for subsequent patch requests")
+	mPostInstanceRegisterInformation.Auth("", "", true, "")
 	mPostInstanceRegisterInformation.Expected("CREATED")
 	mPostInstanceRegisterInformation.Exception("BAD_REQUEST", "ResourceError", "")
 	mPostInstanceRegisterInformation.Exception("FORBIDDEN", "ResourceError", "")

--- a/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSRDLGeneratedClient.java
+++ b/clients/java/zts/core/src/main/java/com/yahoo/athenz/zts/ZTSRDLGeneratedClient.java
@@ -411,6 +411,10 @@ public class ZTSRDLGeneratedClient {
     public InstanceIdentity postInstanceRegisterInformation(InstanceRegisterInformation info, java.util.Map<String, java.util.List<String>> headers) {
         WebTarget target = base.path("/instance");
         Invocation.Builder invocationBuilder = target.request("application/json");
+        if (credsHeader != null) {
+            invocationBuilder = credsHeader.startsWith("Cookie.") ? invocationBuilder.cookie(credsHeader.substring(7),
+                credsToken) : invocationBuilder.header(credsHeader, credsToken);
+        }
         Response response = invocationBuilder.post(javax.ws.rs.client.Entity.entity(info, "application/json"));
         int code = response.getStatus();
         switch (code) {

--- a/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
+++ b/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
@@ -565,8 +565,10 @@ public class ZTSSchema {
 ;
 
         sb.resource("InstanceRegisterInformation", "POST", "/instance")
+            .comment("we have an authenticate enabled for this endpoint but in most cases the service owner might need to make it optional by setting the zts servers no_auth_uri list to include this endpoint. We need the authenticate in case the request comes with a client certificate and the provider needs to know who that principal was in the client certificate")
             .input("info", "InstanceRegisterInformation", "")
             .output("Location", "location", "String", "return location for subsequent patch requests")
+            .auth("", "", true)
             .expected("CREATED")
             .exception("BAD_REQUEST", "ResourceError", "")
 

--- a/core/zts/src/main/rdl/Instance.rdli
+++ b/core/zts/src/main/rdl/Instance.rdli
@@ -36,10 +36,17 @@ type InstanceIdentity Struct {
     Map<String,String> attributes (optional); //other config-like attributes determined at boot time
 }
 
+// we have an authenticate enabled for this endpoint but in most
+// cases the service owner might need to make it optional by setting
+// the zts servers no_auth_uri list to include this endpoint. We
+// need the authenticate in case the request comes with a client
+// certificate and the provider needs to know who that principal
+// was in the client certificate
 resource InstanceIdentity POST "/instance" {
     InstanceRegisterInformation info;
     String location (header="Location", out); //return location for subsequent patch requests
     expected CREATED;
+    authenticate;
     exceptions {
         ResourceError BAD_REQUEST;
         ResourceError FORBIDDEN;

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSResources.java
@@ -421,6 +421,7 @@ public class ZTSResources {
     public Response postInstanceRegisterInformation(InstanceRegisterInformation info) {
         try {
             ResourceContext context = this.delegate.newResourceContext(this.request, this.response);
+            context.authenticate();
             return this.delegate.postInstanceRegisterInformation(context, info);
         } catch (ResourceException e) {
             int code = e.getCode();


### PR DESCRIPTION
we have an authenticate enabled for this endpoint but in most cases the service owner might need to make it optional by setting the zts servers no_auth_uri list to include this endpoint. We need the authenticate in case the request comes with a client certificate and the provider needs to know who that principal was in the client certificate

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.