### PR TITLE
Insert CSRF protection middleware

### DIFF
--- a/ui/index.js
+++ b/ui/index.js
@@ -124,6 +124,15 @@ app.use(function(req, res, next) {
   next();
 });
 
+app.use(function(req, res, next) {
+  //Check for CSRF, if bad origin, force re-auth
+  if (req.get("origin") && req.get("host") !== req.get("origin").split("/")[2]) {
+    res.redirect(302, "/athenz/login?error=1");
+  }else{
+    next();
+  }
+});
+
 app.all('/', routeHandlers.redirect);
 app.get('/athenz', routeHandlers.init, routeHandlers.home);
 app.post('/athenz', routeHandlers.init, routeHandlers.home);


### PR DESCRIPTION
Added a CSRF protection middleware that checks to see if the origin of the request is the same as the host header. If it is not, then force re-auth by redirecting to the login page. This action was chosen to deal with CSRF because codebase performs similar actions when security checks are violated.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
