### PR TITLE
Returning empty map instead of null in FileStore implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,4 @@ libs/nodejs/auth_core/package-lock.json
 ui/package-lock.json
 .envrc
 .clover/
+athenz-docker-build.log

--- a/docker/zms/conf/authorized_services.json
+++ b/docker/zms/conf/authorized_services.json
@@ -31,7 +31,14 @@
                 { "name":"deleteserviceidentity" },
                 { "name":"putpublickeyentry" },
                 { "name":"deletepublickeyentry" },
-                { "name":"putdomainmeta" }
+                { "name":"putdomainmeta" },
+                { "name":"putdomainsystemmeta" },
+                { "name":"putdomaintemplate" },
+                { "name":"putrolemeta" },
+                { "name":"putmembershipdecision" },
+                { "name":"putrolereview" },
+                { "name":"deletedomainrolemember" },
+                { "name":"deletependingmembership" }
             ]
         }
     }

--- a/docker/zms/conf/zms.properties
+++ b/docker/zms/conf/zms.properties
@@ -17,6 +17,13 @@ athenz.zms.authority_classes=com.yahoo.athenz.auth.impl.PrincipalAuthority,com.y
 # in the athenz.zms.authority_classes setting
 #athenz.zms.principal_authority_class=
 
+# User Authority class. If defined and the server is configured to validate
+# all user principals when adding them as members in a role (this is configured
+# with athenz.zms.validate_user_members property), the ZMS Server will call
+# the authority isValidUser api method for validation. This class must be one of
+# the classes listed in the athenz.zms.authority_classes setting
+#athenz.zms.user_authority_class=
+
 # Specifies the user domain name for the current installation
 #athenz.user_domain=user
 
@@ -373,3 +380,38 @@ athenz.zms.no_auth_uri_list=/zms/v1/status
 # successful, it will create that file so that the server can
 # now report that the server is ready to accept production traffic
 #athenz.zms.health_check_path=
+
+# Boolean value indicating whether or not the ZMS server should
+# call the configured user authority and verify if the given
+# user is valid or not before adding the user to a role. The
+# user authority is responsible for validating any usernames
+# that might include wildcards (e.g. user.*).
+#athenz.zms.validate_user_members=false
+
+# If the athenz.zms.validate_user_members property is enabled
+# then this setting provides additional set of comma separated
+# domains that the system might be using referencing accounts
+# that can be validated with the user authority
+#athenz.zms.addl_user_check_domains=
+
+# Boolean value indicating whether or not the ZMS server should
+# verify if the given service exists in the given domain
+# before adding the service to a role. The ZMS Service will
+# automatically skip any service names that include wildcards
+# (e.g. coretech.api*).
+#athenz.zms.validate_service_members=false
+
+# If athenz.zms.validate_service_members property is enabled
+# then this setting includes comma separated list of domains
+# that should be skipped from the service member validation
+# checks. These could include CI/CD domains, for example,
+# that include dynamic services that are not registered.
+#athenz.zms.validate_service_members_skip_domains=
+
+# Boolean value indicating whether or not the zms server
+# should contact the master storage copy when returning
+# data for signed domains api. In multi region environments
+# this could generate large latency since the server
+# needs to contact most likely a server (e.g. mysql instance)
+# running in a different region.
+#athenz.zms.master_copy_for_signed_domains=false

--- a/servers/zms/conf/authorized_services.json
+++ b/servers/zms/conf/authorized_services.json
@@ -31,7 +31,14 @@
                 { "name":"deleteserviceidentity" },
                 { "name":"putpublickeyentry" },
                 { "name":"deletepublickeyentry" },
-                { "name":"putdomainmeta" }
+                { "name":"putdomainmeta" },
+                { "name":"putdomainsystemmeta" },
+                { "name":"putdomaintemplate" },
+                { "name":"putrolemeta" },
+                { "name":"putmembershipdecision" },
+                { "name":"putrolereview" },
+                { "name":"deletedomainrolemember" },
+                { "name":"deletependingmembership" }
             ]
         }
     }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/file/FileConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/file/FileConnection.java
@@ -1575,7 +1575,7 @@ public class FileConnection implements ObjectStoreConnection {
     public Map<String, List<DomainRoleMember>> getPendingDomainRoleMembers(String principal) {
 
         List<String> orgs = new ArrayList<>();
-        Map<String, List<DomainRoleMember>> domainRoleMembersMap = null;
+        Map<String, List<DomainRoleMember>> domainRoleMembersMap = new HashMap<>();
 
         DomainStruct auditDom = getDomainStruct(ZMSConsts.SYS_AUTH_AUDIT_BY_ORG);
         if (auditDom != null && auditDom.getRoles() != null && !auditDom.getRoles().isEmpty()) {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -4891,10 +4891,10 @@ public class DBServiceTest {
     }
 
     @Test
-    public void testGetPendingDomainRoleMembersListNullMap() {
+    public void testGetPendingDomainRoleMembersListEmptyMap() {
         DomainRoleMembership domainRoleMembership = zms.dbService.getPendingDomainRoleMembers("user.user1");
         assertNotNull(domainRoleMembership);
-        assertNull(domainRoleMembership.getDomainRoleMembersList());
+        assertTrue(domainRoleMembership.getDomainRoleMembersList().isEmpty());
     }
 
     @Test

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/file/FileConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/file/FileConnectionTest.java
@@ -17,6 +17,7 @@ package com.yahoo.athenz.zms.store.file;
 
 import static org.testng.Assert.*;
 import java.io.File;
+import java.util.HashMap;
 
 import com.yahoo.athenz.zms.*;
 import com.yahoo.rdl.Timestamp;
@@ -588,7 +589,7 @@ public class FileConnectionTest {
         File fileDir = new File("/home/athenz/zms_store");
         File quotaDir = new File("/home/athenz/zms_quota");
         try (FileConnection fileconnection = new FileConnection(fileDir, quotaDir)) {
-            assertNull(fileconnection.getPendingDomainRoleMembers("user.user1"));
+            assertTrue(fileconnection.getPendingDomainRoleMembers("user.user1").isEmpty());
         }
     }
 


### PR DESCRIPTION
Adding new UI operations in authorized_services.json
Syncing docker properties with zms/conf
Returning empty map from FileStore implementation to keep UI behavior consistent

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
