### PR TITLE
Membership changes for governance/compliance feature

### DIFF
--- a/clients/go/zms/client.go
+++ b/clients/go/zms/client.go
@@ -1077,9 +1077,9 @@ func (client ZMSClient) DeleteRole(domainName DomainName, roleName EntityName, a
 	}
 }
 
-func (client ZMSClient) GetMembership(domainName DomainName, roleName EntityName, memberName MemberName) (*Membership, error) {
+func (client ZMSClient) GetMembership(domainName DomainName, roleName EntityName, memberName MemberName, expiration string) (*Membership, error) {
 	var data *Membership
-	url := client.URL + "/domain/" + fmt.Sprint(domainName) + "/role/" + fmt.Sprint(roleName) + "/member/" + fmt.Sprint(memberName)
+	url := client.URL + "/domain/" + fmt.Sprint(domainName) + "/role/" + fmt.Sprint(roleName) + "/member/" + fmt.Sprint(memberName) + encodeParams(encodeStringParam("expiration", string(expiration), ""))
 	resp, err := client.httpGet(url, nil)
 	if err != nil {
 		return data, err

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -809,6 +809,7 @@ func init() {
 	mGetMembership.Input("domainName", "DomainName", true, "", "", false, nil, "name of the domain")
 	mGetMembership.Input("roleName", "EntityName", true, "", "", false, nil, "name of the role")
 	mGetMembership.Input("memberName", "MemberName", true, "", "", false, nil, "user name to be checked for membership")
+	mGetMembership.Input("expiration", "String", false, "expiration", "", true, nil, "the expiration timestamp")
 	mGetMembership.Auth("", "", true, "")
 	mGetMembership.Exception("BAD_REQUEST", "ResourceError", "")
 	mGetMembership.Exception("FORBIDDEN", "ResourceError", "")

--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSClient.java
@@ -902,9 +902,24 @@ public class ZMSClient implements Closeable {
      * @throws ZMSClientException in case of failure
      */
     public Membership getMembership(String domainName, String roleName, String memberName) {
+        return getMembership(domainName, roleName, memberName, null);
+    }
+
+    /**
+     * Get membership details for the specified member in the given role
+     * in a specified domain with an optional expiration
+     *
+     * @param domainName name of the domain
+     * @param roleName   name of the role
+     * @param memberName name of the member
+     * @param expiration member expiration
+     * @return Membership object
+     * @throws ZMSClientException in case of failure
+     */
+    public Membership getMembership(String domainName, String roleName, String memberName, String expiration) {
         updatePrincipal();
         try {
-            return client.getMembership(domainName, roleName, memberName);
+            return client.getMembership(domainName, roleName, memberName, expiration);
         } catch (ResourceException ex) {
             throw new ZMSClientException(ex.getCode(), ex.getData());
         } catch (Exception ex) {

--- a/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSRDLGeneratedClient.java
+++ b/clients/java/zms/src/main/java/com/yahoo/athenz/zms/ZMSRDLGeneratedClient.java
@@ -602,11 +602,14 @@ public class ZMSRDLGeneratedClient {
 
     }
 
-    public Membership getMembership(String domainName, String roleName, String memberName) {
+    public Membership getMembership(String domainName, String roleName, String memberName, String expiration) {
         WebTarget target = base.path("/domain/{domainName}/role/{roleName}/member/{memberName}")
             .resolveTemplate("domainName", domainName)
             .resolveTemplate("roleName", roleName)
             .resolveTemplate("memberName", memberName);
+        if (expiration != null) {
+            target = target.queryParam("expiration", expiration);
+        }
         Invocation.Builder invocationBuilder = target.request("application/json");
         if (credsHeader != null) {
             invocationBuilder = credsHeader.startsWith("Cookie.") ? invocationBuilder.cookie(credsHeader.substring(7),

--- a/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
+++ b/clients/java/zms/src/test/java/com/yahoo/athenz/zms/ZMSClientTest.java
@@ -1710,10 +1710,10 @@ public class ZMSClientTest {
         ZMSRDLGeneratedClient c = Mockito.mock(ZMSRDLGeneratedClient.class);
         client.setZMSRDLGeneratedClient(c);
         Membership member1Mock = Mockito.mock(Membership.class);
-        Mockito.when(c.getMembership("MbrGetRoleDom1", "Role1", "user.joe")).thenReturn(member1Mock);
+        Mockito.when(c.getMembership("MbrGetRoleDom1", "Role1", "user.joe", null)).thenReturn(member1Mock);
         client.getMembership("MbrGetRoleDom1", "Role1", "user.doe");
         try {
-            Mockito.when(c.getMembership("MbrGetRoleDom1", "Role2", "user.joe")).thenThrow(new ResourceException(204));
+            Mockito.when(c.getMembership("MbrGetRoleDom1", "Role2", "user.joe", null)).thenThrow(new ResourceException(204));
             client.getMembership("MbrGetRoleDom1", "Role2", "user.joe");
             fail();
         } catch  (ResourceException ex) {
@@ -1721,7 +1721,7 @@ public class ZMSClientTest {
         }
 
         try {
-            Mockito.when(c.getMembership("MbrGetRoleDom1", "Role3", "user.joe")).thenThrow(new NullPointerException());
+            Mockito.when(c.getMembership("MbrGetRoleDom1", "Role3", "user.joe", null)).thenThrow(new NullPointerException());
             client.getMembership("MbrGetRoleDom1", "Role3", "user.joe");
             fail();
         } catch (ResourceException ex) {

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -848,6 +848,7 @@ public class ZMSSchema {
             .pathParam("domainName", "DomainName", "name of the domain")
             .pathParam("roleName", "EntityName", "name of the role")
             .pathParam("memberName", "MemberName", "user name to be checked for membership")
+            .queryParam("expiration", "expiration", "String", null, "the expiration timestamp")
             .auth("", "", true)
             .expected("OK")
             .exception("BAD_REQUEST", "ResourceError", "")

--- a/core/zms/src/main/rdl/Role.rdli
+++ b/core/zms/src/main/rdl/Role.rdli
@@ -88,10 +88,11 @@ resource Role DELETE "/domain/{domainName}/role/{roleName}" {
 }
 
 //Get the membership status for a specified user in a role.
-resource Membership GET "/domain/{domainName}/role/{roleName}/member/{memberName}" {
+resource Membership GET "/domain/{domainName}/role/{roleName}/member/{memberName}?expiration={expiration}" {
     DomainName domainName; //name of the domain
     EntityName roleName; //name of the role
     MemberName memberName; //user name to be checked for membership
+    String expiration (optional); //the expiration timestamp
     authenticate;
     exceptions {
         ResourceError BAD_REQUEST;

--- a/libs/go/zmscli/role.go
+++ b/libs/go/zmscli/role.go
@@ -266,7 +266,7 @@ func (cli Zms) CheckMembers(dn string, rn string, members []string) (*string, er
 	var buf bytes.Buffer
 	ms := cli.validatedUsers(members, false)
 	for _, m := range ms {
-		member, err := cli.Zms.GetMembership(zms.DomainName(dn), zms.EntityName(rn), zms.MemberName(m))
+		member, err := cli.Zms.GetMembership(zms.DomainName(dn), zms.EntityName(rn), zms.MemberName(m), "")
 		cli.dumpRoleMembership(&buf, *member)
 		if err != nil {
 			return nil, err

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSHandler.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSHandler.java
@@ -36,7 +36,7 @@ public interface ZMSHandler {
     Role getRole(ResourceContext context, String domainName, String roleName, Boolean auditLog, Boolean expand, Boolean pending);
     void putRole(ResourceContext context, String domainName, String roleName, String auditRef, Role role);
     void deleteRole(ResourceContext context, String domainName, String roleName, String auditRef);
-    Membership getMembership(ResourceContext context, String domainName, String roleName, String memberName);
+    Membership getMembership(ResourceContext context, String domainName, String roleName, String memberName, String expiration);
     DomainRoleMembers getDomainRoleMembers(ResourceContext context, String domainName);
     void putMembership(ResourceContext context, String domainName, String roleName, String memberName, String auditRef, Membership membership);
     void deleteMembership(ResourceContext context, String domainName, String roleName, String memberName, String auditRef);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
@@ -699,11 +699,11 @@ public class ZMSResources {
     @GET
     @Path("/domain/{domainName}/role/{roleName}/member/{memberName}")
     @Produces(MediaType.APPLICATION_JSON)
-    public Membership getMembership(@PathParam("domainName") String domainName, @PathParam("roleName") String roleName, @PathParam("memberName") String memberName) {
+    public Membership getMembership(@PathParam("domainName") String domainName, @PathParam("roleName") String roleName, @PathParam("memberName") String memberName, @QueryParam("expiration") String expiration) {
         try {
             ResourceContext context = this.delegate.newResourceContext(this.request, this.response);
             context.authenticate();
-            return this.delegate.getMembership(context, domainName, roleName, memberName);
+            return this.delegate.getMembership(context, domainName, roleName, memberName, expiration);
         } catch (ResourceException e) {
             int code = e.getCode();
             switch (code) {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/ObjectStoreConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/ObjectStoreConnection.java
@@ -71,9 +71,10 @@ public interface ObjectStoreConnection extends Closeable {
     
     List<RoleMember> listRoleMembers(String domainName, String roleName, Boolean pending);
     int countRoleMembers(String domainName, String roleName);
-    Membership getRoleMember(String domainName, String roleName, String member);
+    Membership getRoleMember(String domainName, String roleName, String member, long expiration);
     boolean insertRoleMember(String domainName, String roleName, RoleMember roleMember, String principal, String auditRef);
     boolean deleteRoleMember(String domainName, String roleName, String member, String principal, String auditRef);
+    boolean deletePendingRoleMember(String domainName, String roleName, String member, String principal, String auditRef);
     boolean confirmRoleMember(String domainName, String roleName, RoleMember roleMember, String principal, String auditRef);
 
     DomainRoleMembers listDomainRoleMembers(String domainName);
@@ -132,13 +133,9 @@ public interface ObjectStoreConnection extends Closeable {
     boolean updateQuota(String domainName, Quota quota);
     boolean deleteQuota(String domainName);
 
-    Map<String, List<DomainRoleMember>> getPendingDomainRoleMembersList(String principal);
+    Map<String, List<DomainRoleMember>> getPendingDomainRoleMembers(String principal);
+    Map<String, List<DomainRoleMember>> getExpiredPendingDomainRoleMembers(int pendingRoleMemberLifespan);
     Set<String> getPendingMembershipApproverRoles(String server, long timestamp);
 
-    List<Map<String, String>> getExpiredPendingMembers(int pendingRoleMemberLifespan);
-
     boolean updateLastNotifiedTimestamp(String server, long timestamp);
-
-    boolean deletePendingRoleMember(int roleId, int principalId, final String admin, final String principal,
-                                           final String auditRef, boolean auditLog, final String caller);
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/NotificationManagerTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/NotificationManagerTest.java
@@ -117,6 +117,15 @@ public class NotificationManagerTest {
     }
 
     @Test
+    public void testCreaeteNotificationNullRecipients() {
+
+        NotificationManager notificationManager = new NotificationManager(dbService, ZMSConsts.USER_DOMAIN_PREFIX);
+        assertNull(notificationManager.createNotification("MEMBERSHIP_APPROVAL", null, null));
+        assertNull(notificationManager.createNotification("MEMBERSHIP_APPROVAL", Collections.EMPTY_SET, null));
+        notificationManager.shutdown();
+    }
+
+    @Test
     public void testCreateNotificationNoValidRecipients() {
         Set<String> recipients = new HashSet<>();
         recipients.add("unix.ykeykey");


### PR DESCRIPTION
Changes include:
a) getMembership now has an optional expiration field. If specified, the server will only return the membership object if the user has the specified expiration date.
b) consistent return object types for getExpiredPendingDomainRoleMembers and getPendingDomainRoleMembers api calls for the object connection interface
c) additional unit test cases

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
