### PR TITLE
Triple brace = no escape

### DIFF
--- a/ui/views/layouts/main.handlebars
+++ b/ui/views/layouts/main.handlebars
@@ -20,7 +20,7 @@
           </div>
         {{/if}}
         <script type="text/javascript">
-          athenzParams = {{{json allParams}}}
+          athenzParams = {{json allParams}}
           athenzScript = '{{athenzScript}}';
           zms = '{{zms}}';
           serviceFQN = '{{serviceFQN}}';


### PR DESCRIPTION
Handlebars HTML-escapes values returned by a {{expression}}. If you don't want Handlebars to escape a value, use the "triple-stash", {{{.

The use of {{{ for  athenzParams = {{{json allParams}}} was leading to an xss on almost every page.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
