### PR TITLE
Zms file sync change

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/FilePrivateKeyStore.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/FilePrivateKeyStore.java
@@ -16,9 +16,6 @@
 package com.yahoo.athenz.auth.impl;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 
 import com.yahoo.athenz.auth.ServerPrivateKey;
@@ -38,7 +35,6 @@ public class FilePrivateKeyStore implements PrivateKeyStore {
     public static final String ATHENZ_PROP_PRIVATE_EC_KEY_ID = "athenz.auth.private_key_store.private_ec_key_id";
     public static final String ATHENZ_PROP_PRIVATE_RSA_KEY = "athenz.auth.private_key_store.private_rsa_key";
     public static final String ATHENZ_PROP_PRIVATE_RSA_KEY_ID = "athenz.auth.private_key_store.private_rsa_key_id";
-    private static final String ATHENZ_STR_JAR_RESOURCE = "JAR_RESOURCE:";
 
     private static final String ZMS_SERVICE = "zms";
     private static final String ZTS_SERVICE = "zts";
@@ -103,59 +99,19 @@ public class FilePrivateKeyStore implements PrivateKeyStore {
         final String privKeyName = System.getProperty(ATHENZ_PROP_PRIVATE_KEY);
         
         if (LOG.isDebugEnabled()) {
-            LOG.debug("FilePrivateKeyStore: private key file=" + privKeyName);
+            LOG.debug("FilePrivateKeyStore: private key file={}", privKeyName);
         }
         
         if (privKeyName == null) {
             return null;
         }
+
+        File privKeyFile = new File(privKeyName);
+        PrivateKey pkey = Crypto.loadPrivateKey(privKeyFile);
         
-        // check to see if this is running in dev mode and thus it's
-        // a resource in our jar file
-        
-        String privKey;
-        if (privKeyName.startsWith(ATHENZ_STR_JAR_RESOURCE)) {
-            privKey = retrieveKeyFromResource(privKeyName.substring(ATHENZ_STR_JAR_RESOURCE.length()));
-        } else {
-            File privKeyFile = new File(privKeyName);
-            privKey = Crypto.encodedFile(privKeyFile);
-        }
-        
-        PrivateKey pkey = Crypto.loadPrivateKey(Crypto.ybase64DecodeString(privKey));
         if (pkey != null) {
             privateKeyId.append(System.getProperty(ATHENZ_PROP_PRIVATE_KEY_ID, "0"));
         }
         return pkey;
-    }
-
-    private String retrieveKeyFromResource(String resourceName) {
-        
-        String key = null;
-        try (InputStream is = getClass().getResourceAsStream(resourceName)) {
-            String resourceData = getString(is);
-            if (resourceData != null) {
-                key = Crypto.ybase64(resourceData.getBytes(StandardCharsets.UTF_8));
-            }
-        } catch (IOException e) {
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("FilePrivateKeyStore: Unable to read key from resource: " + resourceName);
-            }
-        }
-        
-        return key;
-    }
-    
-    String getString(InputStream is) throws IOException {
-        
-        if (is == null) {
-            return null;
-        }
-        
-        int ch;
-        StringBuilder sb = new StringBuilder();
-        while ((ch = is.read()) != -1) {
-            sb.append((char) ch);
-        }
-        return sb.toString();
     }
 }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/FilePrivateKeyStore.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/FilePrivateKeyStore.java
@@ -21,6 +21,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 
+import com.yahoo.athenz.auth.ServerPrivateKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,16 +34,73 @@ public class FilePrivateKeyStore implements PrivateKeyStore {
     
     public static final String ATHENZ_PROP_PRIVATE_KEY = "athenz.auth.private_key_store.private_key";
     public static final String ATHENZ_PROP_PRIVATE_KEY_ID = "athenz.auth.private_key_store.private_key_id";
+    public static final String ATHENZ_PROP_PRIVATE_EC_KEY = "athenz.auth.private_key_store.private_ec_key";
+    public static final String ATHENZ_PROP_PRIVATE_EC_KEY_ID = "athenz.auth.private_key_store.private_ec_key_id";
+    public static final String ATHENZ_PROP_PRIVATE_RSA_KEY = "athenz.auth.private_key_store.private_rsa_key";
+    public static final String ATHENZ_PROP_PRIVATE_RSA_KEY_ID = "athenz.auth.private_key_store.private_rsa_key_id";
     private static final String ATHENZ_STR_JAR_RESOURCE = "JAR_RESOURCE:";
 
+    private static final String ZMS_SERVICE = "zms";
+    private static final String ZTS_SERVICE = "zts";
+
+    private static final String ALGO_RSA = "RSA";
+    private static final String ALGO_EC = "EC";
+
     public FilePrivateKeyStore() {
+    }
+
+    @Override
+    public ServerPrivateKey getPrivateKey(String service, String serverHostName,
+            String serverRegion, String algorithm) {
+
+        // validate our service and algorithm values
+
+        if (!ZMS_SERVICE.equalsIgnoreCase(service) && !ZTS_SERVICE.equalsIgnoreCase(service)) {
+            LOG.error("FilePrivateKeyStore: unknown service: {}", service);
+            return null;
+        }
+
+        if (!ALGO_RSA.equalsIgnoreCase(algorithm) && !ALGO_EC.equalsIgnoreCase(algorithm)) {
+            LOG.error("FilePrivateKeyStore: unknown algorithm: {}", algorithm);
+            return null;
+        }
+
+        String privKeyName;
+        String privKeyId;
+        if (ALGO_RSA.equalsIgnoreCase(algorithm)) {
+            privKeyName = System.getProperty(ATHENZ_PROP_PRIVATE_RSA_KEY);
+            privKeyId = System.getProperty(ATHENZ_PROP_PRIVATE_RSA_KEY_ID, "0");
+        } else {
+            privKeyName = System.getProperty(ATHENZ_PROP_PRIVATE_EC_KEY);
+            privKeyId = System.getProperty(ATHENZ_PROP_PRIVATE_EC_KEY_ID, "0");
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("FilePrivateKeyStore: private key file: {}, id: {}", privKeyName, privKeyId);
+        }
+
+        if (privKeyName == null) {
+            return null;
+        }
+
+        // check to see if this is running in dev mode and thus it's
+        // a resource in our jar file
+
+        File privKeyFile = new File(privKeyName);
+        PrivateKey pkey = Crypto.loadPrivateKey(privKeyFile);
+
+        ServerPrivateKey privateKey = null;
+        if (pkey != null) {
+            privateKey = new ServerPrivateKey(pkey, privKeyId);
+        }
+        return privateKey;
     }
 
     @Override
     public PrivateKey getPrivateKey(String service, String serverHostName,
             StringBuilder privateKeyId) {
         
-        String privKeyName = System.getProperty(ATHENZ_PROP_PRIVATE_KEY);
+        final String privKeyName = System.getProperty(ATHENZ_PROP_PRIVATE_KEY);
         
         if (LOG.isDebugEnabled()) {
             LOG.debug("FilePrivateKeyStore: private key file=" + privKeyName);
@@ -56,24 +114,20 @@ public class FilePrivateKeyStore implements PrivateKeyStore {
         // a resource in our jar file
         
         String privKey;
-        ///CLOVER:OFF
         if (privKeyName.startsWith(ATHENZ_STR_JAR_RESOURCE)) {
             privKey = retrieveKeyFromResource(privKeyName.substring(ATHENZ_STR_JAR_RESOURCE.length()));
         } else {
-            ///CLOVER:ON
             File privKeyFile = new File(privKeyName);
             privKey = Crypto.encodedFile(privKeyFile);
         }
         
         PrivateKey pkey = Crypto.loadPrivateKey(Crypto.ybase64DecodeString(privKey));
-        ///CLOVER:OFF
         if (pkey != null) {
             privateKeyId.append(System.getProperty(ATHENZ_PROP_PRIVATE_KEY_ID, "0"));
         }
-        ///CLOVER:ON
         return pkey;
     }
-    ///CLOVER:OFF
+
     private String retrieveKeyFromResource(String resourceName) {
         
         String key = null;
@@ -104,5 +158,4 @@ public class FilePrivateKeyStore implements PrivateKeyStore {
         }
         return sb.toString();
     }
-    ///CLOVER:ON
 }

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/FilePrivateKeyStoreTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/FilePrivateKeyStoreTest.java
@@ -17,12 +17,9 @@ package com.yahoo.athenz.auth.impl;
 
 import static org.testng.Assert.*;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 
+import com.yahoo.athenz.auth.ServerPrivateKey;
 import org.testng.annotations.Test;
 
 import com.yahoo.athenz.auth.PrivateKeyStore;
@@ -35,7 +32,8 @@ public class FilePrivateKeyStoreTest {
         PrivateKeyStore store = factory.create();
         assertNotNull(store);
     }
-    
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testRetrievePrivateKeyValid() {
         
@@ -56,7 +54,73 @@ public class FilePrivateKeyStoreTest {
             System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, saveProp);
         }
     }
-    
+
+    @Test
+    public void testRetrieveRSAPrivateKeyValid() {
+
+        FilePrivateKeyStoreFactory factory = new FilePrivateKeyStoreFactory();
+        PrivateKeyStore store = factory.create();
+
+        String saveProp = System.getProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY);
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY,
+                "src/test/resources/zts_private_k0.key");
+
+        ServerPrivateKey privKey = store.getPrivateKey("zms", "localhost", "us-east-1", "rsa");
+        assertNotNull(privKey);
+
+        if (saveProp == null) {
+            System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY);
+        } else {
+            System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY, saveProp);
+        }
+    }
+
+    @Test
+    public void testRetrieveECPrivateKeyValid() {
+
+        FilePrivateKeyStoreFactory factory = new FilePrivateKeyStoreFactory();
+        PrivateKeyStore store = factory.create();
+
+        String saveProp = System.getProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY);
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY,
+                "src/test/resources/ec_private.key");
+
+        ServerPrivateKey privKey = store.getPrivateKey("zms", "localhost", "us-east-1", "ec");
+        assertNotNull(privKey);
+
+        if (saveProp == null) {
+            System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY);
+        } else {
+            System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY, saveProp);
+        }
+    }
+
+    @Test
+    public void testRetrieveAlgoPrivateKeyInalid() {
+
+        FilePrivateKeyStoreFactory factory = new FilePrivateKeyStoreFactory();
+        PrivateKeyStore store = factory.create();
+
+        String saveProp = System.getProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY);
+
+        assertNull(store.getPrivateKey("app", "localhost", "us-east-1", "ec"));
+        assertNull(store.getPrivateKey("zms", "localhost", "us-east-1", "unknown"));
+
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY);
+        assertNull(store.getPrivateKey("zms", "localhost", "us-east-1", "ec"));
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY,
+                "src/test/resources/ec_public_invalid.key");
+        assertNull(store.getPrivateKey("zms", "localhost", "us-east-1", "ec"));
+
+        if (saveProp == null) {
+            System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY);
+        } else {
+            System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY, saveProp);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
     @Test
     public void testRetrievePrivateKeyInValid() {
         
@@ -83,26 +147,6 @@ public class FilePrivateKeyStoreTest {
             System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY);
         } else {
             System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, saveProp);
-        }
-    }
-    
-    @Test
-    public void testGetStringNullStream() throws IOException {
-
-        FilePrivateKeyStoreFactory factory = new FilePrivateKeyStoreFactory();
-        FilePrivateKeyStore store = (FilePrivateKeyStore) factory.create();
-        assertNull(store.getString(null));
-    }
-    
-    @Test
-    public void testGetString() throws IOException {
-        String str = "This is a Unit Test String";
-        
-        FilePrivateKeyStoreFactory factory = new FilePrivateKeyStoreFactory();
-        FilePrivateKeyStore store = (FilePrivateKeyStore) factory.create();
-        try (InputStream is = new ByteArrayInputStream(str.getBytes(StandardCharsets.UTF_8))) {
-            String getStr = store.getString(is);
-            assertEquals(getStr, str);
         }
     }
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/ChangeLogStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/ChangeLogStore.java
@@ -28,12 +28,19 @@ import com.yahoo.athenz.zms.SignedDomains;
 public interface ChangeLogStore {
     
     /**
-     * Gets the associated domain data for the key
+     * Gets the associated local domain data for the key
      * @param domainName the name of the domain
      * @return SignedDomain object of the domain or null if absent
      */
-    SignedDomain getSignedDomain(String domainName);
-    
+    SignedDomain getLocalSignedDomain(String domainName);
+
+    /**
+     * Gets the associated server domain data for the key
+     * @param domainName the name of the domain
+     * @return SignedDomain object of the domain or null if absent
+     */
+    SignedDomain getServerSignedDomain(String domainName);
+
     /**
      * Remove the local domain record from the changelog store
      * @param domainName the name of the domain
@@ -58,7 +65,15 @@ public interface ChangeLogStore {
      * @return Set of domain names
      */
     Set<String> getServerDomainList();
-    
+
+    /**
+     * Returns the list of domains configured on the server
+     * with their meta attributes only - primary interest being
+     * the last modification timestamp
+     * @return Array of SignedDomain objects
+     */
+    SignedDomains getServerDomainModifiedList();
+
     /**
      * Returns the list of domains modified since the last call
      * @param lastModTimeBuffer StringBuilder object will be updated to include

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/store/DataStore.java
@@ -17,7 +17,6 @@ package com.yahoo.athenz.zts.store;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-import com.yahoo.athenz.zms.*;
 import com.yahoo.athenz.zts.*;
 import com.yahoo.athenz.zts.ResourceException;
 import com.yahoo.rdl.*;
@@ -25,6 +24,10 @@ import com.yahoo.athenz.auth.util.Crypto;
 import com.yahoo.athenz.common.config.AthenzConfig;
 import com.yahoo.athenz.common.server.util.StringUtils;
 import com.yahoo.athenz.common.utils.SignUtils;
+import com.yahoo.athenz.zms.DomainData;
+import com.yahoo.athenz.zms.Role;
+import com.yahoo.athenz.zms.SignedDomain;
+import com.yahoo.athenz.zms.SignedDomains;
 import com.yahoo.athenz.zts.cache.DataCache;
 import com.yahoo.athenz.zts.cache.DataCacheProvider;
 import com.yahoo.athenz.zts.cache.MemberRole;

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -10513,4 +10513,41 @@ public class ZTSImplTest {
 
         System.clearProperty(ZTSConsts.ZTS_PROP_CERT_BUNDLES_FNAME);
     }
+
+    @Test
+    public void testLoadServerPrivateKey() {
+
+        // first we try with ec private key only
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY, "src/test/resources/zts_private_ec.pem");
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY);
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY);
+
+        zts.loadServicePrivateKey();
+        assertNotNull(zts.privateECKey);
+        assertEquals(zts.privateKey, zts.privateECKey);
+        assertNull(zts.privateRSAKey);
+
+        // now let's try the rsa key
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY, "src/test/resources/zts_private.pem");
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY);
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY);
+
+        zts.loadServicePrivateKey();
+        assertNotNull(zts.privateRSAKey);
+        assertEquals(zts.privateKey, zts.privateRSAKey);
+        assertNull(zts.privateECKey);
+
+        // now back to our regular key setup
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/zts_private.pem");
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_EC_KEY);
+        System.clearProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_RSA_KEY);
+
+        zts.loadServicePrivateKey();
+        assertNotNull(zts.privateKey);
+        assertNull(zts.privateECKey);
+        assertNull(zts.privateRSAKey);
+    }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/MockZMSFileChangeLogStore.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/MockZMSFileChangeLogStore.java
@@ -33,9 +33,9 @@ import com.yahoo.athenz.zts.ZTSConsts;
 
 public class MockZMSFileChangeLogStore extends ZMSFileChangeLogStore {
 
-    private final ZMSClient zms;
-    private DomainList domList = null;
+    private ZMSClient zms;
     private String tagHeader;
+    private boolean refreshSupport = false;
 
     public MockZMSFileChangeLogStore(String rootDirectory, PrivateKey privateKey, String privateKeyId) {
         
@@ -60,7 +60,6 @@ public class MockZMSFileChangeLogStore extends ZMSFileChangeLogStore {
         
         tagHeader = "2014-01-01T12:00:00";
         when(zms.getDomainList()).thenReturn(localDomainList).thenReturn(serverDomainList);
-        
     }
     
     @Override
@@ -68,9 +67,13 @@ public class MockZMSFileChangeLogStore extends ZMSFileChangeLogStore {
         return zms;
     }
 
+    public void setZMSClient(ZMSClient zms) {
+        this.zms = zms;
+    }
+
     public void setDomainList(List<String> domains) {
         if (domains != null) {
-            domList = new DomainList();
+            DomainList domList = new DomainList();
             domList.setNames(domains);
             when(zms.getDomainList()).thenReturn(domList);
         } else {
@@ -101,5 +104,14 @@ public class MockZMSFileChangeLogStore extends ZMSFileChangeLogStore {
         } else {
             return tagHeader;
         }
+    }
+
+    public void setRefreshSupport(boolean refreshSupport) {
+        this.refreshSupport = refreshSupport;
+    }
+
+    @Override
+    public boolean supportsFullRefresh() {
+        return refreshSupport;
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/S3ChangeLogStoreTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/store/impl/S3ChangeLogStoreTest.java
@@ -122,10 +122,9 @@ public class S3ChangeLogStoreTest {
         tempList.add(s3ObjectSummary);
         when(mockObjectListing.getObjectSummaries()).thenReturn(tempList);
 
-
-            List<String> temp = store.getLocalDomainList();
-            assertNotNull(temp);
-            store.getSignedDomain("iaas");
+        List<String> temp = store.getLocalDomainList();
+        assertNotNull(temp);
+        store.getLocalSignedDomain("iaas");
     }
 
     @Test
@@ -512,26 +511,38 @@ public class S3ChangeLogStoreTest {
         // first we'll return null from our s3 client
 
         store.resetAWSS3Client();
-        SignedDomain signedDomain = store.getSignedDomain("iaas");
+        SignedDomain signedDomain = store.getLocalSignedDomain("iaas");
         assertNull(signedDomain);
 
         // next setup our mock aws return object
 
         when(store.awsS3Client.getObject("s3-unit-test-bucket-name", "iaas")).thenReturn(object);
-        signedDomain = store.getSignedDomain("iaas");
+        signedDomain = store.getLocalSignedDomain("iaas");
         assertNotNull(signedDomain);
 
         DomainData domainData = signedDomain.getDomain();
         assertNotNull(domainData);
         assertEquals(domainData.getName(), "iaas");
 
-        signedDomain = store.getSignedDomain("iaas");
+        signedDomain = store.getLocalSignedDomain("iaas");
         assertNotNull(signedDomain);
 
         is1.close();
         is2.close();
     }
-    
+
+    @Test
+    public void testGetServerSignedDomain() {
+        MockS3ChangeLogStore store = new MockS3ChangeLogStore(null);
+        assertNull(store.getServerSignedDomain("iaas"));
+    }
+
+    @Test
+    public void testGetServerDomainModifiedList() {
+        MockS3ChangeLogStore store = new MockS3ChangeLogStore(null);
+        assertNull(store.getServerDomainModifiedList());
+    }
+
     @Test
     public void testGetSignedDomainException() throws IOException {
         MockS3ChangeLogStore store = new MockS3ChangeLogStore(null);
@@ -547,7 +558,7 @@ public class S3ChangeLogStoreTest {
         when(store.awsS3Client.getObject("s3-unit-test-bucket-name", "iaas"))
                 .thenThrow(new AmazonServiceException("test")).thenReturn(object);
         
-        SignedDomain signedDomain = store.getSignedDomain("iaas");
+        SignedDomain signedDomain = store.getLocalSignedDomain("iaas");
         assertNotNull(signedDomain);
         DomainData domainData = signedDomain.getDomain();
         assertNotNull(domainData);


### PR DESCRIPTION
improve zms domain sync carried out from zts. now by default every 10 mins, zms server will retrieve the list of domains from zms and compare the last modified timestamp for each one against the data cached and stored locally in zts. in case there are any domains that are not in sync, the method will retrieve the domain from zms and sync. 

this does not affect the aws s3 storage plugin since we always read from the synced S3 bucket in AWS during each deployment.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
