### PR TITLE
Implement ZTS Notifications DB logic

### DIFF
--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -163,6 +163,11 @@
       <artifactId>jakarta.mail</artifactId>
       <version>1.6.4</version>
     </dependency>
+    <dependency>
+      <groupId>com.yahoo.athenz</groupId>
+      <artifactId>athenz-zms-core</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
   </dependencies>
 
   <distributionManagement>

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/ServerCommonConsts.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/ServerCommonConsts.java
@@ -21,6 +21,8 @@ public final class ServerCommonConsts {
     public static final String OBJECT_ROLE      = "role";
     public static final String USER_DOMAIN      = "user";
 
+    public static final String USER_DOMAIN_PREFIX = "user.";
+
     private ServerCommonConsts() {
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/DomainRoleMembersFetcherCommon.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/DomainRoleMembersFetcherCommon.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Verizon Media
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.common.server.notification;
+
+import com.yahoo.athenz.zms.Role;
+import com.yahoo.athenz.zms.RoleMember;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class DomainRoleMembersFetcherCommon {
+    private final String userDomainPrefix;
+
+    public DomainRoleMembersFetcherCommon(String userDomainPrefix) {
+        this.userDomainPrefix = userDomainPrefix;
+    }
+
+    public Set<String> getDomainRoleMembers(String roleName, List<Role> roles) {
+        if (roles == null) {
+            return new HashSet<>();
+        }
+
+        for (Role role : roles) {
+            if (role.getName().equals(roleName)) {
+                return role.getRoleMembers().stream()
+                        .filter(this::isUnexpiredUser)
+                        .map(RoleMember::getMemberName).collect(Collectors.toSet());
+            }
+        }
+
+        return new HashSet<>();
+    }
+
+    private boolean isUnexpiredUser(RoleMember roleMember) {
+        if (!roleMember.getMemberName().startsWith(userDomainPrefix)) {
+            return false;
+        }
+
+        return (roleMember.getExpiration() == null) || (roleMember.getExpiration().millis() > System.currentTimeMillis());
+    }
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/EmailProvider.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/EmailProvider.java
@@ -23,11 +23,10 @@ public interface EmailProvider {
 
     /**
      * Send an email through the provider
-     * @param status
      * @param recipients
      * @param from
      * @param mimeMessage
      * @return true if mail was sent
      */
-    boolean sendEmail(boolean status, Collection<String> recipients, String from, MimeMessage mimeMessage);
+    boolean sendEmail(Collection<String> recipients, String from, MimeMessage mimeMessage);
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProvider.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/AWSEmailProvider.java
@@ -37,7 +37,7 @@ public class AWSEmailProvider implements EmailProvider {
     private final AmazonSimpleEmailService ses;
 
     @Override
-    public boolean sendEmail(boolean status, Collection<String> recipients, String from, MimeMessage mimeMessage) {
+    public boolean sendEmail(Collection<String> recipients, String from, MimeMessage mimeMessage) {
         try {
             try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
                 mimeMessage.writeTo(outputStream);
@@ -47,13 +47,12 @@ public class AWSEmailProvider implements EmailProvider {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Email with messageId={} sent successfully.", result.getMessageId());
                 }
-                status = status && result != null;
+                return result != null;
             }
         } catch (Exception ex) {
             LOGGER.error("The email could not be sent. Error message: {}", ex.getMessage());
-            status = false;
+            return false;
         }
-        return status;
     }
 
     AWSEmailProvider() {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -145,7 +145,6 @@ public final class ZMSConsts {
     public static final String ZMS_DOMAIN_NAME_MAX_SIZE_DEFAULT = "128";
 
     public static final String USER_DOMAIN        = "user";
-    public static final String USER_DOMAIN_PREFIX = "user.";
 
     public static final String RSA   = "RSA";
     public static final String EC    = "EC";

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -74,6 +74,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
 import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.*;
 
 public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
@@ -2121,7 +2122,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // if the resource does not start with user domain prefix then
         // we have nothing to do and we'll return resource as is
 
-        if (!resource.startsWith(ZMSConsts.USER_DOMAIN_PREFIX)) {
+        if (!resource.startsWith(USER_DOMAIN_PREFIX)) {
             return resource;
         }
 
@@ -2141,11 +2142,11 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 return resource;
             }
 
-            final String userName = resource.substring(ZMSConsts.USER_DOMAIN_PREFIX.length(), idx);
+            final String userName = resource.substring(USER_DOMAIN_PREFIX.length(), idx);
             homeResource = homeDomainPrefix + getUserDomainName(userName) + resource.substring(idx);
 
         } else if (!homeDomain.equals(ZMSConsts.USER_DOMAIN)) {
-            homeResource = homeDomainPrefix + resource.substring(ZMSConsts.USER_DOMAIN_PREFIX.length());
+            homeResource = homeDomainPrefix + resource.substring(USER_DOMAIN_PREFIX.length());
         }
         return homeResource == null ? resource : homeResource;
     }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PendingMembershipApprovalNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/PendingMembershipApprovalNotificationTask.java
@@ -20,12 +20,12 @@ import com.yahoo.athenz.common.server.notification.Notification;
 import com.yahoo.athenz.common.server.notification.NotificationCommon;
 import com.yahoo.athenz.common.server.notification.NotificationTask;
 import com.yahoo.athenz.zms.DBService;
-import com.yahoo.athenz.zms.ZMSConsts;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
 import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL_REMINDER;
 
 public class PendingMembershipApprovalNotificationTask implements NotificationTask {
@@ -40,7 +40,7 @@ public class PendingMembershipApprovalNotificationTask implements NotificationTa
         this.dbService = dbService;
         this.pendingRoleMemberLifespan = pendingRoleMemberLifespan;
         this.monitorIdentity = monitorIdentity;
-        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbService, ZMSConsts.USER_DOMAIN_PREFIX);
+        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbService, USER_DOMAIN_PREFIX);
         this.notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, userDomainPrefix);
     }
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTask.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTask.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
 import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.*;
 
 public class RoleMemberExpiryNotificationTask implements NotificationTask {
@@ -42,7 +43,7 @@ public class RoleMemberExpiryNotificationTask implements NotificationTask {
 
     public RoleMemberExpiryNotificationTask(DBService dbService, String userDomainPrefix) {
         this.dbService = dbService;
-        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbService, ZMSConsts.USER_DOMAIN_PREFIX);
+        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbService, USER_DOMAIN_PREFIX);
         this.notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, userDomainPrefix);
     }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/NotificationManagerTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/NotificationManagerTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 
+import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
 import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.NOTIFICATION_PROP_SERVICE_FACTORY_CLASS;
 import static org.testng.Assert.*;
 
@@ -66,7 +67,7 @@ public class NotificationManagerTest {
     }
 
     public static NotificationManager getNotificationManager(DBService dbsvc, NotificationServiceFactory notificationServiceFactory) {
-        ZMSNotificationTaskFactory zmsNotificationTaskFactory = new ZMSNotificationTaskFactory(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
+        ZMSNotificationTaskFactory zmsNotificationTaskFactory = new ZMSNotificationTaskFactory(dbsvc, USER_DOMAIN_PREFIX);
         List<NotificationTask> notificationTasks = zmsNotificationTaskFactory.getNotificationTasks();
 
         if (notificationServiceFactory == null) {
@@ -140,8 +141,8 @@ public class NotificationManagerTest {
         details.put("domain", "testdom");
         details.put("role", "role1");
 
-        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
-        NotificationCommon notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, ZMSConsts.USER_DOMAIN_PREFIX);
+        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbsvc, USER_DOMAIN_PREFIX);
+        NotificationCommon notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, USER_DOMAIN_PREFIX);
         Notification notification = notificationCommon.createNotification("MEMBERSHIP_APPROVAL", recipients, details);
         assertNotNull(notification);
 
@@ -164,8 +165,8 @@ public class NotificationManagerTest {
         DBService dbsvc = Mockito.mock(DBService.class);
         Mockito.when(dbsvc.getPendingMembershipApproverRoles()).thenReturn(Collections.emptySet());
 
-        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
-        NotificationCommon notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, ZMSConsts.USER_DOMAIN_PREFIX);
+        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbsvc, USER_DOMAIN_PREFIX);
+        NotificationCommon notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, USER_DOMAIN_PREFIX);
         assertNull(notificationCommon.createNotification("MEMBERSHIP_APPROVAL", (Set<String>) null, null));
         assertNull(notificationCommon.createNotification("MEMBERSHIP_APPROVAL", Collections.emptySet(), null));
     }
@@ -194,8 +195,8 @@ public class NotificationManagerTest {
         Mockito.when(mockAthenzDomain.getName()).thenReturn("testdom");
         Mockito.when(mockAthenzDomain.getRoles()).thenReturn(roles);
 
-        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
-        NotificationCommon notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, ZMSConsts.USER_DOMAIN_PREFIX);
+        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbsvc, USER_DOMAIN_PREFIX);
+        NotificationCommon notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, USER_DOMAIN_PREFIX);
         Notification notification = notificationCommon.createNotification("MEMBERSHIP_APPROVAL", recipients, null);
         assertNull(notification);
     }
@@ -259,8 +260,8 @@ public class NotificationManagerTest {
         // call
 
         Mockito.when(dbsvc.getRoleExpiryMembers()).thenReturn(null);
-        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
-        NotificationCommon notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, ZMSConsts.USER_DOMAIN_PREFIX);
+        ZMSDomainRoleMembersFetcher zmsDomainRoleMembersFetcher = new ZMSDomainRoleMembersFetcher(dbsvc, USER_DOMAIN_PREFIX);
+        NotificationCommon notificationCommon = new NotificationCommon(zmsDomainRoleMembersFetcher, USER_DOMAIN_PREFIX);
 
         Map<String, String> details = new HashMap<>();
         assertNull(notificationCommon.createNotification("reminder", (String) null, details));

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PendingMembershipApprovalNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PendingMembershipApprovalNotificationTaskTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 import java.util.Collections;
 import java.util.List;
 
+import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
 import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.NOTIFICATION_TYPE_MEMBERSHIP_APPROVAL_REMINDER;
 import static com.yahoo.athenz.zms.notification.NotificationManagerTest.getNotificationManager;
 import static org.testng.Assert.assertEquals;
@@ -55,7 +56,7 @@ public class PendingMembershipApprovalNotificationTaskTest {
 
         ZMSTestUtils.sleep(1000);
 
-        PendingMembershipApprovalNotificationTask reminder = new PendingMembershipApprovalNotificationTask(dbsvc, 0, "", ZMSConsts.USER_DOMAIN_PREFIX);
+        PendingMembershipApprovalNotificationTask reminder = new PendingMembershipApprovalNotificationTask(dbsvc, 0, "", USER_DOMAIN_PREFIX);
         List<Notification> notifications = reminder.getNotifications();
 
         // Verify contents of notification is as expected

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutMembershipNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/PutMembershipNotificationTaskTest.java
@@ -31,6 +31,7 @@ import org.testng.annotations.Test;
 
 import java.util.*;
 
+import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
 import static com.yahoo.athenz.zms.notification.NotificationManagerTest.getNotificationManager;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
@@ -91,7 +92,7 @@ public class PutMembershipNotificationTaskTest {
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
 
         Role notifyRole = new Role().setAuditEnabled(true).setSelfServe(false);
-        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, ZMSConsts.USER_DOMAIN_PREFIX).getNotifications();
+        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX).getNotifications();
         notificationManager.sendNotifications(notifications);
 
         Notification notification = new Notification("MEMBERSHIP_APPROVAL");
@@ -141,7 +142,7 @@ public class PutMembershipNotificationTaskTest {
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
 
         Role notifyRole = new Role().setAuditEnabled(true).setSelfServe(false);
-        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, ZMSConsts.USER_DOMAIN_PREFIX).getNotifications();
+        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX).getNotifications();
         notificationManager.sendNotifications(notifications);
 
         Notification notification = new Notification("MEMBERSHIP_APPROVAL");
@@ -190,7 +191,7 @@ public class PutMembershipNotificationTaskTest {
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
 
         Role notifyRole = new Role().setAuditEnabled(true).setSelfServe(false);
-        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, ZMSConsts.USER_DOMAIN_PREFIX).getNotifications();
+        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX).getNotifications();
         notificationManager.sendNotifications(notifications);
 
         Notification notification = new Notification("MEMBERSHIP_APPROVAL");
@@ -239,7 +240,7 @@ public class PutMembershipNotificationTaskTest {
         ArgumentCaptor<Notification> captor = ArgumentCaptor.forClass(Notification.class);
 
         Role notifyRole = new Role().setAuditEnabled(false).setSelfServe(true);
-        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, ZMSConsts.USER_DOMAIN_PREFIX).getNotifications();
+        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX).getNotifications();
         notificationManager.sendNotifications(notifications);
 
         Notification notification = new Notification("MEMBERSHIP_APPROVAL");
@@ -308,7 +309,7 @@ public class PutMembershipNotificationTaskTest {
 
         Role notifyRole = new Role().setAuditEnabled(false).setSelfServe(false).setReviewEnabled(true)
                 .setNotifyRoles("athenz:role.approvers,notify");
-        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, ZMSConsts.USER_DOMAIN_PREFIX).getNotifications();
+        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, details, dbsvc, USER_DOMAIN_PREFIX).getNotifications();
         notificationManager.sendNotifications(notifications);
 
         Notification notification = new Notification("MEMBERSHIP_APPROVAL");
@@ -335,7 +336,7 @@ public class PutMembershipNotificationTaskTest {
         NotificationManager notificationManager = getNotificationManager(dbsvc, testfact);
         notificationManager.shutdown();
         Role notifyRole = new Role().setAuditEnabled(false).setSelfServe(false);
-        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, null, dbsvc, ZMSConsts.USER_DOMAIN_PREFIX).getNotifications();
+        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, null, dbsvc, USER_DOMAIN_PREFIX).getNotifications();
         notificationManager.sendNotifications(notifications);
         Mockito.verify(mockNotificationService, times(0)).notify(any());
     }
@@ -351,7 +352,7 @@ public class PutMembershipNotificationTaskTest {
         NotificationManager notificationManager = getNotificationManager(dbsvc, testfact);
         notificationManager.shutdown();
         Role notifyRole = new Role().setAuditEnabled(false).setSelfServe(false);
-        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, null, dbsvc, ZMSConsts.USER_DOMAIN_PREFIX).getNotifications();
+        List<Notification> notifications = new PutMembershipNotificationTask("testdomain1", "neworg", notifyRole, null, dbsvc, USER_DOMAIN_PREFIX).getNotifications();
         notificationManager.sendNotifications(notifications);
         verify(mockNotificationService, never()).notify(any(Notification.class));
     }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/RoleMemberExpiryNotificationTaskTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 
 import java.util.*;
 
+import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
 import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.*;
 import static com.yahoo.athenz.common.server.notification.NotificationServiceConstants.NOTIFICATION_DETAILS_MEMBER;
 import static com.yahoo.athenz.zms.notification.NotificationManagerTest.getNotificationManager;
@@ -44,7 +45,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         Mockito.when(dbsvc.getPendingMembershipApproverRoles()).thenReturn(Collections.emptySet());
 
         NotificationManager notificationManager = getNotificationManager(dbsvc, null);
-        RoleMemberExpiryNotificationTask roleMemberExpiryNotificationTask = new RoleMemberExpiryNotificationTask(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
+        RoleMemberExpiryNotificationTask roleMemberExpiryNotificationTask = new RoleMemberExpiryNotificationTask(dbsvc, USER_DOMAIN_PREFIX);
 
         Map<String, String> details = roleMemberExpiryNotificationTask.processMemberExpiryReminder("athenz", null);
         assertTrue(details.isEmpty());
@@ -88,7 +89,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         DomainRoleMember roleMember = new DomainRoleMember();
         roleMember.setMemberName("user.joe");
 
-        RoleMemberExpiryNotificationTask roleMemberExpiryNotificationTask = new RoleMemberExpiryNotificationTask(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
+        RoleMemberExpiryNotificationTask roleMemberExpiryNotificationTask = new RoleMemberExpiryNotificationTask(dbsvc, USER_DOMAIN_PREFIX);
 
         Map<String, String> details = roleMemberExpiryNotificationTask.processRoleExpiryReminder(domainAdminMap, roleMember);
         assertTrue(details.isEmpty());
@@ -153,7 +154,7 @@ public class RoleMemberExpiryNotificationTaskTest {
         Mockito.when(dbsvc.getRoleExpiryMembers()).thenThrow(new IllegalArgumentException());
         NotificationManager notificationManager = getNotificationManager(dbsvc, testfact);
 
-        RoleMemberExpiryNotificationTask roleMemberExpiryNotificationTask = new RoleMemberExpiryNotificationTask(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
+        RoleMemberExpiryNotificationTask roleMemberExpiryNotificationTask = new RoleMemberExpiryNotificationTask(dbsvc, USER_DOMAIN_PREFIX);
         // to make sure we're not creating any notifications, we're going
         // to configure our mock to throw an exception
 
@@ -185,7 +186,7 @@ public class RoleMemberExpiryNotificationTaskTest {
 
         Mockito.when(mockNotificationService.notify(any())).thenThrow(new IllegalArgumentException());
 
-        RoleMemberExpiryNotificationTask roleMemberExpiryNotificationTask = new RoleMemberExpiryNotificationTask(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
+        RoleMemberExpiryNotificationTask roleMemberExpiryNotificationTask = new RoleMemberExpiryNotificationTask(dbsvc, USER_DOMAIN_PREFIX);
         assertEquals(roleMemberExpiryNotificationTask.getNotifications(), new ArrayList<>());
 
         notificationManager.shutdown();
@@ -232,7 +233,7 @@ public class RoleMemberExpiryNotificationTaskTest {
 
         Mockito.when(dbsvc.getAthenzDomain("athenz1", false)).thenReturn(domain);
 
-        List<Notification> notifications = new RoleMemberExpiryNotificationTask(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX).getNotifications();
+        List<Notification> notifications = new RoleMemberExpiryNotificationTask(dbsvc, USER_DOMAIN_PREFIX).getNotifications();
 
 
         // we should get 2 notifications - one for user and one for domain
@@ -284,7 +285,7 @@ public class RoleMemberExpiryNotificationTaskTest {
 
         Mockito.when(dbsvc.getAthenzDomain("athenz1", false)).thenReturn(null);
 
-        List<Notification> notifications = new RoleMemberExpiryNotificationTask(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX).getNotifications();
+        List<Notification> notifications = new RoleMemberExpiryNotificationTask(dbsvc, USER_DOMAIN_PREFIX).getNotifications();
 
         // we should get 0 notifications
         assertEquals(notifications, new ArrayList<>());

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationTaskFactoryTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/notification/ZMSNotificationTaskFactoryTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 import java.util.List;
 
+import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
 import static org.testng.AssertJUnit.assertEquals;
 
 public class ZMSNotificationTaskFactoryTest {
@@ -31,7 +32,7 @@ public class ZMSNotificationTaskFactoryTest {
     @Test
     public void testNotificationTasksOrdering() {
         DBService dbsvc = Mockito.mock(DBService.class);
-        ZMSNotificationTaskFactory zmsNotificationTaskFactory = new ZMSNotificationTaskFactory(dbsvc, ZMSConsts.USER_DOMAIN_PREFIX);
+        ZMSNotificationTaskFactory zmsNotificationTaskFactory = new ZMSNotificationTaskFactory(dbsvc, USER_DOMAIN_PREFIX);
         List<NotificationTask> notificationTasks = zmsNotificationTaskFactory.getNotificationTasks();
         assertEquals(2, notificationTasks.size());
         assertEquals(notificationTasks.get(0).getDescription(), "pending membership approvals reminders");

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/CertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/CertRecordStoreConnection.java
@@ -16,6 +16,7 @@
 package com.yahoo.athenz.zts.cert;
 
 import java.io.Closeable;
+import java.util.List;
 
 public interface CertRecordStoreConnection extends Closeable {
 
@@ -70,4 +71,20 @@ public interface CertRecordStoreConnection extends Closeable {
      * @return number of records deleted
      */
     int deleteExpiredX509CertRecords(int expiryTimeMins);
+
+    /**
+     * Update lastNotifiedServer and lastNotifiedTime for certificate that failed to refresh for more than one day.
+     * @param lastNotifiedServer
+     * @param lastNotifiedTime
+     * @return True if at least one certificate record was updated (needs notification to be sent)
+     */
+    boolean updateUnrefreshedCertificatesNotificationTimestamp(String lastNotifiedServer, long lastNotifiedTime);
+
+    /**
+     * List all certificates that failed to refresh and require notifications to be sent
+     * @param lastNotifiedServer
+     * @param lastNotifiedTime
+     * @return List of unrefreshed certificate records that need to be modified
+     */
+    List<X509CertRecord> getNotifyUnrefreshedCertificates(String lastNotifiedServer, long lastNotifiedTime);
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
@@ -461,6 +461,21 @@ public class InstanceCertManager {
         return certAuthorityBundles.get(name);
     }
 
+    public List<X509CertRecord> getUnrefreshedCertsNotifications(String serverHostName) {
+        if (certStore == null) {
+            return new ArrayList<>();
+        }
+
+        try (CertRecordStoreConnection storeConnection = certStore.getConnection()) {
+            long updateTs = System.currentTimeMillis();
+            if (storeConnection.updateUnrefreshedCertificatesNotificationTimestamp(serverHostName, updateTs)) {
+                return storeConnection.getNotifyUnrefreshedCertificates(serverHostName, updateTs);
+            }
+        }
+
+        return new ArrayList<>();
+    }
+
     public X509CertRecord getX509CertRecord(final String provider, X509Certificate cert) {
 
         if (certStore == null) {

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509CertRecord.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509CertRecord.java
@@ -29,6 +29,10 @@ public class X509CertRecord {
     private Date prevTime;
     private String prevIP;
     private boolean clientCert;
+    private Date lastNotifiedTime;
+    private String lastNotifiedServer;
+    private Date expiryTime;
+    private String hostName;
 
     public X509CertRecord() {
     }
@@ -111,5 +115,37 @@ public class X509CertRecord {
 
     public boolean getClientCert() {
         return clientCert;
+    }
+
+    public Date getLastNotifiedTime() {
+        return lastNotifiedTime;
+    }
+
+    public void setLastNotifiedTime(Date lastNotifiedTime) {
+        this.lastNotifiedTime = lastNotifiedTime;
+    }
+
+    public String getLastNotifiedServer() {
+        return lastNotifiedServer;
+    }
+
+    public void setLastNotifiedServer(String lastNotifiedServer) {
+        this.lastNotifiedServer = lastNotifiedServer;
+    }
+
+    public Date getExpiryTime() {
+        return expiryTime;
+    }
+
+    public void setExpiryTime(Date expiryTime) {
+        this.expiryTime = expiryTime;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
     }
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
@@ -21,6 +21,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.yahoo.athenz.zts.cert.CertRecordStoreConnection;
 import com.yahoo.athenz.zts.cert.X509CertRecord;
@@ -94,6 +96,18 @@ public class FileCertRecordStoreConnection implements CertRecordStoreConnection 
             count += 1;
         }
         return count;
+    }
+
+    @Override
+    public boolean updateUnrefreshedCertificatesNotificationTimestamp(String lastNotifiedServer, long lastNotifiedTime) {
+        // Currently unimplemented for File
+        return false;
+    }
+
+    @Override
+    public List<X509CertRecord> getNotifyUnrefreshedCertificates(String lastNotifiedServer, long lastNotifiedTime) {
+        // Currently unimplemented for File
+        return new ArrayList<>();
     }
 
     boolean notExpired(long currentTime, long lastModified, int expiryTimeMins) {

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTask.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/CertFailedRefreshNotificationTask.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Verizon Media
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.zts.notification;
+
+import com.yahoo.athenz.common.server.notification.Notification;
+import com.yahoo.athenz.common.server.notification.NotificationCommon;
+import com.yahoo.athenz.common.server.notification.NotificationTask;
+import com.yahoo.athenz.zts.cert.InstanceCertManager;
+import com.yahoo.athenz.zts.store.DataStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.yahoo.athenz.common.ServerCommonConsts.USER_DOMAIN_PREFIX;
+
+public class CertFailedRefreshNotificationTask implements NotificationTask {
+    private final String serverName;
+    private final InstanceCertManager instanceCertManager;
+    private final DataStore dataStore;
+    private final NotificationCommon notificationCommon;
+    private static final Logger LOGGER = LoggerFactory.getLogger(CertFailedRefreshNotificationTask.class);
+    private final static String DESCRIPTION = "certificate failed refresh notification";
+
+    public CertFailedRefreshNotificationTask(InstanceCertManager instanceCertManager, DataStore dataStore, String userDomainPrefix, String serverName) {
+        this.serverName = serverName;
+        this.instanceCertManager = instanceCertManager;
+        this.dataStore = dataStore;
+        ZTSDomainRoleMembersFetcher ztsDomainRoleMembersFetcher = new ZTSDomainRoleMembersFetcher(dataStore, USER_DOMAIN_PREFIX);
+        this.notificationCommon = new NotificationCommon(ztsDomainRoleMembersFetcher, userDomainPrefix);
+    }
+
+    @Override
+    public List<Notification> getNotifications() {
+        return new ArrayList<>();
+        // TODO: Uncomment and continue implementation when UnrefreshedNotification email template is ready
+
+/*        List<Notification> notificationList = new ArrayList<>();
+        List<X509CertRecord> unrefreshedRecords = instanceCertManager.getUnrefreshedNotifications(serverName);
+        if (unrefreshedRecords == null || unrefreshedRecords.isEmpty()) {
+            if (LOGGER.isDebugEnabled()) {
+                LOGGER.debug("No unrefreshed certificates available to send notifications");
+            }
+            return notificationList;
+        }
+
+
+        for (X509CertRecord x509CertRecord: unrefreshedRecords) {
+            String domainName = AthenzUtils.extractPrincipalDomainName(x509CertRecord.getService());
+            DomainData domainData = dataStore.getDomainData(domainName);
+
+        }*/
+    }
+
+    @Override
+    public String getDescription() {
+        return DESCRIPTION;
+    }
+}

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/ZTSDomainRoleMembersFetcher.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/ZTSDomainRoleMembersFetcher.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright 2020 Verizon Media
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.zts.notification;
+
+import com.yahoo.athenz.common.server.notification.DomainRoleMembersFetcher;
+import com.yahoo.athenz.common.server.notification.DomainRoleMembersFetcherCommon;
+import com.yahoo.athenz.zms.DomainData;
+import com.yahoo.athenz.zts.store.DataStore;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class ZTSDomainRoleMembersFetcher implements DomainRoleMembersFetcher {
+
+    private final DataStore dataStore;
+    private final DomainRoleMembersFetcherCommon domainRoleMembersFetcherCommon;
+
+    public ZTSDomainRoleMembersFetcher(DataStore dataStore, String userDomainPrefix) {
+        this.dataStore = dataStore;
+        this.domainRoleMembersFetcherCommon = new DomainRoleMembersFetcherCommon(userDomainPrefix);
+    }
+
+    @Override
+    public Set<String> getDomainRoleMembers(String domainName, String roleName) {
+        if (dataStore == null) {
+            return new HashSet<>();
+        }
+
+        DomainData domainData = dataStore.getDomainData(domainName);
+        if (domainData == null) {
+            return new HashSet<>();
+        }
+
+        return domainRoleMembersFetcherCommon.getDomainRoleMembers(roleName, domainData.getRoles());
+    }
+}

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/ZTSNotificationTaskFactory.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/notification/ZTSNotificationTaskFactory.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2020 Verizon Media
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.zts.notification;
+
+import com.yahoo.athenz.common.server.notification.NotificationTask;
+import com.yahoo.athenz.common.server.notification.NotificationTaskFactory;
+import com.yahoo.athenz.zts.cert.InstanceCertManager;
+import com.yahoo.athenz.zts.store.DataStore;
+
+import java.util.Collections;
+import java.util.List;
+
+public class ZTSNotificationTaskFactory implements NotificationTaskFactory {
+    private final InstanceCertManager instanceCertManager;
+    private final DataStore dataStore;
+    private final String userDomainPrefix;
+    private final String serverName;
+
+    public ZTSNotificationTaskFactory(InstanceCertManager instanceCertManager, DataStore dataStore, String userDomainPrefix, String serverName) {
+        this.instanceCertManager = instanceCertManager;
+        this.dataStore = dataStore;
+        this.userDomainPrefix = userDomainPrefix;
+        this.serverName = serverName;
+    }
+
+    @Override
+    public List<NotificationTask> getNotificationTasks() {
+        return Collections.singletonList(new CertFailedRefreshNotificationTask(instanceCertManager, dataStore, userDomainPrefix, serverName));
+    }
+}

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -6190,7 +6190,8 @@ public class ZTSImplTest {
 
         try {
             ztsImpl.getValidatedX509CertRecord(context, "athenz.provider", "1001",
-                    "athenz.production", cert, "caller", "athenz", "athenz");
+                    "athenz.production", cert, "caller", "athenz", "athenz",
+                    "localhost");
             fail();
         } catch (ResourceException ex) {
             assertEquals(403, ex.getCode());
@@ -6232,7 +6233,8 @@ public class ZTSImplTest {
         ztsImpl.x509CertRefreshResetTime = cert.getNotBefore().getTime() + 1;
 
         X509CertRecord certRecord =  ztsImpl.getValidatedX509CertRecord(context, "athenz.provider",
-                "1001", "athenz.production", cert, "caller", "athenz", "athenz");
+                "1001", "athenz.production", cert, "caller", "athenz", "athenz",
+                "localhost");
         assertNotNull(certRecord);
     }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
@@ -53,34 +53,44 @@ public class DynamoDBCertRecordStoreConnectionTest {
     public void testGetX509CertRecord() {
 
         Date now = new Date();
-        long tstamp = now.getTime();
-
-        Mockito.doReturn(item).when(table).getItem("primaryKey", "athenz.provider:cn:1234");
-
-        Mockito.doReturn("cn").when(item).getString("service");
-        Mockito.doReturn("current-serial").when(item).getString("currentSerial");
-        Mockito.doReturn("current-ip").when(item).getString("currentIP");
-        Mockito.doReturn(tstamp).when(item).getLong("currentTime");
-        Mockito.doReturn("prev-serial").when(item).getString("prevSerial");
-        Mockito.doReturn("prev-ip").when(item).getString("prevIP");
-        Mockito.doReturn(tstamp).when(item).getLong("prevTime");
-        Mockito.doReturn(false).when(item).getBoolean("clientCert");
+        long tstamp = mockNonNullableColumns(now);
+        Mockito.doReturn(tstamp).when(item).getLong("lastNotifiedTime");
+        Mockito.doReturn("last-notified-server").when(item).getString("lastNotifiedServer");
+        Mockito.doReturn(tstamp).when(item).getLong("expiryTime");
+        Mockito.doReturn("hostname").when(item).getString("hostName");
 
         DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
         dbConn.setOperationTimeout(10);
         X509CertRecord certRecord = dbConn.getX509CertRecord("athenz.provider", "1234", "cn");
 
-        assertNotNull(certRecord);
-        assertEquals(certRecord.getService(), "cn");
-        assertEquals(certRecord.getCurrentIP(), "current-ip");
-        assertEquals(certRecord.getCurrentSerial(), "current-serial");
-        assertEquals(certRecord.getCurrentTime(), now);
-        assertEquals(certRecord.getInstanceId(), "1234");
-        assertEquals(certRecord.getPrevIP(), "prev-ip");
-        assertEquals(certRecord.getPrevSerial(), "prev-serial");
-        assertEquals(certRecord.getPrevTime(), now);
-        assertEquals(certRecord.getProvider(), "athenz.provider");
-        assertFalse(certRecord.getClientCert());
+        assertNonNullableColumns(now, certRecord);
+        assertEquals(certRecord.getLastNotifiedTime(), now);
+        assertEquals(certRecord.getLastNotifiedServer(), "last-notified-server");
+        assertEquals(certRecord.getExpiryTime(), now);
+        assertEquals(certRecord.getHostName(), "hostname");
+
+        dbConn.close();
+    }
+
+    @Test
+    public void testGetX509CertRecordNullableColumns() {
+
+        Date now = new Date();
+        mockNonNullableColumns(now);
+        Mockito.doReturn(true).when(item).isNull("lastNotifiedTime");
+        Mockito.doReturn(true).when(item).isNull("lastNotifiedServer");
+        Mockito.doReturn(true).when(item).isNull("expiryTime");
+        Mockito.doReturn(true).when(item).isNull("hostName");
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+        dbConn.setOperationTimeout(10);
+        X509CertRecord certRecord = dbConn.getX509CertRecord("athenz.provider", "1234", "cn");
+
+        assertNonNullableColumns(now, certRecord);
+        assertNull(certRecord.getLastNotifiedTime());
+        assertNull(certRecord.getLastNotifiedServer());
+        assertNull(certRecord.getExpiryTime());
+        assertNull(certRecord.getHostName());
 
         dbConn.close();
     }
@@ -113,19 +123,12 @@ public class DynamoDBCertRecordStoreConnectionTest {
 
         DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
 
-        X509CertRecord certRecord = new X509CertRecord();
         Date now = new Date();
-
-        certRecord.setService("cn");
-        certRecord.setProvider("athenz.provider");
-        certRecord.setInstanceId("1234");
-        certRecord.setCurrentIP("current-ip");
-        certRecord.setCurrentSerial("current-serial");
-        certRecord.setCurrentTime(now);
-        certRecord.setPrevIP("prev-ip");
-        certRecord.setPrevSerial("prev-serial");
-        certRecord.setPrevTime(now);
-        certRecord.setClientCert(false);
+        X509CertRecord certRecord = getRecordNonNullableColumns(now);
+        certRecord.setLastNotifiedTime(now);
+        certRecord.setLastNotifiedServer("last-notified-server");
+        certRecord.setExpiryTime(now);
+        certRecord.setHostName("hostname");
 
         Item item = new Item()
                 .withPrimaryKey("primaryKey", "athenz.provider:cn:1234")
@@ -139,7 +142,48 @@ public class DynamoDBCertRecordStoreConnectionTest {
                 .withString("prevIP", certRecord.getPrevIP())
                 .withLong("prevTime", certRecord.getPrevTime().getTime())
                 .withBoolean("clientCert", certRecord.getClientCert())
-                .withLong("ttl", certRecord.getCurrentTime().getTime() / 1000L + 3660 * 720);
+                .withLong("ttl", certRecord.getCurrentTime().getTime() / 1000L + 3660 * 720)
+                .withLong("lastNotifiedTime", certRecord.getLastNotifiedTime().getTime())
+                .withString("lastNotifiedServer", certRecord.getLastNotifiedServer())
+                .withLong("expiryTime", certRecord.getExpiryTime().getTime())
+                .withString("hostName", certRecord.getHostName());
+
+        Mockito.doReturn(putOutcome).when(table).putItem(item);
+        boolean requestSuccess = dbConn.insertX509CertRecord(certRecord);
+        assertTrue(requestSuccess);
+
+        dbConn.close();
+    }
+
+    @Test
+    public void testInsertX509RecordNullableColumns() {
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+
+        Date now = new Date();
+        X509CertRecord certRecord = getRecordNonNullableColumns(now);
+        certRecord.setLastNotifiedTime(null);
+        certRecord.setLastNotifiedServer(null);
+        certRecord.setExpiryTime(null);
+        certRecord.setHostName(null);
+
+        Item item = new Item()
+                .withPrimaryKey("primaryKey", "athenz.provider:cn:1234")
+                .withString("instanceId", certRecord.getInstanceId())
+                .withString("provider", certRecord.getProvider())
+                .withString("service", certRecord.getService())
+                .withString("currentSerial", certRecord.getCurrentSerial())
+                .withString("currentIP", certRecord.getCurrentIP())
+                .withLong("currentTime", certRecord.getCurrentTime().getTime())
+                .withString("prevSerial", certRecord.getPrevSerial())
+                .withString("prevIP", certRecord.getPrevIP())
+                .withLong("prevTime", certRecord.getPrevTime().getTime())
+                .withBoolean("clientCert", certRecord.getClientCert())
+                .withLong("ttl", certRecord.getCurrentTime().getTime() / 1000L + 3660 * 720)
+                .with("lastNotifiedTime", null)
+                .with("lastNotifiedServer", null)
+                .with("expiryTime", null)
+                .with("hostName", null);
 
         Mockito.doReturn(putOutcome).when(table).putItem(item);
         boolean requestSuccess = dbConn.insertX509CertRecord(certRecord);
@@ -151,19 +195,8 @@ public class DynamoDBCertRecordStoreConnectionTest {
     @Test
     public void testInsertX509RecordException() {
 
-        X509CertRecord certRecord = new X509CertRecord();
         Date now = new Date();
-
-        certRecord.setService("cn");
-        certRecord.setProvider("athenz.provider");
-        certRecord.setInstanceId("1234");
-        certRecord.setCurrentIP("current-ip");
-        certRecord.setCurrentSerial("current-serial");
-        certRecord.setCurrentTime(now);
-        certRecord.setPrevIP("prev-ip");
-        certRecord.setPrevSerial("prev-serial");
-        certRecord.setPrevTime(now);
-        certRecord.setClientCert(false);
+        X509CertRecord certRecord = getRecordNonNullableColumns(now);
 
         Mockito.doThrow(new AmazonDynamoDBException("invalid operation"))
                 .when(table).putItem(ArgumentMatchers.any(Item.class));
@@ -180,19 +213,12 @@ public class DynamoDBCertRecordStoreConnectionTest {
 
         DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
 
-        X509CertRecord certRecord = new X509CertRecord();
         Date now = new Date();
-
-        certRecord.setService("cn");
-        certRecord.setProvider("athenz.provider");
-        certRecord.setInstanceId("1234");
-        certRecord.setCurrentIP("current-ip");
-        certRecord.setCurrentSerial("current-serial");
-        certRecord.setCurrentTime(now);
-        certRecord.setPrevIP("prev-ip");
-        certRecord.setPrevSerial("prev-serial");
-        certRecord.setPrevTime(now);
-        certRecord.setClientCert(false);
+        X509CertRecord certRecord = getRecordNonNullableColumns(now);
+        certRecord.setLastNotifiedTime(now);
+        certRecord.setLastNotifiedServer("last-notified-server");
+        certRecord.setExpiryTime(now);
+        certRecord.setHostName("hostname");
 
         UpdateItemSpec item = new UpdateItemSpec()
                 .withPrimaryKey("primaryKey", "athenz.provider:cn:1234")
@@ -207,7 +233,49 @@ public class DynamoDBCertRecordStoreConnectionTest {
                         new AttributeUpdate("prevIP").put(certRecord.getPrevIP()),
                         new AttributeUpdate("prevTime").put(certRecord.getPrevTime().getTime()),
                         new AttributeUpdate("clientCert").put(certRecord.getClientCert()),
-                        new AttributeUpdate("ttl").put(certRecord.getCurrentTime().getTime() / 1000L + 3660 * 720));
+                        new AttributeUpdate("ttl").put(certRecord.getCurrentTime().getTime() / 1000L + 3660 * 720),
+                        new AttributeUpdate("lastNotifiedTime").put(certRecord.getLastNotifiedTime().getTime()),
+                        new AttributeUpdate("lastNotifiedServer").put(certRecord.getLastNotifiedServer()),
+                        new AttributeUpdate("expiryTime").put(certRecord.getExpiryTime().getTime()),
+                        new AttributeUpdate("hostName").put(certRecord.getHostName()));
+
+        Mockito.doReturn(updateOutcome).when(table).updateItem(item);
+        boolean requestSuccess = dbConn.updateX509CertRecord(certRecord);
+        assertTrue(requestSuccess);
+
+        dbConn.close();
+    }
+
+    @Test
+    public void testUpdateX509RecordNullableColumns() {
+
+        DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
+
+        Date now = new Date();
+        X509CertRecord certRecord = getRecordNonNullableColumns(now);
+        certRecord.setLastNotifiedTime(null);
+        certRecord.setLastNotifiedServer(null);
+        certRecord.setExpiryTime(null);
+        certRecord.setHostName(null);
+
+        UpdateItemSpec item = new UpdateItemSpec()
+                .withPrimaryKey("primaryKey", "athenz.provider:cn:1234")
+                .withAttributeUpdate(
+                        new AttributeUpdate("instanceId").put(certRecord.getInstanceId()),
+                        new AttributeUpdate("provider").put(certRecord.getProvider()),
+                        new AttributeUpdate("service").put(certRecord.getService()),
+                        new AttributeUpdate("currentSerial").put(certRecord.getCurrentSerial()),
+                        new AttributeUpdate("currentIP").put(certRecord.getCurrentIP()),
+                        new AttributeUpdate("currentTime").put(certRecord.getCurrentTime().getTime()),
+                        new AttributeUpdate("prevSerial").put(certRecord.getPrevSerial()),
+                        new AttributeUpdate("prevIP").put(certRecord.getPrevIP()),
+                        new AttributeUpdate("prevTime").put(certRecord.getPrevTime().getTime()),
+                        new AttributeUpdate("clientCert").put(certRecord.getClientCert()),
+                        new AttributeUpdate("ttl").put(certRecord.getCurrentTime().getTime() / 1000L + 3660 * 720),
+                        new AttributeUpdate("lastNotifiedTime").put(null),
+                        new AttributeUpdate("lastNotifiedServer").put(null),
+                        new AttributeUpdate("expiryTime").put(null),
+                        new AttributeUpdate("hostName").put(null));
 
         Mockito.doReturn(updateOutcome).when(table).updateItem(item);
         boolean requestSuccess = dbConn.updateX509CertRecord(certRecord);
@@ -219,19 +287,8 @@ public class DynamoDBCertRecordStoreConnectionTest {
     @Test
     public void testUpdateX509RecordException() {
 
-        X509CertRecord certRecord = new X509CertRecord();
         Date now = new Date();
-
-        certRecord.setService("cn");
-        certRecord.setProvider("athenz.provider");
-        certRecord.setInstanceId("1234");
-        certRecord.setCurrentIP("current-ip");
-        certRecord.setCurrentSerial("current-serial");
-        certRecord.setCurrentTime(now);
-        certRecord.setPrevIP("prev-ip");
-        certRecord.setPrevSerial("prev-serial");
-        certRecord.setPrevTime(now);
-        certRecord.setClientCert(false);
+        X509CertRecord certRecord = getRecordNonNullableColumns(now);
 
         Mockito.doThrow(new AmazonDynamoDBException("invalid operation"))
                 .when(table).updateItem(ArgumentMatchers.any(UpdateItemSpec.class));
@@ -276,4 +333,50 @@ public class DynamoDBCertRecordStoreConnectionTest {
         assertEquals(0, dbConn.deleteExpiredX509CertRecords(100000));
         dbConn.close();
     }
+
+    private X509CertRecord getRecordNonNullableColumns(Date now) {
+        X509CertRecord certRecord = new X509CertRecord();
+        certRecord.setService("cn");
+        certRecord.setProvider("athenz.provider");
+        certRecord.setInstanceId("1234");
+        certRecord.setCurrentIP("current-ip");
+        certRecord.setCurrentSerial("current-serial");
+        certRecord.setCurrentTime(now);
+        certRecord.setPrevIP("prev-ip");
+        certRecord.setPrevSerial("prev-serial");
+        certRecord.setPrevTime(now);
+        certRecord.setClientCert(false);
+        return certRecord;
+    }
+
+    private void assertNonNullableColumns(Date now, X509CertRecord certRecord) {
+        assertNotNull(certRecord);
+        assertEquals(certRecord.getService(), "cn");
+        assertEquals(certRecord.getCurrentIP(), "current-ip");
+        assertEquals(certRecord.getCurrentSerial(), "current-serial");
+        assertEquals(certRecord.getCurrentTime(), now);
+        assertEquals(certRecord.getInstanceId(), "1234");
+        assertEquals(certRecord.getPrevIP(), "prev-ip");
+        assertEquals(certRecord.getPrevSerial(), "prev-serial");
+        assertEquals(certRecord.getPrevTime(), now);
+        assertEquals(certRecord.getProvider(), "athenz.provider");
+        assertFalse(certRecord.getClientCert());
+    }
+
+    private long mockNonNullableColumns(Date now) {
+        long tstamp = now.getTime();
+
+        Mockito.doReturn(item).when(table).getItem("primaryKey", "athenz.provider:cn:1234");
+
+        Mockito.doReturn("cn").when(item).getString("service");
+        Mockito.doReturn("current-serial").when(item).getString("currentSerial");
+        Mockito.doReturn("current-ip").when(item).getString("currentIP");
+        Mockito.doReturn(tstamp).when(item).getLong("currentTime");
+        Mockito.doReturn("prev-serial").when(item).getString("prevSerial");
+        Mockito.doReturn("prev-ip").when(item).getString("prevIP");
+        Mockito.doReturn(tstamp).when(item).getLong("prevTime");
+        Mockito.doReturn(false).when(item).getBoolean("clientCert");
+        return tstamp;
+    }
+
 }


### PR DESCRIPTION
- Created CertFailedRefreshNotificationTask but not yet implemented. Will be implemented after DB logic is approved.
- CertRecordStoreConnection - Added 2 methods to fetch unrefreshed certificates that haven't been notified by other servers.
- DomainRoleMembersFetcherCommon - Added common implementation for ZMS entities (and added a dependency on athenz-zms-core in common)
- JDBCCertRecordStoreConnection - Modified Insert / Update methods for new notification columns.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
