### PR TITLE
Notifications for unrefreshed certificates - Separating EmailNotificationService from providers

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/EmailProvider.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/EmailProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Oath Holdings Inc.
+ * Copyright 2020 Verizon Media
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,19 @@
 
 package com.yahoo.athenz.common.server.notification;
 
-public interface NotificationService {
+import java.util.Collection;
+
+public interface EmailProvider {
 
     /**
-     * send out the notification
-     * @param notification - notification to be sent containing notification type, recipients and additional details
-     * @return status of sent notification
+     * Send an email through the provider
+     * @param subject
+     * @param body
+     * @param status
+     * @param recipients
+     * @param from
+     * @param logoImage
+     * @return true if mail was sent
      */
-    boolean notify (Notification notification);
+    boolean sendEmail(String subject, String body, boolean status, Collection<String> recipients, String from, byte[] logoImage);
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationServiceConstants.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/NotificationServiceConstants.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Verizon Media
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.common.server.notification;
+
+public final class NotificationServiceConstants {
+    public static final String NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL           = "MEMBERSHIP_APPROVAL";
+    public static final String NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL_REMINDER  = "MEMBERSHIP_APPROVAL_REMINDER";
+    public static final String NOTIFICATION_TYPE_PRINCIPAL_EXPIRY_REMINDER     = "PRINCIPAL_EXPIRY_REMINDER";
+    public static final String NOTIFICATION_TYPE_DOMAIN_MEMBER_EXPIRY_REMINDER = "DOMAIN_MEMBER_EXPIRY_REMINDER";
+
+    public static final String NOTIFICATION_DETAILS_DOMAIN         = "domain";
+    public static final String NOTIFICATION_DETAILS_ROLE           = "role";
+    public static final String NOTIFICATION_DETAILS_MEMBER         = "member";
+    public static final String NOTIFICATION_DETAILS_REASON         = "reason";
+    public static final String NOTIFICATION_DETAILS_REQUESTER      = "requester";
+    public static final String NOTIFICATION_DETAILS_EXPIRY_ROLES   = "expiryRoles";
+    public static final String NOTIFICATION_DETAILS_EXPIRY_MEMBERS = "expiryMembers";
+
+    public static final String HTML_LOGO_CID_PLACEHOLDER = "<logo>";
+    public static final String CHARSET_UTF_8 = "UTF-8";
+
+    private NotificationServiceConstants() {
+    }
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProvider.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProvider.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Verizon Media
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.common.server.notification.impl;
+
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
+import com.amazonaws.services.simpleemail.model.RawMessage;
+import com.amazonaws.services.simpleemail.model.SendRawEmailRequest;
+import com.amazonaws.services.simpleemail.model.SendRawEmailResult;
+import com.yahoo.athenz.common.server.notification.EmailProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeBodyPart;
+import javax.mail.internet.MimeMessage;
+import javax.mail.internet.MimeMultipart;
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.util.Collection;
+import java.util.Properties;
+
+import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.CHARSET_UTF_8;
+import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.HTML_LOGO_CID_PLACEHOLDER;
+
+public class AWSEmailProvider implements EmailProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AWSEmailProvider.class);
+    private final AmazonSimpleEmailService ses;
+
+    @Override
+    public boolean sendEmail(String subject, String body, boolean status, Collection<String> recipients, String from, byte[] logoImage) {
+        try {
+            Session session = Session.getDefaultInstance(new Properties());
+
+            // Create a new MimeMessage object.
+            MimeMessage message = new MimeMessage(session);
+
+            // Add subject, from and to lines.
+            message.setSubject(subject, CHARSET_UTF_8);
+            message.setFrom(new InternetAddress(from));
+            message.setRecipients(javax.mail.Message.RecipientType.BCC, InternetAddress.parse(String.join(",", recipients)));
+
+            // Create a multipart/alternative child container.
+            MimeMultipart msgBody = new MimeMultipart("alternative");
+
+            // Create a wrapper for the HTML and text parts.
+            MimeBodyPart wrap = new MimeBodyPart();
+
+            // Set the text part.
+            MimeBodyPart textPart = new MimeBodyPart();
+            textPart.setContent(body, "text/plain; charset=" + CHARSET_UTF_8);
+
+            // Set the HTML part.
+            MimeBodyPart htmlPart = new MimeBodyPart();
+            htmlPart.setContent(body, "text/html; charset=" + CHARSET_UTF_8);
+
+            // Add the text and HTML parts to the child container.
+            msgBody.addBodyPart(textPart);
+            msgBody.addBodyPart(htmlPart);
+
+            // Add the child container to the wrapper object.
+            wrap.setContent(msgBody);
+
+            // Create a multipart/mixed parent container.
+            MimeMultipart msgParent = new MimeMultipart("related");
+
+            // Add the multipart/alternative part to the message.
+            msgParent.addBodyPart(wrap);
+
+            // Add the parent container to the message.
+            message.setContent(msgParent);
+
+            if (logoImage != null) {
+                MimeBodyPart logo = new MimeBodyPart();
+                logo.setContent(logoImage, "image/png");
+                logo.setContentID(HTML_LOGO_CID_PLACEHOLDER);
+                logo.setDisposition(MimeBodyPart.INLINE);
+                // Add the attachment to the message.
+                msgParent.addBodyPart(logo);
+            }
+
+            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+                message.writeTo(outputStream);
+                RawMessage rawMessage = new RawMessage(ByteBuffer.wrap(outputStream.toByteArray()));
+                SendRawEmailRequest rawEmailRequest = new SendRawEmailRequest(rawMessage);
+                SendRawEmailResult result = ses.sendRawEmail(rawEmailRequest);
+                if (LOGGER.isDebugEnabled()) {
+                    LOGGER.debug("Email with messageId={} sent successfully.", result.getMessageId());
+                }
+                status = status && result != null;
+            }
+        } catch (Exception ex) {
+            LOGGER.error("The email could not be sent. Error message: {}", ex.getMessage());
+            status = false;
+        }
+        return status;    }
+
+    AWSEmailProvider() {
+        this(initSES());
+    }
+
+    AWSEmailProvider(AmazonSimpleEmailService ses) {
+        this.ses = ses;
+    }
+
+    private static AmazonSimpleEmailService initSES() {
+        ///CLOVER:OFF
+        Region region = Regions.getCurrentRegion();
+        if (region == null) {
+            region = Region.getRegion(Regions.US_EAST_1);
+        }
+        return AmazonSimpleEmailServiceClientBuilder.standard().withRegion(region.getName()).build();
+        ///CLOVER:ON
+    }
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationService.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationService.java
@@ -16,40 +16,33 @@
 
 package com.yahoo.athenz.common.server.notification.impl;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailServiceClientBuilder;
-import com.amazonaws.services.simpleemail.model.*;
 import com.amazonaws.util.IOUtils;
+import com.yahoo.athenz.common.server.notification.EmailProvider;
 import com.yahoo.athenz.common.server.notification.Notification;
 import com.yahoo.athenz.common.server.notification.NotificationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import javax.mail.internet.MimeBodyPart;
-import javax.mail.internet.MimeMessage;
-import javax.mail.internet.MimeMultipart;
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URL;
-import java.nio.ByteBuffer;
 import java.text.MessageFormat;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.*;
+
 /*
- * This is a reference implementation using AWS SES.
+ * Email based notification service.
  */
 public class EmailNotificationService implements NotificationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(EmailNotificationService.class);
 
     private static final String AT = "@";
-    private static final String CHARSET_UTF_8 = "UTF-8";
     private static final String USER_DOMAIN_DEFAULT = "user";
     private static final String PROP_USER_DOMAIN = "athenz.user_domain";
     private static final String PROP_NOTIFICATION_EMAIL_DOMAIN_FROM = "athenz.notification_email_domain_from";
@@ -85,9 +78,7 @@ public class EmailNotificationService implements NotificationService {
     private static final String HTML_TBODY_TAG_START = "<tbody>";
     private static final String HTML_TBODY_TAG_END = "</tbody>";
 
-    private static final String HTML_LOGO_CID_PLACEHOLDER = "<logo>";
-
-    private final AmazonSimpleEmailService ses;
+    private final EmailProvider emailProvider;
 
     private String userDomainPrefix;
     private String emailDomainFrom;
@@ -103,13 +94,8 @@ public class EmailNotificationService implements NotificationService {
     private String emailDomainMemberExpiryBody;
     private String emailPrincipalExpiryBody;
 
-
-    EmailNotificationService() {
-        this(initSES());
-    }
-
-    EmailNotificationService(AmazonSimpleEmailService ses) {
-        this.ses = ses;
+    EmailNotificationService(EmailProvider emailProvider) {
+        this.emailProvider = emailProvider;
         String userDomain = System.getProperty(PROP_USER_DOMAIN, USER_DOMAIN_DEFAULT);
         userDomainPrefix = userDomain + "\\.";
         emailDomainFrom = System.getProperty(PROP_NOTIFICATION_EMAIL_DOMAIN_FROM);
@@ -140,16 +126,6 @@ public class EmailNotificationService implements NotificationService {
             }
         }
         return fileByteArray;
-    }
-
-    private static AmazonSimpleEmailService initSES() {
-        ///CLOVER:OFF
-        Region region = Regions.getCurrentRegion();
-        if (region == null) {
-            region = Region.getRegion(Regions.US_EAST_1);
-        }
-        return AmazonSimpleEmailServiceClientBuilder.standard().withRegion(region.getName()).build();
-        ///CLOVER:ON
     }
 
     @Override
@@ -215,9 +191,9 @@ public class EmailNotificationService implements NotificationService {
     }
 
     String getMembershipApprovalBody(Map<String, String> metaDetails) {
-        return MessageFormat.format(emailMembershipApprovalBody, metaDetails.get(NotificationService.NOTIFICATION_DETAILS_DOMAIN),
-                metaDetails.get(NotificationService.NOTIFICATION_DETAILS_ROLE), metaDetails.get(NotificationService.NOTIFICATION_DETAILS_MEMBER),
-                metaDetails.get(NotificationService.NOTIFICATION_DETAILS_REASON), metaDetails.get(NotificationService.NOTIFICATION_DETAILS_REQUESTER),
+        return MessageFormat.format(emailMembershipApprovalBody, metaDetails.get(NOTIFICATION_DETAILS_DOMAIN),
+                metaDetails.get(NOTIFICATION_DETAILS_ROLE), metaDetails.get(NOTIFICATION_DETAILS_MEMBER),
+                metaDetails.get(NOTIFICATION_DETAILS_REASON), metaDetails.get(NOTIFICATION_DETAILS_REQUESTER),
                 workflowUrl, athenzUIUrl);
     }
 
@@ -225,7 +201,7 @@ public class EmailNotificationService implements NotificationService {
 
         // first get the template and replace placeholders
         StringBuilder body = new StringBuilder(256);
-        body.append(MessageFormat.format(emailDomainMemberExpiryBody, metaDetails.get(NotificationService.NOTIFICATION_DETAILS_DOMAIN), athenzUIUrl));
+        body.append(MessageFormat.format(emailDomainMemberExpiryBody, metaDetails.get(NOTIFICATION_DETAILS_DOMAIN), athenzUIUrl));
 
         // then get table rows and replace placeholders
         StringBuilder bodyEntry = new StringBuilder(256);
@@ -240,7 +216,7 @@ public class EmailNotificationService implements NotificationService {
 
         // first get the template and replace placeholders
         StringBuilder body = new StringBuilder(256);
-        body.append(MessageFormat.format(emailPrincipalExpiryBody, metaDetails.get(NotificationService.NOTIFICATION_DETAILS_MEMBER), athenzUIUrl));
+        body.append(MessageFormat.format(emailPrincipalExpiryBody, metaDetails.get(NOTIFICATION_DETAILS_MEMBER), athenzUIUrl));
 
         // then get table rows and replace placeholders
         StringBuilder bodyEntry = new StringBuilder(256);
@@ -303,70 +279,6 @@ public class EmailNotificationService implements NotificationService {
     }
 
     private boolean sendEmailMIME(String subject, String body, boolean status, Collection<String> recipients) {
-        try {
-            Session session = Session.getDefaultInstance(new Properties());
-
-            // Create a new MimeMessage object.
-            MimeMessage message = new MimeMessage(session);
-
-            // Add subject, from and to lines.
-            message.setSubject(subject, CHARSET_UTF_8);
-            message.setFrom(new InternetAddress(from + AT + emailDomainFrom));
-            message.setRecipients(javax.mail.Message.RecipientType.BCC, InternetAddress.parse(String.join(",", recipients)));
-
-            // Create a multipart/alternative child container.
-            MimeMultipart msgBody = new MimeMultipart("alternative");
-
-            // Create a wrapper for the HTML and text parts.
-            MimeBodyPart wrap = new MimeBodyPart();
-
-            // Set the text part.
-            MimeBodyPart textPart = new MimeBodyPart();
-            textPart.setContent(body, "text/plain; charset=" + CHARSET_UTF_8);
-
-            // Set the HTML part.
-            MimeBodyPart htmlPart = new MimeBodyPart();
-            htmlPart.setContent(body, "text/html; charset=" + CHARSET_UTF_8);
-
-            // Add the text and HTML parts to the child container.
-            msgBody.addBodyPart(textPart);
-            msgBody.addBodyPart(htmlPart);
-
-            // Add the child container to the wrapper object.
-            wrap.setContent(msgBody);
-
-            // Create a multipart/mixed parent container.
-            MimeMultipart msgParent = new MimeMultipart("related");
-
-            // Add the multipart/alternative part to the message.
-            msgParent.addBodyPart(wrap);
-
-            // Add the parent container to the message.
-            message.setContent(msgParent);
-
-            if (logoImage != null) {
-                MimeBodyPart logo = new MimeBodyPart();
-                logo.setContent(logoImage, "image/png");
-                logo.setContentID(HTML_LOGO_CID_PLACEHOLDER);
-                logo.setDisposition(MimeBodyPart.INLINE);
-                // Add the attachment to the message.
-                msgParent.addBodyPart(logo);
-            }
-
-            try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-                message.writeTo(outputStream);
-                RawMessage rawMessage = new RawMessage(ByteBuffer.wrap(outputStream.toByteArray()));
-                SendRawEmailRequest rawEmailRequest = new SendRawEmailRequest(rawMessage);
-                SendRawEmailResult result = ses.sendRawEmail(rawEmailRequest);
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("Email with messageId={} sent successfully.", result.getMessageId());
-                }
-                status = status && result != null;
-            }
-        } catch (Exception ex) {
-            LOGGER.error("The email could not be sent. Error message: {}", ex.getMessage());
-            status = false;
-        }
-        return status;
+        return emailProvider.sendEmail(subject, body, status, recipients, from + AT + emailDomainFrom, logoImage);
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/NotificationServiceFactoryImpl.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/NotificationServiceFactoryImpl.java
@@ -26,6 +26,6 @@ public class NotificationServiceFactoryImpl implements NotificationServiceFactor
 
     @Override
     public NotificationService create() {
-        return new EmailNotificationService();
+        return new EmailNotificationService(new AWSEmailProvider());
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProviderTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProviderTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2020 Verizon Media
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.common.server.notification.impl;
+
+import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
+import com.amazonaws.services.simpleemail.model.SendEmailRequest;
+import com.amazonaws.services.simpleemail.model.SendRawEmailRequest;
+import com.amazonaws.services.simpleemail.model.SendRawEmailResult;
+import com.yahoo.athenz.common.server.notification.Notification;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class AWSEmailProviderTest {
+    @Test
+    public void testSendEmail() {
+        Set<String> recipients = new HashSet<>(Arrays.asList("user.user1", "user.user2", "user.user3"));
+        String subject = "test email subject";
+        String body = "test email body";
+        System.setProperty("athenz.notification_email_domain_from", "from.example.com");
+        System.setProperty("athenz.notification_email_domain_to", "example.com");
+        System.setProperty("athenz.notification_email_from", "no-reply-athenz");
+
+        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
+        SendRawEmailResult result = mock(SendRawEmailResult.class);
+        Mockito.when(ses.sendRawEmail(any(SendRawEmailRequest.class))).thenReturn(result);
+        AWSEmailProvider awsEmailProvider = new AWSEmailProvider(ses);
+
+        ArgumentCaptor<SendRawEmailRequest> captor = ArgumentCaptor.forClass(SendRawEmailRequest.class);
+
+        EmailNotificationService svc = new EmailNotificationService(awsEmailProvider);
+
+        svc.sendEmail(recipients, subject, body);
+
+        Mockito.verify(ses, atLeastOnce()).sendRawEmail(captor.capture());
+
+        System.clearProperty("athenz.notification_email_domain_from");
+        System.clearProperty("athenz.notification_email_domain_to");
+        System.clearProperty("athenz.notification_email_from");
+    }
+
+    @Test
+    public void testSendEmailBatch() {
+        Set<String> recipients = new HashSet<>();
+        for (int i =0; i<60; i++) {
+            recipients.add("user.user" + i);
+        }
+        String subject = "test email subject";
+        String body = "test email body";
+        System.setProperty("athenz.notification_email_domain_from", "example.com");
+        System.setProperty("athenz.notification_email_domain_to", "example.com");
+        System.setProperty("athenz.notification_email_from", "no-reply-athenz");
+
+        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
+
+        SendRawEmailResult result = mock(SendRawEmailResult.class);
+        Mockito.when(ses.sendRawEmail(any(SendRawEmailRequest.class))).thenReturn(result);
+        ArgumentCaptor<SendRawEmailRequest> captor = ArgumentCaptor.forClass(SendRawEmailRequest.class);
+
+        AWSEmailProvider emailProvider = new AWSEmailProvider(ses);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
+
+        boolean emailResult = svc.sendEmail(recipients, subject, body);
+
+        assertTrue(emailResult);
+        Mockito.verify(ses, times(2)).sendRawEmail(captor.capture());
+
+        System.clearProperty("athenz.notification_email_domain_from");
+        System.clearProperty("athenz.notification_email_domain_to");
+        System.clearProperty("athenz.notification_email_from");
+    }
+
+    @Test
+    public void testSendEmailError() {
+
+        Set<String> recipients = new HashSet<>(Arrays.asList("user.user1", "user.user2", "user.user3"));
+        String subject = "test email subject";
+        String body = "test email body";
+        System.setProperty("athenz.notification_email_domain_to", "example.com");
+        System.setProperty("athenz.notification_email_domain_from", "from.example.com");
+        System.setProperty("athenz.notification_email_from", "no-reply-athenz");
+
+        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
+        Mockito.when(ses.sendEmail(any(SendEmailRequest.class))).thenThrow(new RuntimeException());
+        AWSEmailProvider awsEmailProvider = new AWSEmailProvider(ses);
+
+        EmailNotificationService svc = new EmailNotificationService(awsEmailProvider);
+
+        boolean result = svc.sendEmail(recipients, subject, body);
+        assertFalse(result);
+
+        System.clearProperty("athenz.notification_email_domain_from");
+        System.clearProperty("athenz.notification_email_domain_to");
+        System.clearProperty("athenz.notification_email_from");
+    }
+
+    @Test
+    public void testNotify() {
+
+        System.setProperty("athenz.notification_email_domain_from", "example.com");
+        System.setProperty("athenz.notification_email_domain_to", "example.com");
+        System.setProperty("athenz.notification_email_from", "no-reply-athenz");
+
+        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
+        SendRawEmailResult result = mock(SendRawEmailResult.class);
+        Mockito.when(ses.sendRawEmail(any(SendRawEmailRequest.class))).thenReturn(result);
+        AWSEmailProvider awsEmailProvider = new AWSEmailProvider(ses);
+        EmailNotificationService svc = new EmailNotificationService(awsEmailProvider);
+
+        Notification notification = new Notification(NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL);
+        notification.addRecipient("user.user1").addRecipient("user.user2");
+        Map<String, String> details = new HashMap<>();
+        details.put("domain", "dom1");
+        details.put("role", "role1");
+        details.put("member", "user.member1");
+        details.put("reason", "test reason");
+        details.put("requester", "user.requester");
+        notification.setDetails(details);
+
+        boolean status = svc.notify(notification);
+        assertTrue(status);
+
+        System.clearProperty("athenz.notification_email_domain_from");
+        System.clearProperty("athenz.notification_email_domain_to");
+        System.clearProperty("athenz.notification_email_from");
+    }
+}

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationServiceTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationServiceTest.java
@@ -16,12 +16,7 @@
 
 package com.yahoo.athenz.common.server.notification.impl;
 
-import com.amazonaws.services.simpleemail.AmazonSimpleEmailService;
-
-import com.amazonaws.services.simpleemail.model.*;
-import com.yahoo.athenz.common.server.notification.Notification;
-import com.yahoo.athenz.common.server.notification.NotificationService;
-import org.mockito.ArgumentCaptor;
+import com.yahoo.athenz.common.server.notification.EmailProvider;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -31,8 +26,9 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.util.*;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.NOTIFICATION_DETAILS_EXPIRY_MEMBERS;
+import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.NOTIFICATION_DETAILS_EXPIRY_ROLES;
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
 
 public class EmailNotificationServiceTest {
@@ -50,7 +46,8 @@ public class EmailNotificationServiceTest {
     @Test
     public void testGetBody() {
         System.setProperty("athenz.notification_workflow_url", "https://athenz.example.com/workflow");
-        EmailNotificationService svc = new EmailNotificationService();
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
         Map<String, String> details = new HashMap<>();
         details.put("domain", "dom1");
         details.put("role", "role1");
@@ -80,7 +77,7 @@ public class EmailNotificationServiceTest {
         // now set the correct expiry members details
         // with one bad entry that should be skipped
 
-        details.put(NotificationService.NOTIFICATION_DETAILS_EXPIRY_MEMBERS,
+        details.put(NOTIFICATION_DETAILS_EXPIRY_MEMBERS,
                 "user.joe;role1;2020-12-01T12:00:00.000Z|user.jane;role1;2020-12-01T12:00:00.000Z|user.bad;role3");
         body = svc.getBody("DOMAIN_MEMBER_EXPIRY_REMINDER", details);
         assertNotNull(body);
@@ -96,7 +93,7 @@ public class EmailNotificationServiceTest {
 
         // now try the expiry roles reminder
 
-        details.put(NotificationService.NOTIFICATION_DETAILS_EXPIRY_ROLES,
+        details.put(NOTIFICATION_DETAILS_EXPIRY_ROLES,
                 "athenz1;role1;2020-12-01T12:00:00.000Z|athenz2;role2;2020-12-01T12:00:00.000Z");
         body = svc.getBody("PRINCIPAL_EXPIRY_REMINDER", details);
         assertNotNull(body);
@@ -111,7 +108,8 @@ public class EmailNotificationServiceTest {
 
     @Test
     public void testGetSubject() {
-        EmailNotificationService svc = new EmailNotificationService();
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
         String sub = svc.getSubject("MEMBERSHIP_APPROVAL");
         assertNotNull(sub);
         assertFalse(sub.isEmpty());
@@ -139,8 +137,8 @@ public class EmailNotificationServiceTest {
         System.setProperty("athenz.user_domain", "entuser");
         System.setProperty("athenz.notification_email_domain_from", "from.example.com");
         System.setProperty("athenz.notification_email_domain_to", "example.com");
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        EmailNotificationService svc = new EmailNotificationService(ses);
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
 
         Set<String> recipients = new HashSet<>(Arrays.asList("entuser.user1", "entuser.user2", "entuser.user3"));
         Set<String> recipientsResp = svc.getFullyQualifiedEmailAddresses(recipients);
@@ -159,8 +157,8 @@ public class EmailNotificationServiceTest {
     public void testGetFullyQualifiedEmailAddressesDefaultUserDomain() {
         System.setProperty("athenz.notification_email_domain_from", "from.test.com");
         System.setProperty("athenz.notification_email_domain_to", "test.com");
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        EmailNotificationService svc = new EmailNotificationService(ses);
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
 
         Set<String> recipients = new HashSet<>(Arrays.asList("user.user1", "user.user2", "user.user3"));
         Set<String> recipientsResp = svc.getFullyQualifiedEmailAddresses(recipients);
@@ -176,134 +174,24 @@ public class EmailNotificationServiceTest {
     }
 
     @Test
-    public void testSendEmail() {
-
-        Set<String> recipients = new HashSet<>(Arrays.asList("user.user1", "user.user2", "user.user3"));
-        String subject = "test email subject";
-        String body = "test email body";
-        System.setProperty("athenz.notification_email_domain_from", "from.example.com");
-        System.setProperty("athenz.notification_email_domain_to", "example.com");
-        System.setProperty("athenz.notification_email_from", "no-reply-athenz");
-
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        SendRawEmailResult result = mock(SendRawEmailResult.class);
-        Mockito.when(ses.sendRawEmail(any(SendRawEmailRequest.class))).thenReturn(result);
-
-        ArgumentCaptor<SendRawEmailRequest> captor = ArgumentCaptor.forClass(SendRawEmailRequest.class);
-
-        EmailNotificationService svc = new EmailNotificationService(ses);
-
-        svc.sendEmail(recipients, subject, body);
-
-        Mockito.verify(ses, atLeastOnce()).sendRawEmail(captor.capture());
-
-        System.clearProperty("athenz.notification_email_domain_from");
-        System.clearProperty("athenz.notification_email_domain_to");
-        System.clearProperty("athenz.notification_email_from");
-    }
-
-    @Test
-    public void testSendEmailBatch() {
-        Set<String> recipients = new HashSet<>();
-        for (int i =0; i<60; i++) {
-            recipients.add("user.user" + i);
-        }
-        String subject = "test email subject";
-        String body = "test email body";
-        System.setProperty("athenz.notification_email_domain_from", "example.com");
-        System.setProperty("athenz.notification_email_domain_to", "example.com");
-        System.setProperty("athenz.notification_email_from", "no-reply-athenz");
-
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-
-        SendRawEmailResult result = mock(SendRawEmailResult.class);
-        Mockito.when(ses.sendRawEmail(any(SendRawEmailRequest.class))).thenReturn(result);
-        ArgumentCaptor<SendRawEmailRequest> captor = ArgumentCaptor.forClass(SendRawEmailRequest.class);
-
-        EmailNotificationService svc = new EmailNotificationService(ses);
-        boolean emailResult = svc.sendEmail(recipients, subject, body);
-
-        assertTrue(emailResult);
-        Mockito.verify(ses, times(2)).sendRawEmail(captor.capture());
-
-        System.clearProperty("athenz.notification_email_domain_from");
-        System.clearProperty("athenz.notification_email_domain_to");
-        System.clearProperty("athenz.notification_email_from");
-    }
-
-    @Test
-    public void testSendEmailError() {
-
-        Set<String> recipients = new HashSet<>(Arrays.asList("user.user1", "user.user2", "user.user3"));
-        String subject = "test email subject";
-        String body = "test email body";
-        System.setProperty("athenz.notification_email_domain_to", "example.com");
-        System.setProperty("athenz.notification_email_domain_from", "from.example.com");
-        System.setProperty("athenz.notification_email_from", "no-reply-athenz");
-
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        Mockito.when(ses.sendEmail(any(SendEmailRequest.class))).thenThrow(new RuntimeException());
-
-        EmailNotificationService svc = new EmailNotificationService(ses);
-
-        boolean result = svc.sendEmail(recipients, subject, body);
-        assertFalse(result);
-
-        System.clearProperty("athenz.notification_email_domain_from");
-        System.clearProperty("athenz.notification_email_domain_to");
-        System.clearProperty("athenz.notification_email_from");
-    }
-
-    @Test
-    public void testNotify() {
-
-        System.setProperty("athenz.notification_email_domain_from", "example.com");
-        System.setProperty("athenz.notification_email_domain_to", "example.com");
-        System.setProperty("athenz.notification_email_from", "no-reply-athenz");
-
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        SendRawEmailResult result = mock(SendRawEmailResult.class);
-        Mockito.when(ses.sendRawEmail(any(SendRawEmailRequest.class))).thenReturn(result);
-
-        EmailNotificationService svc = new EmailNotificationService(ses);
-
-        Notification notification = new Notification(NotificationService.NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL);
-        notification.addRecipient("user.user1").addRecipient("user.user2");
-        Map<String, String> details = new HashMap<>();
-        details.put("domain", "dom1");
-        details.put("role", "role1");
-        details.put("member", "user.member1");
-        details.put("reason", "test reason");
-        details.put("requester", "user.requester");
-        notification.setDetails(details);
-
-        boolean status = svc.notify(notification);
-        assertTrue(status);
-
-        System.clearProperty("athenz.notification_email_domain_from");
-        System.clearProperty("athenz.notification_email_domain_to");
-        System.clearProperty("athenz.notification_email_from");
-    }
-
-    @Test
     public void testNotifyNull() {
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        EmailNotificationService svc = new EmailNotificationService(ses);
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
         boolean status = svc.notify(null);
         assertFalse(status);
     }
 
     @Test
     public void testReadContentFromFile() {
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        EmailNotificationService svc = new EmailNotificationService(ses);
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
         assertTrue(svc.readContentFromFile("resources/non-existent").isEmpty());
     }
 
     @Test
     public void testReadContentFromFileNull() throws Exception {
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        EmailNotificationService svc = new EmailNotificationService(ses);
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
         BufferedReader reader = mock(BufferedReader.class);
         Mockito.when(reader.readLine()).thenReturn(null);
         assertTrue(svc.readContentFromFile("resources/dummy").isEmpty());
@@ -311,8 +199,8 @@ public class EmailNotificationServiceTest {
 
     @Test
     public void testReadContentFromFileException() throws Exception {
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        EmailNotificationService svc = new EmailNotificationService(ses);
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
         BufferedReader reader = mock(BufferedReader.class);
         Mockito.when(reader.readLine()).thenThrow(new IOException());
         assertTrue(svc.readContentFromFile("resources/dummy").isEmpty());
@@ -320,15 +208,15 @@ public class EmailNotificationServiceTest {
 
     @Test
     public void testReadBinaryFromFile() {
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        EmailNotificationService svc = new EmailNotificationService(ses);
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
         assertNotNull(svc.readBinaryFromFile("emails/athenz-logo-white.png"));
     }
 
     @Test
     public void testReadBinaryFromFileNull() {
-        AmazonSimpleEmailService ses = mock(AmazonSimpleEmailService.class);
-        EmailNotificationService svc = new EmailNotificationService(ses);
+        EmailProvider emailProvider = mock(EmailProvider.class);
+        EmailNotificationService svc = new EmailNotificationService(emailProvider);
         assertNull(svc.readBinaryFromFile("resources/non-existent"));
     }
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -3459,7 +3459,7 @@ public class DBService {
 
     }
     
-    AthenzDomain getAthenzDomain(String domainName, boolean masterCopy) {
+    public AthenzDomain getAthenzDomain(String domainName, boolean masterCopy) {
         
         // first check to see if we our data is in the cache
         

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -35,6 +35,7 @@ import com.yahoo.athenz.zms.config.AllowedOperation;
 import com.yahoo.athenz.zms.config.AuthorizedService;
 import com.yahoo.athenz.zms.config.AuthorizedServices;
 import com.yahoo.athenz.zms.config.SolutionTemplates;
+import com.yahoo.athenz.zms.notification.NotificationManager;
 import com.yahoo.athenz.zms.store.AthenzDomain;
 import com.yahoo.athenz.zms.store.ObjectStore;
 import com.yahoo.athenz.zms.store.ObjectStoreFactory;
@@ -68,7 +69,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-import static com.yahoo.athenz.common.server.notification.NotificationService.*;
+import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.*;
 
 public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/NotificationManager.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/NotificationManager.java
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package com.yahoo.athenz.zms;
+package com.yahoo.athenz.zms.notification;
 
 import com.google.common.base.Splitter;
 import com.yahoo.athenz.auth.util.AthenzUtils;
 import com.yahoo.athenz.common.server.notification.Notification;
 import com.yahoo.athenz.common.server.notification.NotificationService;
 import com.yahoo.athenz.common.server.notification.NotificationServiceFactory;
+import com.yahoo.athenz.zms.*;
 import com.yahoo.athenz.zms.store.AthenzDomain;
 import com.yahoo.athenz.zms.utils.ZMSUtils;
 import org.slf4j.Logger;
@@ -31,6 +32,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.*;
 
 public class NotificationManager {
 
@@ -43,7 +46,7 @@ public class NotificationManager {
     private int pendingRoleMemberLifespan;
     private String monitorIdentity;
 
-    NotificationManager(final DBService dbService, final String userDomainPrefix) {
+    public NotificationManager(final DBService dbService, final String userDomainPrefix) {
         this.dbService = dbService;
         this.userDomainPrefix = userDomainPrefix;
         String notificationServiceFactoryClass = System.getProperty(ZMSConsts.ZMS_PROP_NOTIFICATION_SERVICE_FACTORY_CLASS);
@@ -82,8 +85,8 @@ public class NotificationManager {
         }
     }
 
-    void generateAndSendPostPutMembershipNotification(final String domain, final String org,
-             final Role role, Map<String, String> details) {
+    public void generateAndSendPostPutMembershipNotification(final String domain, final String org,
+                                                             final Role role, Map<String, String> details) {
 
         if (!isNotificationFeatureAvailable()) {
             return;
@@ -130,7 +133,7 @@ public class NotificationManager {
 
         // create and process our notification
 
-        Notification notification = createNotification(NotificationService.NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL,
+        Notification notification = createNotification(NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL,
                 recipients, details);
         if (notification != null) {
             notificationService.notify(notification);
@@ -272,7 +275,7 @@ public class NotificationManager {
 
         void sendPendingMembershipApprovalReminders() {
             Set<String> recipients = dbService.getPendingMembershipApproverRoles();
-            Notification notification = createNotification(NotificationService.NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL_REMINDER,
+            Notification notification = createNotification(NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL_REMINDER,
                     recipients, null);
             if (notification != null) {
                 notificationService.notify(notification);
@@ -308,7 +311,7 @@ public class NotificationManager {
                 // notification agent for processing
 
                 Map<String, String> details = processRoleExpiryReminder(domainAdminMap, roleMember);
-                Notification notification = createNotification(NotificationService.NOTIFICATION_TYPE_PRINCIPAL_EXPIRY_REMINDER,
+                Notification notification = createNotification(NOTIFICATION_TYPE_PRINCIPAL_EXPIRY_REMINDER,
                         roleMember.getMemberName(), details);
                 if (notification != null) {
                     notificationService.notify(notification);
@@ -321,7 +324,7 @@ public class NotificationManager {
             for (Map.Entry<String, List<MemberRole>> domainAdmin : domainAdminMap.entrySet()) {
 
                 Map<String, String> details = processMemberExpiryReminder(domainAdmin.getKey(), domainAdmin.getValue());
-                Notification notification = createNotification(NotificationService.NOTIFICATION_TYPE_DOMAIN_MEMBER_EXPIRY_REMINDER,
+                Notification notification = createNotification(NOTIFICATION_TYPE_DOMAIN_MEMBER_EXPIRY_REMINDER,
                         ZMSUtils.roleResourceName(domainAdmin.getKey(), ZMSConsts.ADMIN_ROLE_NAME), details);
                 if (notification != null) {
                     notificationService.notify(notification);
@@ -368,8 +371,8 @@ public class NotificationManager {
                 }
                 domainRoleMembers.add(memberRole);
             }
-            details.put(NotificationService.NOTIFICATION_DETAILS_EXPIRY_ROLES, expiryRoles.toString());
-            details.put(NotificationService.NOTIFICATION_DETAILS_MEMBER, member.getMemberName());
+            details.put(NOTIFICATION_DETAILS_EXPIRY_ROLES, expiryRoles.toString());
+            details.put(NOTIFICATION_DETAILS_MEMBER, member.getMemberName());
 
             return details;
         }
@@ -400,8 +403,8 @@ public class NotificationManager {
                         .append(memberRole.getRoleName()).append(';')
                         .append(memberRole.getExpiration().toString());
             }
-            details.put(NotificationService.NOTIFICATION_DETAILS_EXPIRY_MEMBERS, expiryMembers.toString());
-            details.put(NotificationService.NOTIFICATION_DETAILS_DOMAIN, domainName);
+            details.put(NOTIFICATION_DETAILS_EXPIRY_MEMBERS, expiryMembers.toString());
+            details.put(NOTIFICATION_DETAILS_DOMAIN, domainName);
             return details;
         }
     }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.zms;
 
 import com.yahoo.athenz.zms.audit.MockAuditReferenceValidatorImpl;
+import com.yahoo.athenz.zms.notification.NotificationManager;
 import com.yahoo.athenz.zms.store.ObjectStoreConnection;
 import com.yahoo.athenz.common.server.audit.AuditReferenceValidator;
 import com.yahoo.rdl.Timestamp;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -32,12 +32,13 @@ import com.google.common.base.Strings;
 import com.yahoo.athenz.auth.ServerPrivateKey;
 import com.yahoo.athenz.auth.impl.*;
 import com.yahoo.athenz.common.server.notification.Notification;
+import com.yahoo.athenz.zms.notification.NotificationManager;
 import org.mockito.Mockito;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.*;
 
-import static com.yahoo.athenz.common.server.notification.NotificationService.*;
+import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;


### PR DESCRIPTION
1. Seperated provider implementation from EmailNotificationService
2. Currently implemented provider: AWSEmailProvider..
3. The tests checking AWS SES functionality in NotificationManagerTest were extracted to a new test class, AWSEmailProviderTest.
4. Moved Notification constants from interface to dedicated constants file


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
