### PR TITLE
self signer using mins setting

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/SelfCertSigner.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/SelfCertSigner.java
@@ -35,15 +35,14 @@ public class SelfCertSigner implements CertSigner {
         this.caCertificate = caCertificate;
         this.caPrivateKey = caPrivateKey;
         
-        // max certificate validity time in minutes and convert
-        // value to seconds for the certificate signer
+        // max certificate validity time in minutes
         
         maxCertExpiryTimeMins = Integer.parseInt(System.getProperty(ZTSConsts.ZTS_PROP_CERTSIGN_MAX_EXPIRY_TIME, "43200"));
     }
 
     @Override
     public String generateX509Certificate(String csr, String keyUsage, int expiryTime) {
-        int certExpiryTime = expiryTime == 0 ? maxCertExpiryTimeMins * 60 : expiryTime;
+        int certExpiryTime = expiryTime == 0 ? maxCertExpiryTimeMins : expiryTime;
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(csr);
         X509Certificate cert = Crypto.generateX509Certificate(certReq, caPrivateKey,
                 caCertificate, certExpiryTime, false);


### PR DESCRIPTION
Crypto.generateX509Certificate expects the expiry time in mins, so there is no need to multiple by 60 our config for default use case.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
