### PR TITLE
Support jetty's graceful shutdown

### DIFF
--- a/containers/jetty/conf/athenz.properties
+++ b/containers/jetty/conf/athenz.properties
@@ -154,8 +154,8 @@ athenz.jetty_home=/home/athenz
 #athenz.gzip_min_size=1024
 
 # Enable graceful shutdown in the Jetty
-#athenz.graceful_shutdown_support=false
+#athenz.graceful_shutdown=false
 
 # How long to wait for the Jetty server to shutdown, in milliseconds
-# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+# If the athenz.graceful_shutdown is not true, this setting is invalid.
 #athenz.graceful_shutdown_timeout=30000

--- a/containers/jetty/conf/athenz.properties
+++ b/containers/jetty/conf/athenz.properties
@@ -153,10 +153,9 @@ athenz.jetty_home=/home/athenz
 # that will require compression
 #athenz.gzip_min_size=1024
 
-# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
-# If true, the Jetty server instance will be explicitly stopped when the
-# JVM is shutdown. Otherwise the JVM is stopped with the server running.
-#athenz.jetty_stop_at_shutdown=true
+# Enable graceful shutdown in the Jetty
+#athenz.graceful_shutdown_support=false
 
-# How long to wait for the Jetty server to stop, in milliseconds
-#athenz.jetty_stop_timeout=30000
+# How long to wait for the Jetty server to shutdown, in milliseconds
+# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+#athenz.graceful_shutdown_timeout=30000

--- a/containers/jetty/conf/athenz.properties
+++ b/containers/jetty/conf/athenz.properties
@@ -152,3 +152,11 @@ athenz.jetty_home=/home/athenz
 # If GZIP support is enabled, this property specifies the min response size
 # that will require compression
 #athenz.gzip_min_size=1024
+
+# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
+# If true, the Jetty server instance will be explicitly stopped when the
+# JVM is shutdown. Otherwise the JVM is stopped with the server running.
+#athenz.jetty_stop_at_shutdown=true
+
+# How long to wait for the Jetty server to stop, in milliseconds
+#athenz.jetty_stop_timeout=30000

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
@@ -57,8 +57,6 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_HOSTNAME               = "athenz.hostname";
     public static final String ATHENZ_PROP_JETTY_HOME             = "athenz.jetty_home";
     public static final String ATHENZ_PROP_JETTY_TEMP             = "athenz.jetty_temp";
-    public static final String ATHENZ_PROP_JETTY_STOP_AT_SHUTDOWN = "athenz.jetty_stop_at_shutdown";
-    public static final String ATHENZ_PROP_JETTY_STOP_TIMEOUT     = "athenz.jetty_stop_timeout";
     public static final String ATHENZ_PROP_DEBUG                  = "athenz.debug";
     public static final String ATHENZ_PROP_HEALTH_CHECK_URI_LIST  = "athenz.health_check_uri_list";
     public static final String ATHENZ_PROP_HEALTH_CHECK_PATH      = "athenz.health_check_path";
@@ -82,4 +80,7 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_KEYSTORE_PASSWORD_APPNAME   = "athenz.ssl_key_store_password_appname";
     public static final String ATHENZ_PROP_KEYMANAGER_PASSWORD_APPNAME = "athenz.ssl_key_manager_password_appname";
     public static final String ATHENZ_PROP_TRUSTSTORE_PASSWORD_APPNAME = "athenz.ssl_trust_store_password_appname";
+
+    public static final String ATHENZ_PROP_GRACEFUL_SHUTDOWN_SUPPORT = "athenz.graceful_shutdown_support";
+    public static final String ATHENZ_PROP_GRACEFUL_SHUTDOWN_TIMEOUT = "athenz.graceful_shutdown_timeout";
 }

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
@@ -57,6 +57,8 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_HOSTNAME               = "athenz.hostname";
     public static final String ATHENZ_PROP_JETTY_HOME             = "athenz.jetty_home";
     public static final String ATHENZ_PROP_JETTY_TEMP             = "athenz.jetty_temp";
+    public static final String ATHENZ_PROP_JETTY_STOP_AT_SHUTDOWN = "athenz.jetty_stop_at_shutdown";
+    public static final String ATHENZ_PROP_JETTY_STOP_TIMEOUT     = "athenz.jetty_stop_timeout";
     public static final String ATHENZ_PROP_DEBUG                  = "athenz.debug";
     public static final String ATHENZ_PROP_HEALTH_CHECK_URI_LIST  = "athenz.health_check_uri_list";
     public static final String ATHENZ_PROP_HEALTH_CHECK_PATH      = "athenz.health_check_path";

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzConsts.java
@@ -81,6 +81,6 @@ public final class AthenzConsts {
     public static final String ATHENZ_PROP_KEYMANAGER_PASSWORD_APPNAME = "athenz.ssl_key_manager_password_appname";
     public static final String ATHENZ_PROP_TRUSTSTORE_PASSWORD_APPNAME = "athenz.ssl_trust_store_password_appname";
 
-    public static final String ATHENZ_PROP_GRACEFUL_SHUTDOWN_SUPPORT = "athenz.graceful_shutdown_support";
+    public static final String ATHENZ_PROP_GRACEFUL_SHUTDOWN = "athenz.graceful_shutdown";
     public static final String ATHENZ_PROP_GRACEFUL_SHUTDOWN_TIMEOUT = "athenz.graceful_shutdown_timeout";
 }

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -481,6 +481,17 @@ public class AthenzJettyContainer {
         server = new Server(threadPool);
         handlers = new HandlerCollection();
         server.setHandler(handlers);
+
+        long stopTimeout = Long.parseLong(
+                System.getProperty(AthenzConsts.ATHENZ_PROP_JETTY_STOP_TIMEOUT, "30000"));
+        // The default value is 30000
+        server.setStopTimeout(stopTimeout);
+
+        boolean stopAtShutdown = Boolean.parseBoolean(
+                System.getProperty(AthenzConsts.ATHENZ_PROP_JETTY_STOP_AT_SHUTDOWN, "false"));
+        if (stopAtShutdown) {
+            server.setStopAtShutdown(true);
+        }
     }
     
     public static AthenzJettyContainer createJettyContainer() {

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -484,7 +484,6 @@ public class AthenzJettyContainer {
 
         long stopTimeout = Long.parseLong(
                 System.getProperty(AthenzConsts.ATHENZ_PROP_JETTY_STOP_TIMEOUT, "30000"));
-        // The default value is 30000
         server.setStopTimeout(stopTimeout);
 
         boolean stopAtShutdown = Boolean.parseBoolean(

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/AthenzJettyContainer.java
@@ -205,9 +205,9 @@ public class AthenzJettyContainer {
         }
 
         // check to see if graceful shutdown support is enabled
-        boolean gracefulShutdownSupport = Boolean.parseBoolean(
-                System.getProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN_SUPPORT, "false"));
-        if (gracefulShutdownSupport) {
+        boolean gracefulShutdown = Boolean.parseBoolean(
+                System.getProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN, "false"));
+        if (gracefulShutdown) {
             server.setStopAtShutdown(true);
 
             long stopTimeout = Long.parseLong(

--- a/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
+++ b/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
@@ -76,7 +76,7 @@ public class AthenzJettyContainerTest {
         System.clearProperty((AthenzConsts.ATHENZ_PROP_STATUS_PORT));
         System.clearProperty(AthenzConsts.ATHENZ_PROP_PRIVATE_KEY_STORE_FACTORY_CLASS);
         System.clearProperty(AthenzConsts.ATHENZ_PROP_KEEP_ALIVE);
-        System.clearProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN_SUPPORT);
+        System.clearProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN);
         System.clearProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN_TIMEOUT);
     }
     
@@ -614,13 +614,13 @@ public class AthenzJettyContainerTest {
     }
 
     @Test
-    public void testGracefulShutdownSupport() {
+    public void testGracefulShutdown() {
         AthenzJettyContainer container;
         Server server;
         long stopTimeout;
         boolean stopAtShutdown;
 
-        // If the athenz.graceful_shutdown_support is not true.
+        // If the athenz.graceful_shutdown is not true.
         container = new AthenzJettyContainer();
         container.createServer(100);
         container.addServletHandlers("localhost");
@@ -636,7 +636,7 @@ public class AthenzJettyContainerTest {
 
         cleanup();
 
-        // If the athenz.graceful_shutdown_support is not true,
+        // If the athenz.graceful_shutdown is not true,
         // the ahtenz.graceful_shutdown_timeout is invalid.
         System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN_TIMEOUT, "60000");
 
@@ -655,8 +655,8 @@ public class AthenzJettyContainerTest {
 
         cleanup();
 
-        // If the athenz.graceful_shutdown_support is true.
-        System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN_SUPPORT, "true");
+        // If the athenz.graceful_shutdown is true.
+        System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN, "true");
 
         container = new AthenzJettyContainer();
         container.createServer(100);
@@ -673,9 +673,9 @@ public class AthenzJettyContainerTest {
 
         cleanup();
 
-        // If the athenz.graceful_shutdown_support is true and
+        // If the athenz.graceful_shutdown is true and
         // the athenz.graceful_shutdown_timeout is also set
-        System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN_SUPPORT, "true");
+        System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN, "true");
         System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN_TIMEOUT, "60000");
 
         container = new AthenzJettyContainer();
@@ -697,7 +697,7 @@ public class AthenzJettyContainerTest {
         ContextHandlerCollection contextHandlerCollection = null;
         StatisticsHandler statisticsHandler = null;
 
-        System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN_SUPPORT, "false");
+        System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN, "false");
         AthenzJettyContainer container = new AthenzJettyContainer();
         container.createServer(100);
         container.addServletHandlers("localhost");
@@ -716,7 +716,7 @@ public class AthenzJettyContainerTest {
 
         cleanup();
 
-        System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN_SUPPORT, "true");
+        System.setProperty(AthenzConsts.ATHENZ_PROP_GRACEFUL_SHUTDOWN, "true");
         container = new AthenzJettyContainer();
         container.createServer(100);
         container.addServletHandlers("localhost");

--- a/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
+++ b/containers/jetty/src/test/java/com/yahoo/athenz/container/AthenzJettyContainerTest.java
@@ -75,6 +75,8 @@ public class AthenzJettyContainerTest {
         System.clearProperty((AthenzConsts.ATHENZ_PROP_STATUS_PORT));
         System.clearProperty(AthenzConsts.ATHENZ_PROP_PRIVATE_KEY_STORE_FACTORY_CLASS);
         System.clearProperty(AthenzConsts.ATHENZ_PROP_KEEP_ALIVE);
+        System.clearProperty(AthenzConsts.ATHENZ_PROP_JETTY_STOP_TIMEOUT);
+        System.clearProperty(AthenzConsts.ATHENZ_PROP_JETTY_STOP_AT_SHUTDOWN);
     }
     
     @AfterClass
@@ -100,7 +102,63 @@ public class AthenzJettyContainerTest {
         assertEquals(threadPool.getThreads(), 0);
         assertEquals(threadPool.getIdleThreads(), 0);
     }
-    
+
+    @Test
+    public void testStopTimeout() {
+        System.setProperty(AthenzConsts.ATHENZ_PROP_MAX_THREADS, "100");
+
+        AthenzJettyContainer container = new AthenzJettyContainer();
+        container.createServer(100);
+
+        Server server = container.getServer();
+        assertNotNull(server);
+
+        long stopTimeout = server.getStopTimeout();
+        assertEquals(stopTimeout, 30000);
+
+        cleanup();
+
+        System.setProperty(AthenzConsts.ATHENZ_PROP_MAX_THREADS, "100");
+        System.setProperty(AthenzConsts.ATHENZ_PROP_JETTY_STOP_TIMEOUT, "60000");
+
+        container = new AthenzJettyContainer();
+        container.createServer(100);
+
+        server = container.getServer();
+        assertNotNull(server);
+
+        stopTimeout = server.getStopTimeout();
+        assertEquals(stopTimeout, 60000);
+    }
+
+    @Test
+    public void testStopAtShutdown() {
+        System.setProperty(AthenzConsts.ATHENZ_PROP_MAX_THREADS, "100");
+
+        AthenzJettyContainer container = new AthenzJettyContainer();
+        container.createServer(100);
+
+        Server server = container.getServer();
+        assertNotNull(server);
+
+        boolean stopAtShutdown = server.getStopAtShutdown();
+        assertEquals(stopAtShutdown, false);
+
+        cleanup();
+
+        System.setProperty(AthenzConsts.ATHENZ_PROP_MAX_THREADS, "100");
+        System.setProperty(AthenzConsts.ATHENZ_PROP_JETTY_STOP_AT_SHUTDOWN, "true");
+
+        container = new AthenzJettyContainer();
+        container.createServer(100);
+
+        server = container.getServer();
+        assertNotNull(server);
+
+        stopAtShutdown = server.getStopAtShutdown();
+        assertEquals(stopAtShutdown, true);
+    }
+
     @Test
     public void testRequestLogHandler() {
 

--- a/docker/zms/conf/athenz.properties
+++ b/docker/zms/conf/athenz.properties
@@ -118,3 +118,11 @@ athenz.jetty_home=/opt/athenz/zms
 # Enable Proxy Protocol (used by HAProxy and environments such as Amazon Elastic Cloud)
 # for the jetty container.
 #athenz.proxy_protocol=false
+
+# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
+# If true, the Jetty server instance will be explicitly stopped when the
+# JVM is shutdown. Otherwise the JVM is stopped with the server running.
+athenz.jetty_stop_at_shutdown=true
+
+# How long to wait for the Jetty server to stop, in milliseconds
+athenz.jetty_stop_timeout=30000

--- a/docker/zms/conf/athenz.properties
+++ b/docker/zms/conf/athenz.properties
@@ -120,8 +120,8 @@ athenz.jetty_home=/opt/athenz/zms
 #athenz.proxy_protocol=false
 
 # Enable graceful shutdown in the Jetty
-athenz.graceful_shutdown_support=true
+athenz.graceful_shutdown=true
 
 # How long to wait for the Jetty server to shutdown, in milliseconds
-# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+# If the athenz.graceful_shutdown is not true, this setting is invalid.
 athenz.graceful_shutdown_timeout=30000

--- a/docker/zms/conf/athenz.properties
+++ b/docker/zms/conf/athenz.properties
@@ -119,10 +119,9 @@ athenz.jetty_home=/opt/athenz/zms
 # for the jetty container.
 #athenz.proxy_protocol=false
 
-# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
-# If true, the Jetty server instance will be explicitly stopped when the
-# JVM is shutdown. Otherwise the JVM is stopped with the server running.
-athenz.jetty_stop_at_shutdown=true
+# Enable graceful shutdown in the Jetty
+athenz.graceful_shutdown_support=true
 
-# How long to wait for the Jetty server to stop, in milliseconds
-athenz.jetty_stop_timeout=30000
+# How long to wait for the Jetty server to shutdown, in milliseconds
+# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+athenz.graceful_shutdown_timeout=30000

--- a/docker/zts/conf/athenz.properties
+++ b/docker/zts/conf/athenz.properties
@@ -119,3 +119,11 @@ athenz.jetty_home=/opt/athenz/zts
 # Enable Proxy Protocol (used by HAProxy and environments such as Amazon Elastic Cloud)
 # for the jetty container.
 #athenz.proxy_protocol=false
+
+# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
+# If true, the Jetty server instance will be explicitly stopped when the
+# JVM is shutdown. Otherwise the JVM is stopped with the server running.
+athenz.jetty_stop_at_shutdown=true
+
+# How long to wait for the Jetty server to stop, in milliseconds
+athenz.jetty_stop_timeout=30000

--- a/docker/zts/conf/athenz.properties
+++ b/docker/zts/conf/athenz.properties
@@ -121,8 +121,8 @@ athenz.jetty_home=/opt/athenz/zts
 #athenz.proxy_protocol=false
 
 # Enable graceful shutdown in the Jetty
-athenz.graceful_shutdown_support=true
+athenz.graceful_shutdown=true
 
 # How long to wait for the Jetty server to shutdown, in milliseconds
-# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+# If the athenz.graceful_shutdown is not true, this setting is invalid.
 athenz.graceful_shutdown_timeout=30000

--- a/docker/zts/conf/athenz.properties
+++ b/docker/zts/conf/athenz.properties
@@ -120,10 +120,9 @@ athenz.jetty_home=/opt/athenz/zts
 # for the jetty container.
 #athenz.proxy_protocol=false
 
-# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
-# If true, the Jetty server instance will be explicitly stopped when the
-# JVM is shutdown. Otherwise the JVM is stopped with the server running.
-athenz.jetty_stop_at_shutdown=true
+# Enable graceful shutdown in the Jetty
+athenz.graceful_shutdown_support=true
 
-# How long to wait for the Jetty server to stop, in milliseconds
-athenz.jetty_stop_timeout=30000
+# How long to wait for the Jetty server to shutdown, in milliseconds
+# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+athenz.graceful_shutdown_timeout=30000

--- a/servers/zms/conf/athenz.properties
+++ b/servers/zms/conf/athenz.properties
@@ -119,10 +119,9 @@ athenz.ssl_key_store_password=athenz
 # for the jetty container.
 #athenz.proxy_protocol=false
 
-# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
-# If true, the Jetty server instance will be explicitly stopped when the
-# JVM is shutdown. Otherwise the JVM is stopped with the server running.
-#athenz.jetty_stop_at_shutdown=true
+# Enable graceful shutdown in the Jetty
+#athenz.graceful_shutdown_support=false
 
-# How long to wait for the Jetty server to stop, in milliseconds
-#athenz.jetty_stop_timeout=30000
+# How long to wait for the Jetty server to shutdown, in milliseconds
+# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+#athenz.graceful_shutdown_timeout=30000

--- a/servers/zms/conf/athenz.properties
+++ b/servers/zms/conf/athenz.properties
@@ -118,3 +118,11 @@ athenz.ssl_key_store_password=athenz
 # Enable Proxy Protocol (used by HAProxy and environments such as Amazon Elastic Cloud)
 # for the jetty container.
 #athenz.proxy_protocol=false
+
+# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
+# If true, the Jetty server instance will be explicitly stopped when the
+# JVM is shutdown. Otherwise the JVM is stopped with the server running.
+#athenz.jetty_stop_at_shutdown=true
+
+# How long to wait for the Jetty server to stop, in milliseconds
+#athenz.jetty_stop_timeout=30000

--- a/servers/zms/conf/athenz.properties
+++ b/servers/zms/conf/athenz.properties
@@ -120,8 +120,8 @@ athenz.ssl_key_store_password=athenz
 #athenz.proxy_protocol=false
 
 # Enable graceful shutdown in the Jetty
-#athenz.graceful_shutdown_support=false
+#athenz.graceful_shutdown=false
 
 # How long to wait for the Jetty server to shutdown, in milliseconds
-# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+# If the athenz.graceful_shutdown is not true, this setting is invalid.
 #athenz.graceful_shutdown_timeout=30000

--- a/servers/zts/conf/athenz.properties
+++ b/servers/zts/conf/athenz.properties
@@ -119,3 +119,11 @@ athenz.ssl_trust_store_password=athenz
 # Enable Proxy Protocol (used by HAProxy and environments such as Amazon Elastic Cloud)
 # for the jetty container.
 #athenz.proxy_protocol=false
+
+# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
+# If true, the Jetty server instance will be explicitly stopped when the
+# JVM is shutdown. Otherwise the JVM is stopped with the server running.
+#athenz.jetty_stop_at_shutdown=true
+
+# How long to wait for the Jetty server to stop, in milliseconds
+#athenz.jetty_stop_timeout=30000

--- a/servers/zts/conf/athenz.properties
+++ b/servers/zts/conf/athenz.properties
@@ -120,10 +120,9 @@ athenz.ssl_trust_store_password=athenz
 # for the jetty container.
 #athenz.proxy_protocol=false
 
-# Boolean flag to determine the Jetty's behavior when the JVM is shutdown.
-# If true, the Jetty server instance will be explicitly stopped when the
-# JVM is shutdown. Otherwise the JVM is stopped with the server running.
-#athenz.jetty_stop_at_shutdown=true
+# Enable graceful shutdown in the Jetty
+#athenz.graceful_shutdown_support=false
 
-# How long to wait for the Jetty server to stop, in milliseconds
-#athenz.jetty_stop_timeout=30000
+# How long to wait for the Jetty server to shutdown, in milliseconds
+# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+#athenz.graceful_shutdown_timeout=30000

--- a/servers/zts/conf/athenz.properties
+++ b/servers/zts/conf/athenz.properties
@@ -121,8 +121,8 @@ athenz.ssl_trust_store_password=athenz
 #athenz.proxy_protocol=false
 
 # Enable graceful shutdown in the Jetty
-#athenz.graceful_shutdown_support=false
+#athenz.graceful_shutdown=false
 
 # How long to wait for the Jetty server to shutdown, in milliseconds
-# If the athenz.graceful_shutdown_support is not true, this setting is invalid.
+# If the athenz.graceful_shutdown is not true, this setting is invalid.
 #athenz.graceful_shutdown_timeout=30000


### PR DESCRIPTION
## Motivation
Support jetty's graceful shutdown feature to work with kubernetes.

## Modifications
Add two settings for the Jetty.
- athenz.graceful_shutdown
  - @see https://www.eclipse.org/jetty/javadoc/9.4.29.v20200521/org/eclipse/jetty/server/Server.html#setStopAtShutdown(boolean)
- athenz.graceful_shutdown_timeout
  - @see https://www.eclipse.org/jetty/javadoc/9.4.29.v20200521/org/eclipse/jetty/server/Server.html#setStopTimeout(long)

### Verifying this change
- Kill the zms-server while executing the following command
  - `curl https://zms-server:4443/zms/v1/status --insecure`
- In case of `athenz.graceful_shutdown=true`
  - The server stops after returning the response normally.
- In case of `athenz.graceful_shutdown=false`
  - The server will stop before returning the response.(The curl command fails due to connection loss)

------
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.