### PR TITLE
config option to specify tls version for jdbc connections

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -55,6 +55,7 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_JDBC_APP_NAME           = "athenz.zms.jdbc_app_name";
     public static final String ZMS_PROP_JDBC_VERIFY_SERVER_CERT = "athenz.zms.jdbc_verify_server_certificate";
     public static final String ZMS_PROP_JDBC_USE_SSL            = "athenz.zms.jdbc_use_ssl";
+    public static final String ZMS_PROP_JDBC_TLS_VERSIONS       = "athenz.zms.jdbc_tls_versions";
 
     public static final String ZMS_PROP_FILE_STORE_NAME   = "athenz.zms.file_store_name";
     public static final String ZMS_PROP_FILE_STORE_QUOTA  = "athenz.zms.file_store_quota";
@@ -77,6 +78,7 @@ public final class ZMSConsts {
     public static final String DB_PROP_PASSWORD           = "password";
     public static final String DB_PROP_USE_SSL            = "useSSL";
     public static final String DB_PROP_VERIFY_SERVER_CERT = "verifyServerCertificate";
+    public static final String DB_PROP_TLS_PROTOCOLS      = "enabledTLSProtocols";
 
     public static final String ZMS_PROP_USER_AUTHORITY_CLASS      = "athenz.zms.user_authority_class";
     public static final String ZMS_PROP_PRINCIPAL_AUTHORITY_CLASS = "athenz.zms.principal_authority_class";

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/JDBCObjectStoreFactory.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/impl/JDBCObjectStoreFactory.java
@@ -44,6 +44,8 @@ public class JDBCObjectStoreFactory implements ObjectStoreFactory {
                 System.getProperty(ZMSConsts.ZMS_PROP_JDBC_VERIFY_SERVER_CERT, "false"));
         readWriteProperties.setProperty(ZMSConsts.DB_PROP_USE_SSL,
                 System.getProperty(ZMSConsts.ZMS_PROP_JDBC_USE_SSL, "false"));
+        readWriteProperties.setProperty(ZMSConsts.DB_PROP_TLS_PROTOCOLS,
+                System.getProperty(ZMSConsts.ZMS_PROP_JDBC_TLS_VERSIONS, "TLSv1.2,TLSv1.3"));
 
         PoolableDataSource readWriteSrc = DataSourceFactory.create(jdbcStore, readWriteProperties);
         
@@ -65,6 +67,8 @@ public class JDBCObjectStoreFactory implements ObjectStoreFactory {
                     System.getProperty(ZMSConsts.ZMS_PROP_JDBC_VERIFY_SERVER_CERT, "false"));
             readOnlyProperties.setProperty(ZMSConsts.DB_PROP_USE_SSL,
                     System.getProperty(ZMSConsts.ZMS_PROP_JDBC_USE_SSL, "false"));
+            readOnlyProperties.setProperty(ZMSConsts.DB_PROP_TLS_PROTOCOLS,
+                    System.getProperty(ZMSConsts.ZMS_PROP_JDBC_TLS_VERSIONS, "TLSv1.2,TLSv1.3"));
             readOnlySrc = DataSourceFactory.create(jdbcReadOnlyStore, readOnlyProperties);
         }
         


### PR DESCRIPTION
When mysql/j connector talks to a database that it doesn't recognize as supporting tls 1.2 (from their docs: TLSv1,TLSv1.1,TLSv1.2,TLSv1.3 for MySQL Community Servers 8.0, 5.7.28 and later, and 5.6.46 and later, and for all commercial versions of MySQL Servers) it defaults back to tls 1.0 and 1.1 only. This breaks if we want to use tls 1.2 with AWS Aurora unless you explicitly enable tls 1.2 support in the connector.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
