### PR TITLE
add /zms/v1 path to the ZMS endpoint URL

### DIFF
--- a/clients/go/zms/examples/get-access/example.md
+++ b/clients/go/zms/examples/get-access/example.md
@@ -45,7 +45,7 @@ and create a service and obtain the TLS certificate in Athenz UI
     - zms-cli -d home.userid.movies add-policy editors_policy grant read to editors on rec.movie
 
   - go build
-  - ./get-access -zms https://zms-endpoint.com -cert /path/to/cert -key /path/to/key -domain home.userid -resource "home.userid:rec.movie" -action read
+  - ./get-access -zms https://<zms-endpoint-domain>:<port>/zms/v1 -cert /path/to/cert -key /path/to/key -domain home.userid -resource "home.userid:rec.movie" -action read
 
 
 ## License


### PR DESCRIPTION
PR adds the `zms/v1` path in the endpoint URL in the ZMS example for clarity.
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
