### PR TITLE
Fix UI issues in Role Member Review Reminder

### DIFF
--- a/ui/src/components/denali/icons/Icon.js
+++ b/ui/src/components/denali/icons/Icon.js
@@ -36,7 +36,7 @@ const Icon = (props) => {
             ref={props.innerRef}
             data-testid='icon'
         >
-            <title>{props.icon}</title>
+            {props.enableTitle && <title>{props.icon}</title>}
             {icon.map((path, index) => (
                 <path key={index} d={path} />
             ))}
@@ -59,12 +59,15 @@ Icon.propTypes = {
     onClick: PropTypes.func,
     isLink: PropTypes.bool,
     innerRef: P.oneOfType([P.func, P.object]),
+    /*By default icon will display name on hover. Setting this to false will stop it*/
+    enableTitle: PropTypes.bool
 };
 
 Icon.defaultProps = {
     icon: 'x',
     size: '1em',
     verticalAlign: 'text-bottom',
+    enableTitle: true
 };
 
 export default Icon;

--- a/ui/src/components/role/RoleMember.js
+++ b/ui/src/components/role/RoleMember.js
@@ -108,30 +108,31 @@ export default class RoleMember extends React.Component {
                         }
                     >
                         {' '}
+                        {review && (
+                            <StyledTagFullNameExpiry>
+                                {' | '}
+                                <Menu
+                                    placement='bottom-start'
+                                    trigger={
+                                        <span>
+                                            <Icon
+                                                enableTitle={false}
+                                                icon={'assignment-priority'}
+                                                color={colors.icons}
+                                                isLink
+                                                size={'1.25em'}
+                                                verticalAlign={'text-bottom'}
+                                            />
+                                        </span>
+                                    }
+                                >
+                                    <MenuDiv>{'Reminder: ' + review}</MenuDiv>
+                                </Menu>
+                            </StyledTagFullNameExpiry>
+                        )}
                         {this.props.item.memberName}{' '}
                     </StyledAnchor>
                     {fullName}
-                    {review && (
-                        <StyledTagFullNameExpiry>
-                            {' | '}
-                            <Menu
-                                placement='bottom-start'
-                                trigger={
-                                    <span>
-                                        <Icon
-                                            icon={'assignment-priority'}
-                                            color={colors.icons}
-                                            isLink
-                                            size={'1.25em'}
-                                            verticalAlign={'text-bottom'}
-                                        />
-                                    </span>
-                                }
-                            >
-                                <MenuDiv>{'Reminder: ' + review}</MenuDiv>
-                            </Menu>
-                        </StyledTagFullNameExpiry>
-                    )}
                     {exp && (
                         <StyledTagFullNameExpiry>
                             {' | '}
@@ -157,29 +158,30 @@ export default class RoleMember extends React.Component {
                         }
                     >
                         {' '}
+                        {review && (
+                            <StyledTagFullNameExpiry>
+                                <Menu
+                                    placement='bottom-start'
+                                    trigger={
+                                        <span>
+                                            <Icon
+                                                enableTitle={false}
+                                                icon={'assignment-priority'}
+                                                color={colors.icons}
+                                                isLink
+                                                size={'1.25em'}
+                                                verticalAlign={'text-bottom'}
+                                            />
+                                        </span>
+                                    }
+                                >
+                                    <MenuDiv>{'Reminder: ' + review}</MenuDiv>
+                                </Menu>
+                            </StyledTagFullNameExpiry>
+                        )}
                         {this.props.item.memberName}{' '}
                     </StyledAnchor>
                     {fullName}
-                    {review && (
-                        <StyledTagFullNameExpiry>
-                            <Menu
-                                placement='bottom-start'
-                                trigger={
-                                    <span>
-                                        <Icon
-                                            icon={'assignment-priority'}
-                                            color={colors.icons}
-                                            isLink
-                                            size={'1.25em'}
-                                            verticalAlign={'text-bottom'}
-                                        />
-                                    </span>
-                                }
-                            >
-                                <MenuDiv>{'Reminder: ' + review}</MenuDiv>
-                            </Menu>
-                        </StyledTagFullNameExpiry>
-                    )}
                     {exp && (
                         <StyledTagFullNameExpiry>
                             {' | '}


### PR DESCRIPTION
1. Moved the Role Member Reminder Icon to the left so it can be hovered without being covered by the 'X'
2. Disabled the Reminder icon title which caused it to appear on top of the tooltip


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
