### PR TITLE
extend self serve functionality

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -7470,15 +7470,6 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         return isAllowedPutMembershipAccess(principal, reqDomain, role);
     }
 
-    boolean isAllowedPutMembershipSelfServe(final Principal principal, final Role role, final RoleMember member) {
-
-        if (role.getSelfServe() != Boolean.TRUE) {
-            return false;
-        }
-
-        return principal.getFullName().equals(member.getMemberName());
-    }
-
     boolean isAllowedPutMembership(Principal principal, final AthenzDomain domain, final Role role,
             final RoleMember member) {
 
@@ -7495,10 +7486,11 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             member.setApproved(!auditEnabled);
             return true;
 
-        } else if (isAllowedPutMembershipSelfServe(principal, role, member)) {
+        } else if (role.getSelfServe() == Boolean.TRUE) {
 
-            // if the role is self-serve, and users are trying to add themselves, allow it
-            // but with member status set to inactive. It has to be approved by domain admins.
+            // if the role is self-serve then users are allowed to add anyone
+            // since the request must be approved by someone else so we'll allow it
+            // but with member status set to inactive.
 
             member.setActive(false);
             member.setApproved(false);


### PR DESCRIPTION
since with self-serve someone else (domain admin for regular roles and external approvers for audit enabled roles) needs to approve the request, there is no point to limit to the users themselves. we now allow in the self-serve role for anyone to add anyone else.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
