### PR TITLE
access token validate method in zpe

### DIFF
--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeConsts.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeConsts.java
@@ -62,7 +62,8 @@ public final class ZpeConsts {
     public static final String ZPE_PROP_MON_TIMEOUT           = "athenz.zpe.monitor_timeout_secs";
     public static final String ZPE_PROP_MON_CLEANUP_TOKENS    = "athenz.zpe.cleanup_tokens_secs";
     public static final String ZPE_PROP_POLICY_DIR            = "athenz.zpe.policy_dir";
-    
+    public static final String ZPE_PROP_SKIP_POLICY_DIR_CHECK = "athenz.zpe.skip_policy_dir_check";
+
     public static final String ZPE_PROP_X509_CA_ISSUERS       = "athenz.zpe.x509.ca.issuers";
 
 }

--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeThreadFactory.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeThreadFactory.java
@@ -19,6 +19,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
 class ZpeThreadFactory implements ThreadFactory {
+
     private static final AtomicInteger POOLNUMBER = new AtomicInteger(1);
     private final ThreadGroup group;
     private final AtomicInteger threadNumber = new AtomicInteger(1);
@@ -26,15 +27,12 @@ class ZpeThreadFactory implements ThreadFactory {
 
     public ZpeThreadFactory(String name) {
         SecurityManager s = System.getSecurityManager();
-        group = (s != null) ? s.getThreadGroup() : Thread.currentThread()
-                .getThreadGroup();
-        namePrefix = name + "-pool-" + POOLNUMBER.getAndIncrement()
-                + "-thread-";
+        group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        namePrefix = name + "-pool-" + POOLNUMBER.getAndIncrement() + "-thread-";
     }
 
     public Thread newThread(Runnable target) {
-        Thread thrd = new Thread(group, target, namePrefix
-                + threadNumber.getAndIncrement(), 0);
+        Thread thrd = new Thread(group, target, namePrefix + threadNumber.getAndIncrement(), 0);
         thrd.setDaemon(true);
         if (thrd.getPriority() != Thread.NORM_PRIORITY) {
             thrd.setPriority(Thread.NORM_PRIORITY);

--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdMonitor.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdMonitor.java
@@ -24,6 +24,7 @@ import org.slf4j.LoggerFactory;
  * Used in monitoring the policy directory for file changes.
  */
 public class ZpeUpdMonitor implements Runnable {
+
     private static final Logger LOG = LoggerFactory.getLogger(ZpeUpdMonitor.class);
 
     private String dirName;
@@ -47,6 +48,7 @@ public class ZpeUpdMonitor implements Runnable {
         if (dirName == null) {
             return null;
         }
+
         // read all the file names in the policy directory and add to the list
 
         File pdir = new File(dirName);
@@ -75,6 +77,7 @@ public class ZpeUpdMonitor implements Runnable {
 
     @Override
     public void run() {
+
         if (updLoader == null) {
             LOG.error("run: No ZpeUpdPolLoader to monitor");
             return;
@@ -91,9 +94,21 @@ public class ZpeUpdMonitor implements Runnable {
         ZpeUpdPolLoader.cleanupRoleTokenCache();
         ZpeUpdPolLoader.cleanupAccessTokenCache();
 
+        // only process files if the feature has not
+        // been disabled
+
+        if (updLoader.skipPolicyDirCheck) {
+            return;
+        }
+
         try {
             updLoader.loadDb(loadFileStatus());
             if (firstRun) {
+
+                // if in the ZpeUpdater init method we're still
+                // blocked on wait(), this will cause the method
+                // to finish instead of waiting the full 5 secs
+
                 firstRun = false;
                 synchronized (updLoader) {
                     updLoader.notify();

--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdater.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeUpdater.java
@@ -41,14 +41,12 @@ public class ZpeUpdater implements ZpeClient {
             rootDir = File.separator + "home" + File.separator + "athenz";
         }
 
-        ZPECLT_POLDIR_DEFAULT = rootDir + File.separator + "var"
-                + File.separator + "zpe";
-        
+        ZPECLT_POLDIR_DEFAULT = rootDir + File.separator + "var" + File.separator + "zpe";
         String dirName = System.getProperty(ZpeConsts.ZPE_PROP_POLICY_DIR, ZPECLT_POLDIR_DEFAULT);
         
         try {
             if (LOG.isDebugEnabled()) {
-                LOG.debug("static-init: start monitoring policy directory=" + dirName);
+                LOG.debug("static-init: start monitoring policy directory={}", dirName);
             }
             // load the file
             POLICYLOADER = new ZpeUpdPolLoader(dirName);
@@ -57,9 +55,8 @@ public class ZpeUpdater implements ZpeClient {
             POLICYLOADER.start();
 
         } catch (Exception exc) {
-            LOG.error("static-init: failed loading policy files. System property("
-                    + ZpeConsts.ZPE_PROP_POLICY_DIR + ") Policy-directory(" + dirName + ")",
-                    exc);
+            LOG.error("static-init: failed loading policy files. System property({}) Policy-directory({}})",
+                    ZpeConsts.ZPE_PROP_POLICY_DIR, dirName, exc);
             throw new RuntimeException(exc);
         }
     }
@@ -101,4 +98,3 @@ public class ZpeUpdater implements ZpeClient {
         return POLICYLOADER.getStandardRoleDenyMap(domain);
     }
 }
-

--- a/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestZpeMatch.java
+++ b/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestZpeMatch.java
@@ -17,7 +17,6 @@ package com.yahoo.athenz.zpe;
 
 import org.testng.annotations.Test;
 
-import com.yahoo.athenz.zpe.ZpeUpdPolLoader;
 import com.yahoo.athenz.zpe.match.ZpeMatch;
 import com.yahoo.athenz.zpe.match.impl.ZpeMatchAll;
 import com.yahoo.athenz.zpe.match.impl.ZpeMatchEqual;

--- a/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestZpeUpdPolLoader.java
+++ b/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestZpeUpdPolLoader.java
@@ -24,8 +24,7 @@ import com.yahoo.athenz.zpe.match.impl.ZpeMatchEqual;
 import com.yahoo.athenz.zpe.match.impl.ZpeMatchRegex;
 import com.yahoo.athenz.zpe.match.impl.ZpeMatchStartsWith;
 
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 import java.io.File;
 
@@ -34,9 +33,6 @@ public class TestZpeUpdPolLoader {
     static String TEST_POL_DIR  = "./src/test/resources/upd_pol_dir/";
     static String TEST_POL_FILE = "angler.pol";
     static String TEST_POL_GOOD_FILE = "./src/test/resources/pol_dir/angler.pol";
-    
-    static String TEST_POL_FILE_EMPTY      = "empty.pol";
-    static String TEST_POL_GOOD_FILE_EMPTY = "./src/test/resources/pol_dir/empty.pol";
 
     @Test
     public void testGetMatchObject() {
@@ -96,7 +92,7 @@ public class TestZpeUpdPolLoader {
         long lastModMilliSeconds = polFile.lastModified();
         java.util.Map<String, ZpeUpdPolLoader.ZpeFileStatus> fsmap = loader.getFileStatusMap();
         ZpeUpdPolLoader.ZpeFileStatus fstat = fsmap.get(polFile.getName());
-        assertTrue(!fstat.validPolFile);
+        assertFalse(fstat.validPolFile);
 
         // move good policy file over the bad one
         java.nio.file.Path goodFile = java.nio.file.Paths.get(TEST_POL_GOOD_FILE);


### PR DESCRIPTION
Provide new static method to validate access token: validateAccessToken

Additionally provide a new system property "athenz.zpe.skip_policy_dir_check" that can be set to "true" to skip any policy file handling. This is useful when ZPE is only used to validate access tokens and not carry out authorization checks.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
