### PR TITLE
implementation of ssh cert record registration

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -174,6 +174,7 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_PRIVATE_KEY_STORE_FACTORY_CLASS  = "athenz.zts.private_key_store_factory_class";
     public static final String ZTS_PROP_CERT_RECORD_STORE_FACTORY_CLASS  = "athenz.zts.cert_record_store_factory_class";
     public static final String ZTS_PROP_HOSTNAME_RESOLVER_FACTORY_CLASS  = "athenz.zts.hostname_resolver_factory_class";
+    public static final String ZTS_PROP_SSH_RECORD_STORE_FACTORY_CLASS   = "athenz.zts.ssh_record_store_factory_class";
 
     public static final String ZTS_METRIC_FACTORY_CLASS            = "com.yahoo.athenz.common.metrics.impl.NoOpMetricFactory";
     public static final String ZTS_CHANGE_LOG_STORE_FACTORY_CLASS  = "com.yahoo.athenz.zts.store.impl.ZMSFileChangeLogStoreFactory";

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -5150,7 +5150,8 @@ public class ZTSImplTest {
         Mockito.when(providerClient.confirmInstance(Mockito.any())).thenReturn(confirmation);
         Mockito.when(instanceManager.insertX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.doThrow(new ResourceException(500, "Invalid SSH")).when(instanceManager)
-                .generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
+                .generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.any());
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
@@ -5212,8 +5213,8 @@ public class ZTSImplTest {
         Mockito.when(instanceProviderManager.getProvider("athenz.provider")).thenReturn(providerClient);
         Mockito.when(providerClient.confirmInstance(Mockito.any())).thenReturn(confirmation);
         Mockito.when(instanceManager.insertX509CertRecord(Mockito.any())).thenReturn(true);
-        Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(true);
+        Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(true);
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
@@ -5909,7 +5910,7 @@ public class ZTSImplTest {
                 .setProvider("athenz.provider").setToken(false);
         
         Mockito.doReturn(false).when(instanceManager).generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(),
-                Mockito.any(), Mockito.any());
+                Mockito.any(), Mockito.any(), Mockito.any());
         
         ResourceContext context = createResourceContext(null);
 
@@ -6079,8 +6080,8 @@ public class ZTSImplTest {
         certRecord.setPrevSerial("16503746516960996918");
         Mockito.when(instanceManager.getX509CertRecord("athenz.provider", "1001", "athenz.production")).thenReturn(certRecord);
         Mockito.when(instanceManager.updateX509CertRecord(Mockito.any())).thenReturn(true);
-        Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
-                .thenReturn(true);
+        Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(true);
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
@@ -6739,7 +6740,7 @@ public class ZTSImplTest {
         Mockito.when(instanceManager.getX509CertRecord("athenz.provider", "1001", "athenz.production")).thenReturn(certRecord);
         Mockito.when(instanceManager.updateX509CertRecord(Mockito.any())).thenReturn(true);
         Mockito.when(instanceManager.generateSSHIdentity(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.eq("ssh-csr"),
-                Mockito.eq("user"))).thenReturn(false);
+                Mockito.any(), Mockito.eq("user"))).thenReturn(false);
 
         path = Paths.get("src/test/resources/athenz.instanceid.pem");
         String pem = new String(Files.readAllBytes(path));
@@ -7572,7 +7573,7 @@ public class ZTSImplTest {
                 "v=S1;d=athenz;n=production;s=signature", 0, certAuthority);
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production");
-        Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr", "user")).thenReturn(true);
+        Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr", null, "user")).thenReturn(true);
         
         ztsImpl.instanceCertManager = instanceManager;
         
@@ -7621,7 +7622,7 @@ public class ZTSImplTest {
                 "v=S1;d=athenz;n=production;s=signature", 0, certAuthority);
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production");
-        Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr", "user")).thenReturn(true);
+        Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr", null, "user")).thenReturn(true);
         
         ztsImpl.instanceCertManager = instanceManager;
         
@@ -7670,7 +7671,7 @@ public class ZTSImplTest {
                 "v=S1;d=athenz;n=production;s=signature", 0, certAuthority);
 
         InstanceIdentity identity = new InstanceIdentity().setName("athenz.production");
-        Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr", "user")).thenReturn(false);
+        Mockito.when(instanceManager.generateSSHIdentity(principal, identity, null, "ssh-csr", null, "user")).thenReturn(false);
         
         ztsImpl.instanceCertManager = instanceManager;
         


### PR DESCRIPTION
if configured, when a host registers or refreshers its x.509 identity and requests ssh certs as well, the server will keep record of the ssh cert details and pass them to the ssh signer when the caller (possibly ssh bastion) is trying to get host certs using the /sshcert endpoint.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
