### PR TITLE
admin link fix

### DIFF
--- a/ui/src/utils/req.js
+++ b/ui/src/utils/req.js
@@ -92,7 +92,7 @@ module.exports = {
   getAdminLinks: function(admins) {
     if(admins && admins.length) {
       return admins.split(',').map(function(admin) {
-        return '<a target="_blank" href=\'' + config.userLink(admin) + '\'>' + admin + '</a>';
+        return admin;
       }).join(', ');
     }
 

--- a/ui/test/unit/utils/req.js
+++ b/ui/test/unit/utils/req.js
@@ -148,16 +148,13 @@ describe('req utils', function() {
 
   it('should test getAdminLinks when there is one admin', function() {
     var adminLinkStr = reqUtils.getAdminLinks('rummykub');
-
-	// TODO: restrict verify
-	expect(adminLinkStr).to.contain('http');
+	expect(adminLinkStr).to.contain('rummykub');
   });
 
 
   it('should test getAdminLinks when there is more than one admin, some with user prefixes', function() {
     var adminLinkStr = reqUtils.getAdminLinks('rummykub,beezlebub,abercadaber');
-	// TODO: restrict verify
-	expect(adminLinkStr).to.contain('http');
+	expect(adminLinkStr).to.contain('rummykub, beezlebub, abercadaber');
   });
 
   it('should test getAdminLinks when there are none', function() {


### PR DESCRIPTION
this addresses a side-effect created by the xss PR #800 where the admin names were now showing up with http links in clear text. for now we're just removing the http links and just showing the admin user ids.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
