### PR TITLE
Limit unrefreshed certs notifications

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/CertRecordStoreConnection.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/CertRecordStoreConnection.java
@@ -76,9 +76,12 @@ public interface CertRecordStoreConnection extends Closeable {
      * Update lastNotifiedServer and lastNotifiedTime for certificate that failed to refresh for more than one day.
      * @param lastNotifiedServer
      * @param lastNotifiedTime
+     * @param provider
      * @return True if at least one certificate record was updated (needs notification to be sent)
      */
-    boolean updateUnrefreshedCertificatesNotificationTimestamp(String lastNotifiedServer, long lastNotifiedTime);
+    boolean updateUnrefreshedCertificatesNotificationTimestamp(String lastNotifiedServer,
+                                                               long lastNotifiedTime,
+                                                               String provider);
 
     /**
      * List all certificates that failed to refresh and require notifications to be sent

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -184,5 +184,8 @@ public final class ZTSConsts {
     public static final String ZTS_PRINCIPAL_AUTHORITY_CLASS       = "com.yahoo.athenz.auth.impl.PrincipalAuthority";
     public static final String ZTS_CERT_RECORD_STORE_FACTORY_CLASS = "com.yahoo.athenz.zts.cert.impl.FileCertRecordStoreFactory";
 
+    public static final String ZTS_PROP_NOTIFICATION_CERT_FAIL_PROVIDER_LIST = "athenz.zts.notification_cert_fail_provider_list";
+
+
     public static final String ZTS_JSON_PARSER_ERROR_RESPONSE = "{\"code\":400,\"message\":\"Invalid Object: checkout https://github.com/yahoo/athenz/core/zts for object defintions\"}";
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
@@ -511,14 +511,14 @@ public class InstanceCertManager {
         return certAuthorityBundles.get(name);
     }
 
-    public List<X509CertRecord> getUnrefreshedCertsNotifications(String serverHostName) {
+    public List<X509CertRecord> getUnrefreshedCertsNotifications(String serverHostName, String provider) {
         if (certStore == null) {
             return new ArrayList<>();
         }
 
         try (CertRecordStoreConnection storeConnection = certStore.getConnection()) {
             long updateTs = System.currentTimeMillis();
-            if (storeConnection.updateUnrefreshedCertificatesNotificationTimestamp(serverHostName, updateTs)) {
+            if (storeConnection.updateUnrefreshedCertificatesNotificationTimestamp(serverHostName, updateTs, provider)) {
                 return storeConnection.getNotifyUnrefreshedCertificates(serverHostName, updateTs);
             }
         }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnection.java
@@ -210,7 +210,9 @@ public class DynamoDBCertRecordStoreConnection implements CertRecordStoreConnect
     }
 
     @Override
-    public boolean updateUnrefreshedCertificatesNotificationTimestamp(String lastNotifiedServer, long lastNotifiedTime) {
+    public boolean updateUnrefreshedCertificatesNotificationTimestamp(String lastNotifiedServer,
+                                                                      long lastNotifiedTime,
+                                                                      String provider) {
         // Currently unimplemented for AWS
         return false;
     }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnection.java
@@ -99,13 +99,16 @@ public class FileCertRecordStoreConnection implements CertRecordStoreConnection 
     }
 
     @Override
-    public boolean updateUnrefreshedCertificatesNotificationTimestamp(String lastNotifiedServer, long lastNotifiedTime) {
+    public boolean updateUnrefreshedCertificatesNotificationTimestamp(String lastNotifiedServer,
+                                                                      long lastNotifiedTime,
+                                                                      String provider) {
         // Currently unimplemented for File
         return false;
     }
 
     @Override
-    public List<X509CertRecord> getNotifyUnrefreshedCertificates(String lastNotifiedServer, long lastNotifiedTime) {
+    public List<X509CertRecord> getNotifyUnrefreshedCertificates(String lastNotifiedServer,
+                                                                 long lastNotifiedTime) {
         // Currently unimplemented for File
         return new ArrayList<>();
     }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/InstanceCertManagerTest.java
@@ -1263,7 +1263,10 @@ public class InstanceCertManagerTest {
         record.setHostName("testHost");
         List<X509CertRecord> x509CertRecords = Collections.singletonList(record);
         String lastNotifiedServer = "server";
-        Mockito.when(certConnection.updateUnrefreshedCertificatesNotificationTimestamp(eq(lastNotifiedServer), anyLong()))
+        String provider = "provider";
+        Mockito.when(certConnection.updateUnrefreshedCertificatesNotificationTimestamp(
+                eq(lastNotifiedServer),
+                anyLong(), eq(provider)))
                 .thenReturn(true)
                 .thenReturn(false);
         Mockito.when(certConnection.getNotifyUnrefreshedCertificates(eq(lastNotifiedServer), anyLong()))
@@ -1271,9 +1274,9 @@ public class InstanceCertManagerTest {
         instance.setCertStore(certStore);
 
         // Assert that unrefreshed certificates will return only if at least 1 row was updated
-        List<X509CertRecord> unrefreshedCertificateNotifications = instance.getUnrefreshedCertsNotifications(lastNotifiedServer);
+        List<X509CertRecord> unrefreshedCertificateNotifications = instance.getUnrefreshedCertsNotifications(lastNotifiedServer, provider);
         assertEquals(unrefreshedCertificateNotifications.get(0).getHostName(), "testHost");
-        unrefreshedCertificateNotifications = instance.getUnrefreshedCertsNotifications(lastNotifiedServer);
+        unrefreshedCertificateNotifications = instance.getUnrefreshedCertsNotifications(lastNotifiedServer, provider);
         assertEquals(unrefreshedCertificateNotifications, new ArrayList<>());
         instance.shutdown();
     }
@@ -1282,7 +1285,9 @@ public class InstanceCertManagerTest {
     public void testNoCertStoreUnrefreshedCerts() {
         InstanceCertManager instance = new InstanceCertManager(null, null, null, false);
         instance.setCertStore(null);
-        List<X509CertRecord> unrefreshedCertificateNotifications = instance.getUnrefreshedCertsNotifications("localhost");
+        List<X509CertRecord> unrefreshedCertificateNotifications = instance.getUnrefreshedCertsNotifications(
+                "localhost",
+                "provdider");
         assertEquals(unrefreshedCertificateNotifications, new ArrayList<>());
     }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
@@ -391,7 +391,10 @@ public class DynamoDBCertRecordStoreConnectionTest {
     public void testUpdateUnrefreshedCertificatesNotificationTimestamp() {
         DynamoDBCertRecordStoreConnection dbConn = new DynamoDBCertRecordStoreConnection(dynamoDB, tableName);
         long timestamp = System.currentTimeMillis();
-        boolean result = dbConn.updateUnrefreshedCertificatesNotificationTimestamp("localhost", timestamp);
+        boolean result = dbConn.updateUnrefreshedCertificatesNotificationTimestamp(
+                "localhost",
+                timestamp,
+                "provider");
 
         // For DynamoDB, unrefreshed certs unimplemented. Assert false
         assertFalse(result);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/FileCertRecordStoreConnectionTest.java
@@ -244,9 +244,12 @@ public class FileCertRecordStoreConnectionTest {
         FileCertRecordStoreConnection con = (FileCertRecordStoreConnection) store.getConnection();
         assertNotNull(con);
         long timestamp = System.currentTimeMillis();
-        boolean result = con.updateUnrefreshedCertificatesNotificationTimestamp("localhost", timestamp);
+        boolean result = con.updateUnrefreshedCertificatesNotificationTimestamp(
+                "localhost",
+                timestamp,
+                "provider");
 
-        // For File store, unrefreshed certs unimplemented. Assert false
+        // For File store, unrefreshed certs unimplemented. Assert false;
         assertFalse(result);
     }
 
@@ -258,7 +261,9 @@ public class FileCertRecordStoreConnectionTest {
         FileCertRecordStoreConnection con = (FileCertRecordStoreConnection) store.getConnection();
         assertNotNull(con);
         long timestamp = System.currentTimeMillis();
-        List<X509CertRecord> records = con.getNotifyUnrefreshedCertificates("localhost", timestamp);
+        List<X509CertRecord> records = con.getNotifyUnrefreshedCertificates(
+                "localhost",
+                timestamp);
 
         // For File store, unrefreshed certs unimplemented. Assert empty collection
         assertEquals(records, new ArrayList<>());

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/JDBCCertRecordStoreConnectionTest.java
@@ -445,12 +445,13 @@ public class JDBCCertRecordStoreConnectionTest {
                 .thenReturn(3) // 3 members updated
                 .thenReturn(0); // On second call, no members were updated
         long timestamp = System.currentTimeMillis();
-        boolean result = jdbcConn.updateUnrefreshedCertificatesNotificationTimestamp("localhost", timestamp);
+        boolean result = jdbcConn.updateUnrefreshedCertificatesNotificationTimestamp("localhost", timestamp, "provider");
         java.sql.Timestamp ts = new java.sql.Timestamp(timestamp);
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(1, ts);
         Mockito.verify(mockPrepStmt, times(1)).setString(2, "localhost");
+        Mockito.verify(mockPrepStmt, times(1)).setString(3, "provider");
         assertTrue(result);
-        result = jdbcConn.updateUnrefreshedCertificatesNotificationTimestamp("localhost", timestamp);
+        result = jdbcConn.updateUnrefreshedCertificatesNotificationTimestamp("localhost", timestamp, "provider");
         assertFalse(result);
         jdbcConn.close();
     }
@@ -461,7 +462,10 @@ public class JDBCCertRecordStoreConnectionTest {
         Mockito.when(mockPrepStmt.executeUpdate())
                 .thenThrow(new SQLException("sql error"));
         try {
-            jdbcConn.updateUnrefreshedCertificatesNotificationTimestamp("localhost", System.currentTimeMillis());
+            jdbcConn.updateUnrefreshedCertificatesNotificationTimestamp(
+                    "localhost",
+                    System.currentTimeMillis(),
+                    "provider");
             fail();
         } catch (RuntimeException ex) {
             assertTrue(ex.getMessage().contains("sql error"));


### PR DESCRIPTION
Send unrefreshed certs notifications only to records with:
1. A listed hostname
2. Provider is one of the configured providers in zts.properties attribute: athenz.zts.cert_fail_provider_list


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
