### PR TITLE
remove non-existent default athenz.io jwks json url

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParserFactory.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/oauth/parser/DefaultOAuthJwtAccessTokenParserFactory.java
@@ -31,8 +31,7 @@ public class DefaultOAuthJwtAccessTokenParserFactory implements OAuthJwtAccessTo
 
     @Override
     public OAuthJwtAccessTokenParser create(KeyStore keyStore) throws IllegalArgumentException {
-        String jwksUrl = GET_PROPERTY.apply(JWKS_URL, "https://athenz.io/jwks.json");
-
+        final String jwksUrl = GET_PROPERTY.apply(JWKS_URL, null);
         return new DefaultOAuthJwtAccessTokenParser(keyStore, jwksUrl);
     }
 


### PR DESCRIPTION
this url does not exist and causes connection timeouts during unit tests resulting in exceeding job limit for travis builds and failure


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
