### PR TITLE
Throw exception back to client if refresh fails in aws credentials provider

### DIFF
--- a/clients/java/zts/core/src/test/java/com/yahoo/athenz/zts/ZTSClientTest.java
+++ b/clients/java/zts/core/src/test/java/com/yahoo/athenz/zts/ZTSClientTest.java
@@ -2790,9 +2790,24 @@ public class ZTSClientTest {
     public void testGetAWSCredentialsProvider() {
 
         ZTSClientMock client = new ZTSClientMock("http://localhost:4080");
-        assertNotNull(client.getAWSCredentialProvider("domain", "role"));
-        assertNotNull(client.getAWSCredentialProvider("domain", "role", "id", null, null));
-        assertNotNull(client.getAWSCredentialProvider("domain", "role", "id", 100, 300));
+        try {
+            client.getAWSCredentialProvider("domain", "role");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+        try {
+            client.getAWSCredentialProvider("domain", "role", "id", 100, 300);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+        try {
+            client.getAWSCredentialProvider("domain", "role", "id", null, null);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
     }
 
     @Test


### PR DESCRIPTION
this allows the client to know right away if their provider is invalid rather than getting a provider which then returns null to the api call which fails but there is no indication what has failed.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
