### PR TITLE
fixes to cert-db changes

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -3055,6 +3055,7 @@ public class ZTSImpl implements KeyStore, ZTSHandler {
             x509CertRecord.setCurrentSerial(certSerialNumber);
             x509CertRecord.setCurrentIP(reqIp);
             x509CertRecord.setCurrentTime(new Date());
+            x509CertRecord.setExpiryTime(newCert.getNotAfter());
 
             // we must be able to update our record db otherwise we will
             // not be able to validate the refresh request next time

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnection.java
@@ -107,7 +107,7 @@ public class DynamoDBCertRecordStoreConnection implements CertRecordStoreConnect
     }
 
     private Date getDateFromItem(Item item, String key) {
-        if (item.isNull(key)) {
+        if (item.isNull(key) || item.get(key) == null) {
             return null;
         }
 
@@ -143,10 +143,7 @@ public class DynamoDBCertRecordStoreConnection implements CertRecordStoreConnect
                             new AttributeUpdate(KEY_PREV_TIME).put(getLongFromDate(certRecord.getPrevTime())),
                             new AttributeUpdate(KEY_CLIENT_CERT).put(certRecord.getClientCert()),
                             new AttributeUpdate(KEY_TTL).put(certRecord.getCurrentTime().getTime() / 1000L + expiryTime),
-                            new AttributeUpdate(KEY_LAST_NOTIFIED_TIME).put(getLongFromDate(certRecord.getLastNotifiedTime())),
-                            new AttributeUpdate(KEY_LAST_NOTIFIED_SERVER).put(certRecord.getLastNotifiedServer()),
-                            new AttributeUpdate(KEY_EXPIRY_TIME).put(getLongFromDate(certRecord.getExpiryTime())),
-                            new AttributeUpdate(KEY_HOSTNAME).put(certRecord.getHostName())
+                            new AttributeUpdate(KEY_EXPIRY_TIME).put(getLongFromDate(certRecord.getExpiryTime()))
                     );
             table.updateItem(updateItemSpec);
             return true;
@@ -175,8 +172,6 @@ public class DynamoDBCertRecordStoreConnection implements CertRecordStoreConnect
                     .with(KEY_PREV_TIME, getLongFromDate(certRecord.getPrevTime()))
                     .withBoolean(KEY_CLIENT_CERT, certRecord.getClientCert())
                     .withLong(KEY_TTL, certRecord.getCurrentTime().getTime() / 1000L + expiryTime)
-                    .with(KEY_LAST_NOTIFIED_TIME, getLongFromDate(certRecord.getLastNotifiedTime()))
-                    .with(KEY_LAST_NOTIFIED_SERVER, certRecord.getLastNotifiedServer())
                     .with(KEY_EXPIRY_TIME, getLongFromDate(certRecord.getExpiryTime()))
                     .with(KEY_HOSTNAME, certRecord.getHostName());
             table.putItem(item);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreConnection.java
@@ -35,11 +35,11 @@ public class JDBCCertRecordStoreConnection implements CertRecordStoreConnection 
     private static final String SQL_GET_X509_RECORD = "SELECT * FROM certificates WHERE provider=? AND instanceId=? AND service=?;";
     private static final String SQL_INSERT_X509_RECORD = "INSERT INTO certificates " +
             "(provider, instanceId, service, currentSerial, currentTime, currentIP, prevSerial, prevTime, prevIP, clientCert, " +
-            "lastNotifiedTime, lastNotifiedServer, expiryTime, hostName) " +
-            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?);";
+            "expiryTime, hostName) " +
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?);";
     private static final String SQL_UPDATE_X509_RECORD = "UPDATE certificates SET " +
             "currentSerial=?, currentTime=?, currentIP=?, prevSerial=?, prevTime=?, prevIP=?, " +
-            "lastNotifiedTime=?, lastNotifiedServer=?, expiryTime=?, hostName=? " +
+            "expiryTime=?, hostName=? " +
             "WHERE provider=? AND instanceId=? AND service=?;";
     private static final String SQL_DELETE_X509_RECORD = "DELETE from certificates " +
             "WHERE provider=? AND instanceId=? AND service=?;";
@@ -180,13 +180,11 @@ public class JDBCCertRecordStoreConnection implements CertRecordStoreConnection 
             ps.setString(4, certRecord.getPrevSerial());
             ps.setTimestamp(5, getTimestampFromDate(certRecord.getPrevTime()));
             ps.setString(6, certRecord.getPrevIP());
-            ps.setTimestamp(7, getTimestampFromDate(certRecord.getLastNotifiedTime()));
-            ps.setString(8, certRecord.getLastNotifiedServer());
-            ps.setTimestamp(9, getTimestampFromDate(certRecord.getExpiryTime()));
-            ps.setString(10, certRecord.getHostName());
-            ps.setString(11, certRecord.getProvider());
-            ps.setString(12, certRecord.getInstanceId());
-            ps.setString(13, certRecord.getService());
+            ps.setTimestamp(7, getTimestampFromDate(certRecord.getExpiryTime()));
+            ps.setString(8, certRecord.getHostName());
+            ps.setString(9, certRecord.getProvider());
+            ps.setString(10, certRecord.getInstanceId());
+            ps.setString(11, certRecord.getService());
             affectedRows = executeUpdate(ps, caller);
         } catch (SQLException ex) {
             throw sqlError(ex, caller);
@@ -211,10 +209,8 @@ public class JDBCCertRecordStoreConnection implements CertRecordStoreConnection 
             ps.setTimestamp(8, getTimestampFromDate(certRecord.getPrevTime()));
             ps.setString(9, certRecord.getPrevIP());
             ps.setBoolean(10, certRecord.getClientCert());
-            ps.setTimestamp(11, getTimestampFromDate(certRecord.getLastNotifiedTime()));
-            ps.setString(12, certRecord.getLastNotifiedServer());
-            ps.setTimestamp(13, getTimestampFromDate(certRecord.getExpiryTime()));
-            ps.setString(14, certRecord.getHostName());
+            ps.setTimestamp(11, getTimestampFromDate(certRecord.getExpiryTime()));
+            ps.setString(12, certRecord.getHostName());
 
             affectedRows = executeUpdate(ps, caller);
             

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
@@ -55,8 +55,10 @@ public class DynamoDBCertRecordStoreConnectionTest {
         Date now = new Date();
         long tstamp = mockNonNullableColumns(now);
         Mockito.doReturn(tstamp).when(item).getLong("lastNotifiedTime");
+        Mockito.doReturn(tstamp).when(item).get("lastNotifiedTime");
         Mockito.doReturn("last-notified-server").when(item).getString("lastNotifiedServer");
         Mockito.doReturn(tstamp).when(item).getLong("expiryTime");
+        Mockito.doReturn(tstamp).when(item).get("expiryTime");
         Mockito.doReturn("hostname").when(item).getString("hostName");
 
         DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
@@ -367,14 +369,18 @@ public class DynamoDBCertRecordStoreConnectionTest {
         long tstamp = now.getTime();
 
         Mockito.doReturn(item).when(table).getItem("primaryKey", "athenz.provider:cn:1234");
+        Mockito.doReturn(false).when(item).isNull("currentTime");
+        Mockito.doReturn(false).when(item).isNull("prevTime");
 
         Mockito.doReturn("cn").when(item).getString("service");
         Mockito.doReturn("current-serial").when(item).getString("currentSerial");
         Mockito.doReturn("current-ip").when(item).getString("currentIP");
         Mockito.doReturn(tstamp).when(item).getLong("currentTime");
+        Mockito.doReturn(tstamp).when(item).get("currentTime");
         Mockito.doReturn("prev-serial").when(item).getString("prevSerial");
         Mockito.doReturn("prev-ip").when(item).getString("prevIP");
         Mockito.doReturn(tstamp).when(item).getLong("prevTime");
+        Mockito.doReturn(tstamp).when(item).get("prevTime");
         Mockito.doReturn(false).when(item).getBoolean("clientCert");
         return tstamp;
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreConnectionTest.java
@@ -154,9 +154,7 @@ public class JDBCCertRecordStoreConnectionTest {
 
         verifyInsertNonNullableColumns(now);
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(11, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(12, "last-notified-server");
-        Mockito.verify(mockPrepStmt, times(1)).setTimestamp(13, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(14, "hostname");
+        Mockito.verify(mockPrepStmt, times(1)).setString(12, "hostname");
 
         jdbcConn.close();
     }
@@ -180,8 +178,6 @@ public class JDBCCertRecordStoreConnectionTest {
         verifyInsertNonNullableColumns(now);
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(11, null);
         Mockito.verify(mockPrepStmt, times(1)).setString(12, null);
-        Mockito.verify(mockPrepStmt, times(1)).setTimestamp(13, null);
-        Mockito.verify(mockPrepStmt, times(1)).setString(14, null);
 
         jdbcConn.close();
     }
@@ -216,9 +212,7 @@ public class JDBCCertRecordStoreConnectionTest {
         Mockito.verify(mockPrepStmt, times(1)).setString(9, "prev-ip");
         Mockito.verify(mockPrepStmt, times(1)).setBoolean(10, false);
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(11, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(12, "last-notified-server");
-        Mockito.verify(mockPrepStmt, times(1)).setTimestamp(13, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(14, "hostname");
+        Mockito.verify(mockPrepStmt, times(1)).setString(12, "hostname");
 
         Mockito.verify(mockPrepStmt, times(1)).setString(1, "current-serial");
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(2, new java.sql.Timestamp(now.getTime()));
@@ -226,12 +220,10 @@ public class JDBCCertRecordStoreConnectionTest {
         Mockito.verify(mockPrepStmt, times(1)).setString(4, "prev-serial");
         Mockito.verify(mockPrepStmt, times(1)).setString(6, "prev-ip");
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(7, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(8, "last-notified-server");
-        Mockito.verify(mockPrepStmt, times(1)).setTimestamp(9, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(10, "hostname");
-        Mockito.verify(mockPrepStmt, times(1)).setString(11, "ostk");
-        Mockito.verify(mockPrepStmt, times(1)).setString(12, "instance-id");
-        Mockito.verify(mockPrepStmt, times(1)).setString(13, "cn");
+        Mockito.verify(mockPrepStmt, times(1)).setString(8, "hostname");
+        Mockito.verify(mockPrepStmt, times(1)).setString(9, "ostk");
+        Mockito.verify(mockPrepStmt, times(1)).setString(10, "instance-id");
+        Mockito.verify(mockPrepStmt, times(1)).setString(11, "cn");
 
         // common between insert/update so count is 2 times
         Mockito.verify(mockPrepStmt, times(2)).setTimestamp(5, new java.sql.Timestamp(now.getTime()));
@@ -246,11 +238,8 @@ public class JDBCCertRecordStoreConnectionTest {
 
         Date now = new Date();
         X509CertRecord certRecord = getRecordWithNonNullableColumns(now);
-        certRecord.setLastNotifiedTime(now);
-        certRecord.setLastNotifiedServer("lat-notified-server");
         certRecord.setExpiryTime(now);
         certRecord.setHostName("hostname");
-
 
         Mockito.doThrow(new SQLException("error", "state", 503))
                 .when(mockPrepStmt).executeUpdate();
@@ -283,9 +272,7 @@ public class JDBCCertRecordStoreConnectionTest {
 
         verifyUpdateNonNullableColumns(now);
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(7, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(8, "last-notified-server");
-        Mockito.verify(mockPrepStmt, times(1)).setTimestamp(9, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(10, "hostname");
+        Mockito.verify(mockPrepStmt, times(1)).setString(8, "hostname");
 
         jdbcConn.close();
     }
@@ -309,8 +296,6 @@ public class JDBCCertRecordStoreConnectionTest {
         verifyUpdateNonNullableColumns(now);
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(7, null);
         Mockito.verify(mockPrepStmt, times(1)).setString(8, null);
-        Mockito.verify(mockPrepStmt, times(1)).setTimestamp(9, null);
-        Mockito.verify(mockPrepStmt, times(1)).setString(10, null);
 
         jdbcConn.close();
     }
@@ -322,9 +307,9 @@ public class JDBCCertRecordStoreConnectionTest {
         Mockito.verify(mockPrepStmt, times(1)).setString(4, "prev-serial");
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(5, new Timestamp(now.getTime()));
         Mockito.verify(mockPrepStmt, times(1)).setString(6, "prev-ip");
-        Mockito.verify(mockPrepStmt, times(1)).setString(11, "ostk");
-        Mockito.verify(mockPrepStmt, times(1)).setString(12, "instance-id");
-        Mockito.verify(mockPrepStmt, times(1)).setString(13, "cn");
+        Mockito.verify(mockPrepStmt, times(1)).setString(9, "ostk");
+        Mockito.verify(mockPrepStmt, times(1)).setString(10, "instance-id");
+        Mockito.verify(mockPrepStmt, times(1)).setString(11, "cn");
     }
 
     @Test
@@ -334,8 +319,6 @@ public class JDBCCertRecordStoreConnectionTest {
 
         Date now = new Date();
         X509CertRecord certRecord = getRecordWithNonNullableColumns(now);
-        certRecord.setLastNotifiedTime(now);
-        certRecord.setLastNotifiedServer("last-notified-server");
         certRecord.setExpiryTime(now);
         certRecord.setHostName("hostname");
 


### PR DESCRIPTION
JDBC changes: when inserting or updating a record there is no need to set the last notified stamp and server name since those are never set or modified during those operations. Those are only set during the notification processing.

DynamoDB: item isNull is not enough if the column data is null, otherwise we get a number exception. added a check to make sure get(attrName) is null or not.

ZTS: expiry time was not updated during the refresh operation so that's fixed now.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
