### PR TITLE
Added configuration item for services that should ignore notifications

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -192,6 +192,7 @@ public final class ZTSConsts {
     public static final String ZTS_CERT_RECORD_STORE_FACTORY_CLASS = "com.yahoo.athenz.zts.cert.impl.FileCertRecordStoreFactory";
 
     public static final String ZTS_PROP_NOTIFICATION_CERT_FAIL_PROVIDER_LIST = "athenz.zts.notification_cert_fail_provider_list";
+    public static final String ZTS_PROP_NOTIFICATION_CERT_FAIL_IGNORED_SERVICES_LIST = "athenz.zts.notification_cert_fail_ignored_services_list";
 
     public static final String ZTS_JSON_PARSER_ERROR_RESPONSE = "{\"code\":400,\"message\":\"Invalid Object: checkout https://github.com/yahoo/athenz/tree/master/core/zts/src/main/rdl for object defintions\"}";
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/GlobStringsMatcher.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/GlobStringsMatcher.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2020 Verizon Media
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.zts.utils;
+
+import com.yahoo.athenz.common.server.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class GlobStringsMatcher {
+    private static final Logger LOGGER = LoggerFactory.getLogger(GlobStringsMatcher.class);
+
+    private final List<String> patterns;
+
+    public GlobStringsMatcher(String systemProperty) {
+        List<String> globList = ZTSUtils.splitCommaSeperatedSystemProperty(systemProperty);
+        patterns = globList.stream().map(glob -> StringUtils.patternFromGlob(glob)).collect(Collectors.toList());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Ignored Services Regex List: " + Arrays.toString(patterns.toArray()));
+        }
+    }
+
+    public boolean isMatch(String value) {
+        return patterns.stream().anyMatch(pattern -> value.matches(pattern));
+    }
+}

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -15,6 +15,7 @@
  */
 package com.yahoo.athenz.zts.utils;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.bouncycastle.pkcs.PKCS10CertificationRequest;
@@ -41,6 +42,8 @@ import java.security.SecureRandom;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ZTSUtils {
 
@@ -399,5 +402,15 @@ public class ZTSUtils {
             boolVal = Boolean.parseBoolean(value);
         }
         return boolVal;
+    }
+
+    public static List<String> splitCommaSeperatedSystemProperty(String property) {
+        String propertyListStr = System.getProperty(property, null);
+
+        if (propertyListStr == null) {
+            return new ArrayList<>();
+        }
+
+        return Stream.of(propertyListStr.trim().split("\\s*,\\s*")).collect(Collectors.toList());
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/GlobStringsMatcherTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/GlobStringsMatcherTest.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2020 Verizon Media
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package com.yahoo.athenz.zts.utils;
+
+import com.yahoo.athenz.zts.ZTSConsts;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertFalse;
+import static org.testng.AssertJUnit.assertTrue;
+
+public class GlobStringsMatcherTest {
+
+    @Test
+    public void testGlobStringMatcher() {
+        String globStrings =
+                "aaa.bbb.ccc.ddd, "
+                + "???.ddd, "
+                + "*.bbb.*.ddd, "
+                + "aaa.??, ";
+
+        String systemProperty = ZTSConsts.ZTS_PROP_NOTIFICATION_CERT_FAIL_IGNORED_SERVICES_LIST;
+        System.setProperty(systemProperty, globStrings);
+        GlobStringsMatcher globStringsMatcher = new GlobStringsMatcher(systemProperty);
+
+        assertTrue(globStringsMatcher.isMatch("aaa.bbb.ccc.ddd"));
+        assertTrue(globStringsMatcher.isMatch("ccc.ddd"));
+        assertTrue(globStringsMatcher.isMatch("aaa.yy"));
+        assertTrue(globStringsMatcher.isMatch("1.2.bbb.444.555.ddd"));
+
+        assertFalse(globStringsMatcher.isMatch("1.2.3.ddd"));
+        assertFalse(globStringsMatcher.isMatch("ddd"));
+        assertFalse(globStringsMatcher.isMatch("ccc"));
+        assertFalse(globStringsMatcher.isMatch("bbb"));
+        assertFalse(globStringsMatcher.isMatch("bbb.ccc"));
+        assertFalse(globStringsMatcher.isMatch("1.2.ddd.3"));
+        assertFalse(globStringsMatcher.isMatch("something.else"));
+
+        System.clearProperty(systemProperty);
+
+    }
+}


### PR DESCRIPTION
Services listed in  athenz.zts.notification_cert_fail_ignored_services_list will not receive certificate failure notifications


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
