### PR TITLE
Expose DEFAULT_RETRY_CHECK_FREQUENCY

### DIFF
--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresher.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/KeyRefresher.java
@@ -34,7 +34,7 @@ public class KeyRefresher {
     private Thread scanForFileChangesThread;
     private boolean shutdown = false; //only for testing
     //60 seconds * 60 (min in an hour)
-    private static final int DEFAULT_RETRY_CHECK_FREQUENCY = 60_000 * 60;
+    public static final int DEFAULT_RETRY_CHECK_FREQUENCY = 60_000 * 60;
 
     private final MessageDigest md = MessageDigest.getInstance("MD5");
     private final byte[] lastPublicCertManagerChecksum = new byte[md.getDigestLength()];


### PR DESCRIPTION
I would like to use this value as a fallback if we do not set an override in our application config.

Hypothetically:
```java
refresher.startup(config.getOrDefault("retryFrequency", DEFAULT_RETRY_CHECK_FREQUENCY));
```

The current workaround is something like:
```java
if (config.get("retryFrequency") != null) {
    refresher.startup(config.get("retryFrequency"));
} else {
    refresher.startup();
}
```