### PR TITLE
Refactor so that cert and key pem representation can be passed in memory.

### DIFF
--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
@@ -15,16 +15,21 @@
  */
 package com.oath.auth;
 
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
 import java.io.*;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
-import java.security.KeyManagementException;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.security.NoSuchAlgorithmException;
-import java.security.PrivateKey;
-import java.security.UnrecoverableKeyException;
+import java.security.*;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
@@ -32,18 +37,6 @@ import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.TrustManager;
-
-import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
-import org.bouncycastle.openssl.PEMKeyPair;
-import org.bouncycastle.openssl.PEMParser;
-import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class Utils {
 

--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
@@ -306,6 +306,10 @@ public class Utils {
         };
     }
 
+    static Supplier<InputStream> inputStreamSupplierFromString(String s) throws UncheckedIOException {
+        return () -> new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+    }
+
     /**
      * @param athenzPublicCert the location on the public certificate file
      * @param athenzPrivateKey the location of the private key file
@@ -370,9 +374,9 @@ public class Utils {
             final String athenzPublicCertPem,
             final String athenzPrivateKeyPem) throws IOException, KeyRefresherException {
         return createKeyStore(
-                () -> new ByteArrayInputStream(athenzPublicCertPem.getBytes(StandardCharsets.UTF_8)),
+                inputStreamSupplierFromString(athenzPublicCertPem),
                 () -> "in memory certificate pem",
-                () -> new ByteArrayInputStream(athenzPrivateKeyPem.getBytes(StandardCharsets.UTF_8)),
+                inputStreamSupplierFromString(athenzPrivateKeyPem),
                 () -> "in memory private key pem");
     }
 

--- a/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
+++ b/libs/java/cert_refresher/src/main/java/com/oath/auth/Utils.java
@@ -15,13 +15,9 @@
  */
 package com.oath.auth;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
+import java.io.*;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -35,6 +31,7 @@ import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.KeyManagerFactory;
@@ -54,16 +51,16 @@ public class Utils {
 
     private static final String SSLCONTEXT_ALGORITHM = "TLSv1.2";
     private static final String PROP_KEY_WAIT_TIME = "athenz.cert_refresher.key_wait_time";
-    
+
     private static final char[] KEYSTORE_PASSWORD = "secret".toCharArray();
-    
+
     private static final String DEFAULT_KEYSTORE_TYPE = "JKS";
-    
+
     // how long to wait for keys - default 10 mins
-    
+
     private static final long KEY_WAIT_TIME_MILLIS = TimeUnit.MINUTES.toMillis(
             Integer.parseInt(System.getProperty(PROP_KEY_WAIT_TIME, "10")));
-    
+
     public static KeyStore getKeyStore(final String jksFilePath) throws FileNotFoundException, IOException, KeyRefresherException {
         return getKeyStore(jksFilePath, KEYSTORE_PASSWORD);
     }
@@ -76,7 +73,7 @@ public class Utils {
         String keyStoreFailMsg = "Unable to load " + jksFilePath + " as a KeyStore.  Please check the validity of the file.";
         try {
             keyStore = KeyStore.getInstance(DEFAULT_KEYSTORE_TYPE);
-            
+
             ///CLOVER:OFF
             if (Paths.get(jksFilePath).isAbsolute()) {
                 // Can not cover this branch in unit test. Can not refer any files by absolute paths
@@ -95,7 +92,7 @@ public class Utils {
             } catch (NoSuchAlgorithmException | CertificateException e) {
                 throw new KeyRefresherException(keyStoreFailMsg, e);
             }
-            
+
         } catch (KeyStoreException ignored) {
             LOG.error("No Provider supports a KeyStoreSpi implementation for the specified type.", ignored);
         }
@@ -109,7 +106,7 @@ public class Utils {
             keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
             keyManagerFactory.init(keystore, KEYSTORE_PASSWORD);
         } catch (NoSuchAlgorithmException e) {
-            throw new KeyRefresherException("No Provider supports a KeyManagerFactorySpi implementation for the specified algorithm." , e);
+            throw new KeyRefresherException("No Provider supports a KeyManagerFactorySpi implementation for the specified algorithm.", e);
         } catch (UnrecoverableKeyException e) {
             throw new KeyRefresherException("key cannot be recovered (e.g. the given password is wrong).", e);
         } catch (KeyStoreException e) {
@@ -125,17 +122,18 @@ public class Utils {
      * the paths to the private key and certificate files along with the
      * trust-store path which has been created already and just needs to be
      * monitored for changes. Using default password of "secret" for both stores.
-     * @param trustStorePath path to the trust-store
+     *
+     * @param trustStorePath   path to the trust-store
      * @param athenzPublicCert path to the certificate file
      * @param athenzPrivateKey path to the private key file
      * @return KeyRefresher object
-     * @throws KeyRefresherException 
-     * @throws InterruptedException 
-     * @throws IOException 
-     * @throws FileNotFoundException 
+     * @throws KeyRefresherException
+     * @throws InterruptedException
+     * @throws IOException
+     * @throws FileNotFoundException
      */
     public static KeyRefresher generateKeyRefresher(final String trustStorePath,
-            final String athenzPublicCert, final String athenzPrivateKey)
+                                                    final String athenzPublicCert, final String athenzPrivateKey)
             throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
         return generateKeyRefresher(trustStorePath, KEYSTORE_PASSWORD, athenzPublicCert,
                 athenzPrivateKey, null);
@@ -148,23 +146,24 @@ public class Utils {
      * the paths to the private key and certificate files along with the
      * trust-store path which has been created already and just needs to be
      * monitored for changes.
-     * @param trustStorePath path to the trust-store
+     *
+     * @param trustStorePath     path to the trust-store
      * @param trustStorePassword trust store password
-     * @param athenzPublicCert path to the certificate file
-     * @param athenzPrivateKey path to the private key file
+     * @param athenzPublicCert   path to the certificate file
+     * @param athenzPrivateKey   path to the private key file
      * @return KeyRefresher object
-     * @throws KeyRefresherException 
-     * @throws InterruptedException 
-     * @throws IOException 
-     * @throws FileNotFoundException 
+     * @throws KeyRefresherException
+     * @throws InterruptedException
+     * @throws IOException
+     * @throws FileNotFoundException
      */
     public static KeyRefresher generateKeyRefresher(final String trustStorePath,
-            final String trustStorePassword, final String athenzPublicCert, final String athenzPrivateKey)
+                                                    final String trustStorePassword, final String athenzPublicCert, final String athenzPrivateKey)
             throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
         return generateKeyRefresher(trustStorePath, trustStorePassword.toCharArray(),
                 athenzPublicCert, athenzPrivateKey, null);
     }
-    
+
     /**
      * Generate the KeyRefresher object first as the server will need access to
      * it (to turn it off and on as needed). It requires that the proxies are
@@ -172,18 +171,19 @@ public class Utils {
      * the paths to the private key and certificate files along with the
      * trust-store path which has been created already and just needs to be
      * monitored for changes.
-     * @param trustStorePath path to the trust-store
+     *
+     * @param trustStorePath     path to the trust-store
      * @param trustStorePassword trust store password
-     * @param athenzPublicCert path to the certificate file
-     * @param athenzPrivateKey path to the private key file
+     * @param athenzPublicCert   path to the certificate file
+     * @param athenzPrivateKey   path to the private key file
      * @return KeyRefresher object
-     * @throws KeyRefresherException 
-     * @throws InterruptedException 
-     * @throws IOException 
-     * @throws FileNotFoundException 
+     * @throws KeyRefresherException
+     * @throws InterruptedException
+     * @throws IOException
+     * @throws FileNotFoundException
      */
     public static KeyRefresher generateKeyRefresher(final String trustStorePath,
-            final char[] trustStorePassword, final String athenzPublicCert, final String athenzPrivateKey)
+                                                    final char[] trustStorePassword, final String athenzPublicCert, final String athenzPrivateKey)
             throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
         return generateKeyRefresher(trustStorePath, trustStorePassword,
                 athenzPublicCert, athenzPrivateKey, null);
@@ -196,10 +196,11 @@ public class Utils {
      * the paths to the private key and certificate files along with the
      * trust-store path which has been created already and just needs to be
      * monitored for changes.
-     * @param trustStorePath path to the trust-store
-     * @param trustStorePassword trust store password
-     * @param athenzPublicCert path to the certificate file
-     * @param athenzPrivateKey path to the private key file
+     *
+     * @param trustStorePath       path to the trust-store
+     * @param trustStorePassword   trust store password
+     * @param athenzPublicCert     path to the certificate file
+     * @param athenzPrivateKey     path to the private key file
      * @param keyRefresherListener notify listener that key/cert has changed
      * @return KeyRefresher object
      * @throws KeyRefresherException
@@ -208,8 +209,8 @@ public class Utils {
      * @throws FileNotFoundException
      */
     public static KeyRefresher generateKeyRefresher(final String trustStorePath,
-            final char[] trustStorePassword, final String athenzPublicCert,
-            final String athenzPrivateKey, final KeyRefresherListener keyRefresherListener)
+                                                    final char[] trustStorePassword, final String athenzPublicCert,
+                                                    final String athenzPrivateKey, final KeyRefresherListener keyRefresherListener)
             throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
         TrustStore trustStore = new TrustStore(trustStorePath,
                 new JavaKeyStoreProvider(trustStorePath, trustStorePassword));
@@ -223,28 +224,29 @@ public class Utils {
      * the paths to the private key and certificate files along with the
      * trust-store path which has been created already and just needs to be
      * monitored for changes. Using default password of "secret" for both stores.
-     * @param caCertPath path to the trust-store
+     *
+     * @param caCertPath       path to the trust-store
      * @param athenzPublicCert path to the certificate file
      * @param athenzPrivateKey path to the private key file
      * @return KeyRefresher object
-     * @throws KeyRefresherException 
-     * @throws InterruptedException 
-     * @throws IOException 
-     * @throws FileNotFoundException 
+     * @throws KeyRefresherException
+     * @throws InterruptedException
+     * @throws IOException
+     * @throws FileNotFoundException
      */
     public static KeyRefresher generateKeyRefresherFromCaCert(final String caCertPath,
-            final String athenzPublicCert, final String athenzPrivateKey) throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
+                                                              final String athenzPublicCert, final String athenzPrivateKey) throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
         TrustStore trustStore = new TrustStore(caCertPath, new CaCertKeyStoreProvider(caCertPath));
         return getKeyRefresher(athenzPublicCert, athenzPrivateKey, trustStore);
     }
-    
+
     static KeyRefresher getKeyRefresher(String athenzPublicCert, String athenzPrivateKey,
-            TrustStore trustStore) throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
+                                        TrustStore trustStore) throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
         return getKeyRefresher(athenzPublicCert, athenzPrivateKey, trustStore, null);
     }
 
     static KeyRefresher getKeyRefresher(String athenzPublicCert, String athenzPrivateKey,
-            TrustStore trustStore, final KeyRefresherListener keyRefresherListener)
+                                        TrustStore trustStore, final KeyRefresherListener keyRefresherListener)
             throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
         KeyRefresher keyRefresher = null;
         KeyManagerProxy keyManagerProxy =
@@ -262,35 +264,56 @@ public class Utils {
     /**
      * this method will create a new SSLContext object that can be updated on the fly should the
      * public/private keys / trustStore change.
-     * @param keyManagerProxy uses standard KeyManager interface except also allows
-     *        for the updating of KeyManager on the fly
+     *
+     * @param keyManagerProxy   uses standard KeyManager interface except also allows
+     *                          for the updating of KeyManager on the fly
      * @param trustManagerProxy uses standard TrustManager interface except also allows
-     *        for the updating of TrustManager on the fly
+     *                          for the updating of TrustManager on the fly
      * @return a valid SSLContext object using the passed in key/trust managers
-     * @throws KeyRefresherException 
+     * @throws KeyRefresherException
      */
     public static SSLContext buildSSLContext(KeyManagerProxy keyManagerProxy,
-            TrustManagerProxy trustManagerProxy) throws KeyRefresherException {
+                                             TrustManagerProxy trustManagerProxy) throws KeyRefresherException {
         SSLContext sslContext = null;
         try {
             sslContext = SSLContext.getInstance(SSLCONTEXT_ALGORITHM);
-            sslContext.init(new KeyManager[]{ keyManagerProxy }, new TrustManager[] { trustManagerProxy }, null);
-        } catch (NoSuchAlgorithmException  e) {
-            throw new KeyRefresherException("No Provider supports a SSLContextSpi implementation for the specified protocol " + SSLCONTEXT_ALGORITHM , e);
+            sslContext.init(new KeyManager[]{keyManagerProxy}, new TrustManager[]{trustManagerProxy}, null);
+        } catch (NoSuchAlgorithmException e) {
+            throw new KeyRefresherException("No Provider supports a SSLContextSpi implementation for the specified protocol " + SSLCONTEXT_ALGORITHM, e);
         } catch (KeyManagementException e) {
             throw new KeyRefresherException("Unable to create SSLContext.", e);
-        } 
+        }
         return sslContext;
     }
-    
+
+    static Supplier<InputStream> inputStreamSupplierFromFile(File file) throws UncheckedIOException {
+        return () -> {
+            try {
+                return new FileInputStream(file);
+            } catch (FileNotFoundException e) {
+                throw new UncheckedIOException(e);
+            }
+        };
+    }
+
+    static Supplier<InputStream> inputStreamSupplierFromResource(String resource) throws UncheckedIOException {
+        return () -> {
+            InputStream ret = Utils.class.getClassLoader().getResourceAsStream(resource);
+            if (ret == null) {
+                throw new UncheckedIOException(new FileNotFoundException("Certificate or private key file is empty " + resource));
+            }
+            return ret;
+        };
+    }
+
     /**
      * @param athenzPublicCert the location on the public certificate file
      * @param athenzPrivateKey the location of the private key file
      * @return a KeyStore with loaded key and certificate
-     * @throws IOException 
-     * @throws FileNotFoundException 
-     * @throws InterruptedException 
-     * @throws KeyRefresherException 
+     * @throws IOException
+     * @throws FileNotFoundException
+     * @throws InterruptedException
+     * @throws KeyRefresherException
      */
     public static KeyStore createKeyStore(final String athenzPublicCert, final String athenzPrivateKey) throws FileNotFoundException, IOException, InterruptedException, KeyRefresherException {
         if (athenzPublicCert == null || athenzPublicCert.isEmpty()) {
@@ -299,16 +322,16 @@ public class Utils {
         if (athenzPrivateKey == null || athenzPrivateKey.isEmpty()) {
             throw new FileNotFoundException("athenzPrivateKey can not be empty");
         }
-        
-        List<? extends Certificate> certificates;
-        PrivateKey privateKey;
-        KeyStore keyStore = null;
-        File certFile;
-        File keyFile;
 
+        final Supplier<InputStream> certFileSupplier;
+        final Supplier<InputStream> keyFileSupplier;
+        final Supplier<String> certLocationSupplier = () -> athenzPublicCert;
+        final Supplier<String> keyLocationSupplier = () -> athenzPrivateKey;
         if (Paths.get(athenzPublicCert).isAbsolute() && Paths.get(athenzPrivateKey).isAbsolute()) {
-            certFile = new File(athenzPublicCert);
-            keyFile = new File(athenzPrivateKey);
+            final File certFile = new File(athenzPublicCert);
+            final File keyFile = new File(athenzPrivateKey);
+            certFileSupplier = inputStreamSupplierFromFile(certFile);
+            keyFileSupplier = inputStreamSupplierFromFile(keyFile);
             long startTime = System.currentTimeMillis();
             while (!certFile.exists() || !keyFile.exists()) {
                 long durationInMillis = System.currentTimeMillis() - startTime;
@@ -322,23 +345,65 @@ public class Utils {
                 Thread.sleep(1000);
             }
         } else {
-            URL certURL = Utils.class.getClassLoader().getResource(athenzPublicCert);
-            URL keyURL = Utils.class.getClassLoader().getResource(athenzPrivateKey);
-            if (null == certURL || null == keyURL) {
-                throw new IllegalArgumentException("Certificate or private key file is empty.");
-            }
-            certFile = new File(certURL.getFile());
-            keyFile = new File(keyURL.getFile());
+            certFileSupplier = inputStreamSupplierFromResource(athenzPublicCert);
+            keyFileSupplier = inputStreamSupplierFromResource(athenzPrivateKey);
         }
 
-        try (InputStream publicCertStream  = new FileInputStream(certFile);
-                InputStream privateKeyStream =  new FileInputStream(keyFile);
-                PEMParser pemParser = new PEMParser(new InputStreamReader(privateKeyStream))) {
+        // Pass input stream providers that throw unchecked exceptions which are caught and rethrown from here.
+        try {
+            return createKeyStore(certFileSupplier, certLocationSupplier, keyFileSupplier, keyLocationSupplier);
+        } catch (UncheckedIOException e) {
+            throw e.getCause();
+        }
+    }
+
+    /**
+     * Create a {@link KeyStore} from in-memory pem strings.
+     *
+     * @param athenzPublicCertPem The public certificate pem
+     * @param athenzPrivateKeyPem The private key pem
+     * @return a KeyStore with loaded key and certificate
+     * @throws IOException
+     * @throws KeyRefresherException
+     */
+    public static KeyStore createKeyStoreFromPems(
+            final String athenzPublicCertPem,
+            final String athenzPrivateKeyPem) throws IOException, KeyRefresherException {
+        return createKeyStore(
+                () -> new ByteArrayInputStream(athenzPublicCertPem.getBytes(StandardCharsets.UTF_8)),
+                () -> "in memory certificate pem",
+                () -> new ByteArrayInputStream(athenzPrivateKeyPem.getBytes(StandardCharsets.UTF_8)),
+                () -> "in memory private key pem");
+    }
+
+    /**
+     * Create a {@link KeyStore} from suppliers of {@link InputStream} for cert and key.
+     *
+     * @param athenzPublicCertInputStream      Supplier of the certificate input stream
+     * @param athenzPublicCertLocationSupplier Supplier of the location of the certificate (for error logging)
+     * @param athenzPrivateKeyInputStream      Supplier of the private key input stream
+     * @param athenzPrivateKeyLocationSupplier Supplier of the location of the certificate (for error logging)
+     * @return a KeyStore with loaded key and certificate
+     * @throws IOException
+     * @throws KeyRefresherException
+     */
+    public static KeyStore createKeyStore(
+            final Supplier<InputStream> athenzPublicCertInputStream,
+            final Supplier<String> athenzPublicCertLocationSupplier,
+            final Supplier<InputStream> athenzPrivateKeyInputStream,
+            final Supplier<String> athenzPrivateKeyLocationSupplier) throws IOException, KeyRefresherException {
+        List<? extends Certificate> certificates;
+        PrivateKey privateKey;
+        KeyStore keyStore = null;
+
+        try (InputStream publicCertStream = athenzPublicCertInputStream.get();
+             InputStream privateKeyStream = athenzPrivateKeyInputStream.get();
+             PEMParser pemParser = new PEMParser(new InputStreamReader(privateKeyStream))) {
 
             final CertificateFactory cf = CertificateFactory.getInstance("X.509");
             final JcaPEMKeyConverter pemConverter = new JcaPEMKeyConverter();
             Object key = pemParser.readObject();
-            
+
             if (key instanceof PEMKeyPair) {
                 PrivateKeyInfo pKeyInfo = ((PEMKeyPair) key).getPrivateKeyInfo();
                 privateKey = pemConverter.getPrivateKey(pKeyInfo);
@@ -348,26 +413,28 @@ public class Utils {
                 throw new KeyRefresherException("Unknown object type: " + key.getClass().getName());
             }
 
+            //noinspection unchecked
             certificates = (List<? extends Certificate>) cf.generateCertificates(publicCertStream);
             if (certificates.isEmpty()) {
                 throw new KeyRefresherException("Certificate file contains empty certificate or an invalid certificate.");
             }
-             //We are going to assume that the first one is the main certificate which will be used for the alias
+            //We are going to assume that the first one is the main certificate which will be used for the alias
             String alias = ((X509Certificate) certificates.get(0)).getSubjectX500Principal().getName();
             if (LOG.isDebugEnabled()) {
                 LOG.debug("{} number of certificates found.  Using {} alias to create the keystore", certificates.size(), alias);
             }
             keyStore = KeyStore.getInstance(DEFAULT_KEYSTORE_TYPE);
             keyStore.load(null);
-            keyStore.setKeyEntry(alias, privateKey, KEYSTORE_PASSWORD, certificates.toArray(new X509Certificate[certificates.size()]));
-        
-        } catch (CertificateException |  NoSuchAlgorithmException e) {
-            String keyStoreFailMsg = "Unable to load " + athenzPublicCert + " as a KeyStore.  Please check the validity of the file.";
+            keyStore.setKeyEntry(alias, privateKey, KEYSTORE_PASSWORD,
+                    certificates.toArray((Certificate[]) new X509Certificate[certificates.size()]));
+
+        } catch (CertificateException | NoSuchAlgorithmException e) {
+            String keyStoreFailMsg = "Unable to load " + athenzPublicCertLocationSupplier.get() + " as a KeyStore.  Please check the validity of the file.";
             throw new KeyRefresherException(keyStoreFailMsg, e);
         } catch (KeyStoreException ignored) {
             LOG.error("No Provider supports a KeyStoreSpi implementation for the specified type.", ignored);
         }
-        
+
         return keyStore;
     }
 
@@ -375,11 +442,12 @@ public class Utils {
      * Generate JKS X.509 Truststore based on given input stream.
      * It is expected that the input stream is a list of x.509
      * certificates.
+     *
      * @param inputStream input stream for the x.509 certificates.
      *                    caller responsible for closing the stream
      * @return KeyStore including all x.509 certificates
      * @throws IOException
-     * @throws KeyRefresherException 
+     * @throws KeyRefresherException
      */
     public static KeyStore generateTrustStore(InputStream inputStream) throws IOException, KeyRefresherException {
         CertificateFactory factory;
@@ -397,7 +465,7 @@ public class Utils {
             throw new KeyRefresherException(keyStoreFailMsg, e);
         } catch (KeyStoreException ignored) {
             LOG.error("No Provider supports a KeyStoreSpi implementation for the specified type " + DEFAULT_KEYSTORE_TYPE, ignored);
-        } 
+        }
         return keyStore;
     }
 }

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyStoreTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyStoreTest.java
@@ -20,24 +20,28 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 
+import com.google.common.io.Resources;
 import org.junit.Test;
 
 public class KeyStoreTest {
 
     static final String ALIAS_NAME = "cn=athenz.syncer,o=my test company,l=sunnyvale,st=ca,c=us";
-    
+
     @Test
     public void testGetKeyStore() throws Exception {
 
         KeyStore keyStore = Utils.getKeyStore("truststore.jks", "123456".toCharArray());
         assertNotNull(keyStore);
-        
+
         // default password is secret - key exception
-        
+
         try {
             Utils.getKeyStore("truststore.jks");
             fail();
@@ -52,7 +56,7 @@ public class KeyStoreTest {
         assertNotNull(keyStore);
         String alias = null;
         for (Enumeration<?> e = keyStore.aliases(); e.hasMoreElements(); ) {
-            alias = (String)e.nextElement();
+            alias = (String) e.nextElement();
             assertEquals(ALIAS_NAME, alias);
         }
         X509Certificate[] chain = (X509Certificate[]) keyStore.getCertificateChain(alias);
@@ -66,16 +70,35 @@ public class KeyStoreTest {
         assertNotNull(keyStore);
         String alias = null;
         for (Enumeration<?> e = keyStore.aliases(); e.hasMoreElements(); ) {
-            alias = (String)e.nextElement();
+            alias = (String) e.nextElement();
             assertEquals(ALIAS_NAME, alias);
         }
-        
+
         X509Certificate[] chain = (X509Certificate[]) keyStore.getCertificateChain(alias);
         assertNotNull(chain);
         assertTrue(chain.length == 2);
     }
-    
-    @Test (expected = KeyRefresherException.class)
+
+    @Test
+    public void testCreateKeyStoreFromPems() throws Exception {
+        String athenzPublicCertPem = Resources.toString(
+                Resources.getResource("rsa_public_x510_w_intermediate.cert"), StandardCharsets.UTF_8);
+        String athenzPrivateKeyPem = Resources.toString(
+                Resources.getResource("rsa_private.key"), StandardCharsets.UTF_8);
+        KeyStore keyStore = Utils.createKeyStoreFromPems(athenzPublicCertPem, athenzPrivateKeyPem);
+        assertNotNull(keyStore);
+        String alias = null;
+        for (Enumeration<?> e = keyStore.aliases(); e.hasMoreElements(); ) {
+            alias = (String) e.nextElement();
+            assertEquals(ALIAS_NAME, alias);
+        }
+
+        X509Certificate[] chain = (X509Certificate[]) keyStore.getCertificateChain(alias);
+        assertNotNull(chain);
+        assertTrue(chain.length == 2);
+    }
+
+    @Test(expected = KeyRefresherException.class)
     public void testCreateKeyStoreEmpty() throws Exception {
         Utils.createKeyStore("rsa_public_x510_empty.cert", "rsa_private.key");
     }

--- a/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyStoreTest.java
+++ b/libs/java/cert_refresher/src/test/java/com/oath/auth/KeyStoreTest.java
@@ -15,20 +15,15 @@
  */
 package com.oath.auth;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import com.google.common.io.Resources;
+import org.junit.Test;
 
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.util.Enumeration;
 
-import com.google.common.io.Resources;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 public class KeyStoreTest {
 


### PR DESCRIPTION
There are some instances (such as running in Hadoop) where the credentials are provided in-memory and shouldn't be written to file on a shared system. Athenz already has the code to parse `InputStream`, so refactoring to make a method `createKeyStoreFromPems` shared with the original `createKeyStore`.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
