### PR TITLE
system admin option to reset domain last modified timestamp

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -4285,4 +4285,15 @@ public class DBService {
         }
         return noActionMembers;
     }
+
+    void updateDomainModTimestamp(final String domainName) {
+
+        try (ObjectStoreConnection con = store.getConnection(true, true)) {
+
+            // update domain time-stamps, and invalidate local cache entry
+
+            con.updateDomainModTimestamp(domainName);
+            cacheStore.invalidate(domainName);
+        }
+    }
 }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -248,6 +248,7 @@ public final class ZMSConsts {
     public static final String SYSTEM_META_AUDIT_ENABLED   = "auditenabled";
     public static final String SYSTEM_META_ENABLED         = "enabled";
     public static final String SYSTEM_META_ORG             = "org";
+    public static final String SYSTEM_META_LAST_MOD_TIME   = "modified";
 
     // HTTP operation types used in metrics
     public static final String HTTP_GET     = "GET";

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -1745,7 +1745,13 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
              throw ZMSUtils.requestError("Unique Product Id must be specified for top level domain", caller);
         }
 
-        dbService.executePutDomainMeta(ctx, domainName, meta, attribute, deleteAllowed, auditRef, caller);
+        // if this is just to update the timestamp then we will handle it separately
+
+        if (ZMSConsts.SYSTEM_META_LAST_MOD_TIME.equals(attribute)) {
+            dbService.updateDomainModTimestamp(domainName);
+        } else {
+            dbService.executePutDomainMeta(ctx, domainName, meta, attribute, deleteAllowed, auditRef, caller);
+        }
         metric.stopTiming(timerMetric, domainName, principalDomain);
     }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -1798,6 +1798,31 @@ public class ZMSImplTest {
     }
 
     @Test
+    public void testPutDomainSystemMetaModifiedTimestamp() throws InterruptedException {
+
+        final String domainName = "metadomainmodified";
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
+                "Test Domain1", "testOrg", adminUser);
+        zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
+
+        Domain resDom1 = zms.getDomain(mockDomRsrcCtx, domainName);
+        assertNotNull(resDom1);
+        long domMod1 = resDom1.getModified().millis();
+
+        Thread.sleep(1);
+
+        DomainMeta meta = new DomainMeta();
+        zms.putDomainSystemMeta(mockDomRsrcCtx, domainName, "modified", auditRef, meta);
+
+        Domain resDom2 = zms.getDomain(mockDomRsrcCtx, domainName);
+        assertNotNull(resDom2);
+        long domMod2 = resDom2.getModified().millis();
+
+        assertTrue(domMod2 > domMod1);
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
+    }
+
+    @Test
     public void testPutDomainMetaInvalid() {
 
         // enable product id support


### PR DESCRIPTION
if we need to make sure a domain is synced from zts to zms, this option would allow system admins to change the last modified timestamp thus marking the domain as changed rather than asking the domain admin to make some change that is not necessary in the domain.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
