### PR TITLE
replace deprecated SslContextFactory usage with SslContextFactory.Server

### DIFF
--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -286,7 +286,7 @@ public class AthenzJettyContainer {
         this.privateKeyStore = pkeyFactory.create();
     }
     
-    SslContextFactory createSSLContextObject(boolean needClientAuth) {
+    SslContextFactory.Server createSSLContextObject(boolean needClientAuth) {
         
         final String keyStorePath = System.getProperty(AthenzConsts.ATHENZ_PROP_KEYSTORE_PATH);
         final String keyStorePasswordAppName = System.getProperty(AthenzConsts.ATHENZ_PROP_KEYSTORE_PASSWORD_APPNAME);
@@ -305,7 +305,7 @@ public class AthenzJettyContainer {
         boolean enableOCSP = Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_ENABLE_OCSP, "false"));
         boolean renegotiationAllowed = Boolean.parseBoolean(System.getProperty(AthenzConsts.ATHENZ_PROP_RENEGOTIATION_ALLOWED, "true"));
 
-        SslContextFactory sslContextFactory = new SslContextFactory();
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
         sslContextFactory.setEndpointIdentificationAlgorithm(null);
 
         if (keyStorePath != null) {
@@ -377,7 +377,7 @@ public class AthenzJettyContainer {
         
         // SSL Context Factory
     
-        SslContextFactory sslContextFactory = createSSLContextObject(needClientAuth);
+        SslContextFactory.Server sslContextFactory = createSSLContextObject(needClientAuth);
     
         // SSL HTTP Configuration
         

--- a/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
+++ b/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
@@ -336,7 +336,7 @@ public class AthenzJettyContainerTest {
         System.setProperty(AthenzConsts.ATHENZ_PROP_INCLUDED_CIPHER_SUITES, DEFAULT_INCLUDED_CIPHERS);
         System.setProperty(AthenzConsts.ATHENZ_PROP_EXCLUDED_PROTOCOLS, AthenzJettyContainer.ATHENZ_DEFAULT_EXCLUDED_PROTOCOLS);
         
-        SslContextFactory sslContextFactory = container.createSSLContextObject(true);
+        SslContextFactory.Server sslContextFactory = container.createSSLContextObject(true);
         assertNotNull(sslContextFactory);
         assertEquals(sslContextFactory.getKeyStorePath(), "file:///tmp/keystore");
         assertEquals(sslContextFactory.getKeyStoreType(), "PKCS12");
@@ -352,7 +352,7 @@ public class AthenzJettyContainerTest {
     public void testCreateSSLContextObjectNoValues() {
         
         AthenzJettyContainer container = new AthenzJettyContainer();
-        SslContextFactory sslContextFactory = container.createSSLContextObject(false);
+        SslContextFactory.Server sslContextFactory = container.createSSLContextObject(false);
         
         assertNotNull(sslContextFactory);
         assertNull(sslContextFactory.getKeyStoreResource());
@@ -378,7 +378,7 @@ public class AthenzJettyContainerTest {
         System.setProperty(AthenzConsts.ATHENZ_PROP_INCLUDED_CIPHER_SUITES, DEFAULT_INCLUDED_CIPHERS);
         System.setProperty(AthenzConsts.ATHENZ_PROP_EXCLUDED_PROTOCOLS, AthenzJettyContainer.ATHENZ_DEFAULT_EXCLUDED_PROTOCOLS);
         
-        SslContextFactory sslContextFactory = container.createSSLContextObject(true);
+        SslContextFactory.Server sslContextFactory = container.createSSLContextObject(true);
         assertNotNull(sslContextFactory);
         assertNull(sslContextFactory.getKeyStoreResource());
         // store type always defaults to PKCS12
@@ -402,7 +402,7 @@ public class AthenzJettyContainerTest {
         System.setProperty(AthenzConsts.ATHENZ_PROP_INCLUDED_CIPHER_SUITES, DEFAULT_INCLUDED_CIPHERS);
         System.setProperty(AthenzConsts.ATHENZ_PROP_EXCLUDED_PROTOCOLS, AthenzJettyContainer.ATHENZ_DEFAULT_EXCLUDED_PROTOCOLS);
         
-        SslContextFactory sslContextFactory = container.createSSLContextObject(false);
+        SslContextFactory.Server sslContextFactory = container.createSSLContextObject(false);
         assertNotNull(sslContextFactory);
         assertEquals(sslContextFactory.getKeyStorePath(), "file:///tmp/keystore");
         assertEquals(sslContextFactory.getKeyStoreType(), "PKCS12");


### PR DESCRIPTION
Addresses the following issue in Jetty 9.4.24:

https://github.com/eclipse/jetty.project/issues/4385

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
