### PR TITLE
ability to remove optional string attributes set on roles

### DIFF
--- a/clients/go/zms/Makefile
+++ b/clients/go/zms/Makefile
@@ -53,7 +53,7 @@ src/$(RDL_LIB):
 	go get github.com/ardielle/ardielle-tools/...
 
 model.go: $(RDL_FILE)
-	$(GOPATH)/bin/rdl -ps generate -t -o $@ go-model $(RDL_FILE)
+	$(GOPATH)/bin/rdl -ps generate -t -o $@ athenz-go-model $(RDL_FILE)
 
 client.go: $(RDL_FILE)
 	$(GOPATH)/bin/rdl -ps generate -t -o $@ athenz-go-client $(RDL_FILE)

--- a/clients/go/zms/model.go
+++ b/clients/go/zms/model.go
@@ -118,7 +118,7 @@ type DomainMeta struct {
 	//
 	// a description of the domain
 	//
-	Description string `json:"description,omitempty" rdl:"optional"`
+	Description string `json:"description" rdl:"optional"`
 
 	//
 	// a reference to an Organization. (i.e. org:media)
@@ -141,7 +141,7 @@ type DomainMeta struct {
 	// associated cloud (i.e. aws) account id (system attribute - uniqueness
 	// check)
 	//
-	Account string `json:"account,omitempty" rdl:"optional"`
+	Account string `json:"account" rdl:"optional"`
 
 	//
 	// associated product id (system attribute - uniqueness check)
@@ -151,12 +151,12 @@ type DomainMeta struct {
 	//
 	// associated application id
 	//
-	ApplicationId string `json:"applicationId,omitempty" rdl:"optional"`
+	ApplicationId string `json:"applicationId" rdl:"optional"`
 
 	//
 	// domain certificate dns domain (system attribute)
 	//
-	CertDnsDomain string `json:"certDnsDomain,omitempty" rdl:"optional"`
+	CertDnsDomain string `json:"certDnsDomain" rdl:"optional"`
 
 	//
 	// all user members in the domain will have specified max expiry days
@@ -290,7 +290,7 @@ type Domain struct {
 	//
 	// a description of the domain
 	//
-	Description string `json:"description,omitempty" rdl:"optional"`
+	Description string `json:"description" rdl:"optional"`
 
 	//
 	// a reference to an Organization. (i.e. org:media)
@@ -313,7 +313,7 @@ type Domain struct {
 	// associated cloud (i.e. aws) account id (system attribute - uniqueness
 	// check)
 	//
-	Account string `json:"account,omitempty" rdl:"optional"`
+	Account string `json:"account" rdl:"optional"`
 
 	//
 	// associated product id (system attribute - uniqueness check)
@@ -323,12 +323,12 @@ type Domain struct {
 	//
 	// associated application id
 	//
-	ApplicationId string `json:"applicationId,omitempty" rdl:"optional"`
+	ApplicationId string `json:"applicationId" rdl:"optional"`
 
 	//
 	// domain certificate dns domain (system attribute)
 	//
-	CertDnsDomain string `json:"certDnsDomain,omitempty" rdl:"optional"`
+	CertDnsDomain string `json:"certDnsDomain" rdl:"optional"`
 
 	//
 	// all user members in the domain will have specified max expiry days
@@ -548,7 +548,7 @@ type RoleList struct {
 	// be used in the next role list request as the value for the skip query
 	// parameter.
 	//
-	Next string `json:"next,omitempty" rdl:"optional"`
+	Next string `json:"next" rdl:"optional"`
 }
 
 //
@@ -634,7 +634,7 @@ type RoleAuditLog struct {
 	//
 	// audit reference string for the change as supplied by admin
 	//
-	AuditRef string `json:"auditRef,omitempty" rdl:"optional"`
+	AuditRef string `json:"auditRef" rdl:"optional"`
 }
 
 //
@@ -741,7 +741,7 @@ type RoleMember struct {
 	//
 	// audit reference string for the change as supplied by admin
 	//
-	AuditRef string `json:"auditRef,omitempty" rdl:"optional"`
+	AuditRef string `json:"auditRef" rdl:"optional"`
 
 	//
 	// for pending membership requests, the request time
@@ -898,17 +898,17 @@ type RoleMeta struct {
 	//
 	// list of roles whose members should be notified for member review/approval
 	//
-	NotifyRoles ResourceNames `json:"notifyRoles,omitempty" rdl:"optional"`
+	NotifyRoles string `json:"notifyRoles" rdl:"optional"`
 
 	//
 	// membership filtered based on user authority configured attributes
 	//
-	UserAuthorityFilter AuthorityKeywords `json:"userAuthorityFilter,omitempty" rdl:"optional"`
+	UserAuthorityFilter string `json:"userAuthorityFilter" rdl:"optional"`
 
 	//
 	// expiration enforced by a user authority configured attribute
 	//
-	UserAuthorityExpiration AuthorityKeyword `json:"userAuthorityExpiration,omitempty" rdl:"optional"`
+	UserAuthorityExpiration string `json:"userAuthorityExpiration" rdl:"optional"`
 }
 
 //
@@ -951,21 +951,21 @@ func (self *RoleMeta) Validate() error {
 		}
 	}
 	if self.NotifyRoles != "" {
-		val := rdl.Validate(ZMSSchema(), "ResourceNames", self.NotifyRoles)
+		val := rdl.Validate(ZMSSchema(), "String", self.NotifyRoles)
 		if !val.Valid {
-			return fmt.Errorf("RoleMeta.notifyRoles does not contain a valid ResourceNames (%v)", val.Error)
+			return fmt.Errorf("RoleMeta.notifyRoles does not contain a valid String (%v)", val.Error)
 		}
 	}
 	if self.UserAuthorityFilter != "" {
-		val := rdl.Validate(ZMSSchema(), "AuthorityKeywords", self.UserAuthorityFilter)
+		val := rdl.Validate(ZMSSchema(), "String", self.UserAuthorityFilter)
 		if !val.Valid {
-			return fmt.Errorf("RoleMeta.userAuthorityFilter does not contain a valid AuthorityKeywords (%v)", val.Error)
+			return fmt.Errorf("RoleMeta.userAuthorityFilter does not contain a valid String (%v)", val.Error)
 		}
 	}
 	if self.UserAuthorityExpiration != "" {
-		val := rdl.Validate(ZMSSchema(), "AuthorityKeyword", self.UserAuthorityExpiration)
+		val := rdl.Validate(ZMSSchema(), "String", self.UserAuthorityExpiration)
 		if !val.Valid {
-			return fmt.Errorf("RoleMeta.userAuthorityExpiration does not contain a valid AuthorityKeyword (%v)", val.Error)
+			return fmt.Errorf("RoleMeta.userAuthorityExpiration does not contain a valid String (%v)", val.Error)
 		}
 	}
 	return nil
@@ -1027,17 +1027,17 @@ type Role struct {
 	//
 	// list of roles whose members should be notified for member review/approval
 	//
-	NotifyRoles ResourceNames `json:"notifyRoles,omitempty" rdl:"optional"`
+	NotifyRoles string `json:"notifyRoles" rdl:"optional"`
 
 	//
 	// membership filtered based on user authority configured attributes
 	//
-	UserAuthorityFilter AuthorityKeywords `json:"userAuthorityFilter,omitempty" rdl:"optional"`
+	UserAuthorityFilter string `json:"userAuthorityFilter" rdl:"optional"`
 
 	//
 	// expiration enforced by a user authority configured attribute
 	//
-	UserAuthorityExpiration AuthorityKeyword `json:"userAuthorityExpiration,omitempty" rdl:"optional"`
+	UserAuthorityExpiration string `json:"userAuthorityExpiration" rdl:"optional"`
 
 	//
 	// name of the role
@@ -1122,21 +1122,21 @@ func (self *Role) Validate() error {
 		}
 	}
 	if self.NotifyRoles != "" {
-		val := rdl.Validate(ZMSSchema(), "ResourceNames", self.NotifyRoles)
+		val := rdl.Validate(ZMSSchema(), "String", self.NotifyRoles)
 		if !val.Valid {
-			return fmt.Errorf("Role.notifyRoles does not contain a valid ResourceNames (%v)", val.Error)
+			return fmt.Errorf("Role.notifyRoles does not contain a valid String (%v)", val.Error)
 		}
 	}
 	if self.UserAuthorityFilter != "" {
-		val := rdl.Validate(ZMSSchema(), "AuthorityKeywords", self.UserAuthorityFilter)
+		val := rdl.Validate(ZMSSchema(), "String", self.UserAuthorityFilter)
 		if !val.Valid {
-			return fmt.Errorf("Role.userAuthorityFilter does not contain a valid AuthorityKeywords (%v)", val.Error)
+			return fmt.Errorf("Role.userAuthorityFilter does not contain a valid String (%v)", val.Error)
 		}
 	}
 	if self.UserAuthorityExpiration != "" {
-		val := rdl.Validate(ZMSSchema(), "AuthorityKeyword", self.UserAuthorityExpiration)
+		val := rdl.Validate(ZMSSchema(), "String", self.UserAuthorityExpiration)
 		if !val.Valid {
-			return fmt.Errorf("Role.userAuthorityExpiration does not contain a valid AuthorityKeyword (%v)", val.Error)
+			return fmt.Errorf("Role.userAuthorityExpiration does not contain a valid String (%v)", val.Error)
 		}
 	}
 	if self.Name == "" {
@@ -1261,7 +1261,7 @@ type Membership struct {
 	//
 	// audit reference string for the change as supplied by admin
 	//
-	AuditRef string `json:"auditRef,omitempty" rdl:"optional"`
+	AuditRef string `json:"auditRef" rdl:"optional"`
 
 	//
 	// pending members only - name of the principal requesting the change
@@ -1453,7 +1453,7 @@ type MemberRole struct {
 	//
 	// audit reference string for the change as supplied by admin
 	//
-	AuditRef string `json:"auditRef,omitempty" rdl:"optional"`
+	AuditRef string `json:"auditRef" rdl:"optional"`
 
 	//
 	// pending members only - name of the principal requesting the change
@@ -2144,7 +2144,7 @@ type ServiceIdentity struct {
 	//
 	// description of the service
 	//
-	Description string `json:"description,omitempty" rdl:"optional"`
+	Description string `json:"description" rdl:"optional"`
 
 	//
 	// array of public keys for key rotation
@@ -2154,7 +2154,7 @@ type ServiceIdentity struct {
 	//
 	// if present, then this service can provision tenants via this endpoint.
 	//
-	ProviderEndpoint string `json:"providerEndpoint,omitempty" rdl:"optional"`
+	ProviderEndpoint string `json:"providerEndpoint" rdl:"optional"`
 
 	//
 	// the timestamp when this entry was last modified
@@ -2164,7 +2164,7 @@ type ServiceIdentity struct {
 	//
 	// the path of the executable that runs the service
 	//
-	Executable string `json:"executable,omitempty" rdl:"optional"`
+	Executable string `json:"executable" rdl:"optional"`
 
 	//
 	// list of host names that this service can run on
@@ -2174,12 +2174,12 @@ type ServiceIdentity struct {
 	//
 	// local (unix) user name this service can run as
 	//
-	User string `json:"user,omitempty" rdl:"optional"`
+	User string `json:"user" rdl:"optional"`
 
 	//
 	// local (unix) group name this service can run as
 	//
-	Group string `json:"group,omitempty" rdl:"optional"`
+	Group string `json:"group" rdl:"optional"`
 }
 
 //
@@ -2332,7 +2332,7 @@ type ServiceIdentityList struct {
 	// be used in the next service list request as the value for the skip query
 	// parameter.
 	//
-	Next string `json:"next,omitempty" rdl:"optional"`
+	Next string `json:"next" rdl:"optional"`
 }
 
 //
@@ -2399,7 +2399,7 @@ type ServiceIdentitySystemMeta struct {
 	//
 	// provider callback endpoint
 	//
-	ProviderEndpoint string `json:"providerEndpoint,omitempty" rdl:"optional"`
+	ProviderEndpoint string `json:"providerEndpoint" rdl:"optional"`
 }
 
 //
@@ -2452,12 +2452,12 @@ type TemplateMetaData struct {
 	//
 	// name of the template
 	//
-	TemplateName string `json:"templateName,omitempty" rdl:"optional"`
+	TemplateName string `json:"templateName" rdl:"optional"`
 
 	//
 	// description of the template
 	//
-	Description string `json:"description,omitempty" rdl:"optional"`
+	Description string `json:"description" rdl:"optional"`
 
 	//
 	// Version from DB(zms_store->domain_template->version)
@@ -2472,7 +2472,7 @@ type TemplateMetaData struct {
 	//
 	// placeholders in the template roles/policies to replace (ex:_service_)
 	//
-	KeywordsToReplace string `json:"keywordsToReplace,omitempty" rdl:"optional"`
+	KeywordsToReplace string `json:"keywordsToReplace" rdl:"optional"`
 
 	//
 	// the updated timestamp of the template(solution_templates.json)
@@ -3011,7 +3011,7 @@ type DomainList struct {
 	// be used in the next domain list request as the value for the skip query
 	// parameter.
 	//
-	Next string `json:"next,omitempty" rdl:"optional"`
+	Next string `json:"next" rdl:"optional"`
 }
 
 //
@@ -3078,7 +3078,7 @@ type TopLevelDomain struct {
 	//
 	// a description of the domain
 	//
-	Description string `json:"description,omitempty" rdl:"optional"`
+	Description string `json:"description" rdl:"optional"`
 
 	//
 	// a reference to an Organization. (i.e. org:media)
@@ -3101,7 +3101,7 @@ type TopLevelDomain struct {
 	// associated cloud (i.e. aws) account id (system attribute - uniqueness
 	// check)
 	//
-	Account string `json:"account,omitempty" rdl:"optional"`
+	Account string `json:"account" rdl:"optional"`
 
 	//
 	// associated product id (system attribute - uniqueness check)
@@ -3111,12 +3111,12 @@ type TopLevelDomain struct {
 	//
 	// associated application id
 	//
-	ApplicationId string `json:"applicationId,omitempty" rdl:"optional"`
+	ApplicationId string `json:"applicationId" rdl:"optional"`
 
 	//
 	// domain certificate dns domain (system attribute)
 	//
-	CertDnsDomain string `json:"certDnsDomain,omitempty" rdl:"optional"`
+	CertDnsDomain string `json:"certDnsDomain" rdl:"optional"`
 
 	//
 	// all user members in the domain will have specified max expiry days
@@ -3274,7 +3274,7 @@ type SubDomain struct {
 	//
 	// a description of the domain
 	//
-	Description string `json:"description,omitempty" rdl:"optional"`
+	Description string `json:"description" rdl:"optional"`
 
 	//
 	// a reference to an Organization. (i.e. org:media)
@@ -3297,7 +3297,7 @@ type SubDomain struct {
 	// associated cloud (i.e. aws) account id (system attribute - uniqueness
 	// check)
 	//
-	Account string `json:"account,omitempty" rdl:"optional"`
+	Account string `json:"account" rdl:"optional"`
 
 	//
 	// associated product id (system attribute - uniqueness check)
@@ -3307,12 +3307,12 @@ type SubDomain struct {
 	//
 	// associated application id
 	//
-	ApplicationId string `json:"applicationId,omitempty" rdl:"optional"`
+	ApplicationId string `json:"applicationId" rdl:"optional"`
 
 	//
 	// domain certificate dns domain (system attribute)
 	//
-	CertDnsDomain string `json:"certDnsDomain,omitempty" rdl:"optional"`
+	CertDnsDomain string `json:"certDnsDomain" rdl:"optional"`
 
 	//
 	// all user members in the domain will have specified max expiry days
@@ -3484,7 +3484,7 @@ type UserDomain struct {
 	//
 	// a description of the domain
 	//
-	Description string `json:"description,omitempty" rdl:"optional"`
+	Description string `json:"description" rdl:"optional"`
 
 	//
 	// a reference to an Organization. (i.e. org:media)
@@ -3507,7 +3507,7 @@ type UserDomain struct {
 	// associated cloud (i.e. aws) account id (system attribute - uniqueness
 	// check)
 	//
-	Account string `json:"account,omitempty" rdl:"optional"`
+	Account string `json:"account" rdl:"optional"`
 
 	//
 	// associated product id (system attribute - uniqueness check)
@@ -3517,12 +3517,12 @@ type UserDomain struct {
 	//
 	// associated application id
 	//
-	ApplicationId string `json:"applicationId,omitempty" rdl:"optional"`
+	ApplicationId string `json:"applicationId" rdl:"optional"`
 
 	//
 	// domain certificate dns domain (system attribute)
 	//
-	CertDnsDomain string `json:"certDnsDomain,omitempty" rdl:"optional"`
+	CertDnsDomain string `json:"certDnsDomain" rdl:"optional"`
 
 	//
 	// all user members in the domain will have specified max expiry days
@@ -3959,7 +3959,7 @@ type PolicyList struct {
 	// be used in the next policy list request as the value for the skip query
 	// parameter.
 	//
-	Next string `json:"next,omitempty" rdl:"optional"`
+	Next string `json:"next" rdl:"optional"`
 }
 
 //
@@ -4723,7 +4723,7 @@ type DomainData struct {
 	//
 	// a description of the domain
 	//
-	Description string `json:"description,omitempty" rdl:"optional"`
+	Description string `json:"description" rdl:"optional"`
 
 	//
 	// a reference to an Organization. (i.e. org:media)
@@ -4746,7 +4746,7 @@ type DomainData struct {
 	// associated cloud (i.e. aws) account id (system attribute - uniqueness
 	// check)
 	//
-	Account string `json:"account,omitempty" rdl:"optional"`
+	Account string `json:"account" rdl:"optional"`
 
 	//
 	// associated product id (system attribute - uniqueness check)
@@ -4756,12 +4756,12 @@ type DomainData struct {
 	//
 	// associated application id
 	//
-	ApplicationId string `json:"applicationId,omitempty" rdl:"optional"`
+	ApplicationId string `json:"applicationId" rdl:"optional"`
 
 	//
 	// domain certificate dns domain (system attribute)
 	//
-	CertDnsDomain string `json:"certDnsDomain,omitempty" rdl:"optional"`
+	CertDnsDomain string `json:"certDnsDomain" rdl:"optional"`
 
 	//
 	// all user members in the domain will have specified max expiry days
@@ -4962,12 +4962,12 @@ type SignedDomain struct {
 	//
 	// signature generated based on the domain object
 	//
-	Signature string `json:"signature,omitempty" rdl:"optional"`
+	Signature string `json:"signature" rdl:"optional"`
 
 	//
 	// the identifier of the key used to generate the signature
 	//
-	KeyId string `json:"keyId,omitempty" rdl:"optional"`
+	KeyId string `json:"keyId" rdl:"optional"`
 }
 
 //
@@ -5184,7 +5184,7 @@ type UserToken struct {
 	//
 	// Authorization header name for the token
 	//
-	Header string `json:"header,omitempty" rdl:"optional"`
+	Header string `json:"header" rdl:"optional"`
 }
 
 //

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -167,9 +167,9 @@ func init() {
 	tRoleMeta.Field("memberReviewDays", "Int32", true, nil, "all user members in the role will have specified max review days")
 	tRoleMeta.Field("serviceReviewDays", "Int32", true, nil, "all services in the role will have specified max review days")
 	tRoleMeta.Field("reviewEnabled", "Bool", true, false, "Flag indicates whether or not role updates require another review and approval")
-	tRoleMeta.Field("notifyRoles", "ResourceNames", true, nil, "list of roles whose members should be notified for member review/approval")
-	tRoleMeta.Field("userAuthorityFilter", "AuthorityKeywords", true, nil, "membership filtered based on user authority configured attributes")
-	tRoleMeta.Field("userAuthorityExpiration", "AuthorityKeyword", true, nil, "expiration enforced by a user authority configured attribute")
+	tRoleMeta.Field("notifyRoles", "String", true, nil, "list of roles whose members should be notified for member review/approval")
+	tRoleMeta.Field("userAuthorityFilter", "String", true, nil, "membership filtered based on user authority configured attributes")
+	tRoleMeta.Field("userAuthorityExpiration", "String", true, nil, "expiration enforced by a user authority configured attribute")
 	sb.AddType(tRoleMeta.Build())
 
 	tRole := rdl.NewStructTypeBuilder("RoleMeta", "Role")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -145,9 +145,9 @@ public class ZMSSchema {
             .field("memberReviewDays", "Int32", true, "all user members in the role will have specified max review days")
             .field("serviceReviewDays", "Int32", true, "all services in the role will have specified max review days")
             .field("reviewEnabled", "Bool", true, "Flag indicates whether or not role updates require another review and approval", false)
-            .field("notifyRoles", "ResourceNames", true, "list of roles whose members should be notified for member review/approval")
-            .field("userAuthorityFilter", "AuthorityKeywords", true, "membership filtered based on user authority configured attributes")
-            .field("userAuthorityExpiration", "AuthorityKeyword", true, "expiration enforced by a user authority configured attribute");
+            .field("notifyRoles", "String", true, "list of roles whose members should be notified for member review/approval")
+            .field("userAuthorityFilter", "String", true, "membership filtered based on user authority configured attributes")
+            .field("userAuthorityExpiration", "String", true, "expiration enforced by a user authority configured attribute");
 
         sb.structType("Role", "RoleMeta")
             .comment("The representation for a Role with set of members.")

--- a/core/zms/src/main/rdl/Role.tdl
+++ b/core/zms/src/main/rdl/Role.tdl
@@ -43,9 +43,9 @@ type RoleMeta Struct {
     Int32 memberReviewDays (optional); //all user members in the role will have specified max review days
     Int32 serviceReviewDays (optional); //all services in the role will have specified max review days
     Bool reviewEnabled (optional, default=false); //Flag indicates whether or not role updates require another review and approval
-    ResourceNames notifyRoles (optional); //list of roles whose members should be notified for member review/approval
-    AuthorityKeywords userAuthorityFilter (optional); //membership filtered based on user authority configured attributes
-    AuthorityKeyword userAuthorityExpiration (optional); //expiration enforced by a user authority configured attribute
+    String notifyRoles (optional); //list of roles whose members should be notified for member review/approval
+    String userAuthorityFilter (optional); //membership filtered based on user authority configured attributes
+    String userAuthorityExpiration (optional); //expiration enforced by a user authority configured attribute
 }
 
 //The representation for a Role with set of members.

--- a/libs/go/zmscli/role.go
+++ b/libs/go/zmscli/role.go
@@ -384,7 +384,7 @@ func (cli Zms) SetRoleUserAuthorityFilter(dn string, rn, filter string) (*string
 		return nil, err
 	}
 	meta := getRoleMetaObject(role)
-	meta.UserAuthorityFilter = zms.AuthorityKeywords(filter)
+	meta.UserAuthorityFilter = filter
 
 	err = cli.Zms.PutRoleMeta(zms.DomainName(dn), zms.EntityName(rn), cli.AuditRef, &meta)
 	if err != nil {
@@ -400,7 +400,7 @@ func (cli Zms) SetRoleUserAuthorityExpiration(dn string, rn, filter string) (*st
 		return nil, err
 	}
 	meta := getRoleMetaObject(role)
-	meta.UserAuthorityExpiration = zms.AuthorityKeyword(filter)
+	meta.UserAuthorityExpiration = filter
 
 	err = cli.Zms.PutRoleMeta(zms.DomainName(dn), zms.EntityName(rn), cli.AuditRef, &meta)
 	if err != nil {
@@ -528,7 +528,7 @@ func (cli Zms) SetRoleNotifyRoles(dn string, rn string, notifyRoles string) (*st
 		return nil, err
 	}
 	meta := getRoleMetaObject(role)
-	meta.NotifyRoles = zms.ResourceNames(notifyRoles)
+	meta.NotifyRoles = notifyRoles
 
 	err = cli.Zms.PutRoleMeta(zms.DomainName(dn), zms.EntityName(rn), cli.AuditRef, &meta)
 	if err != nil {

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,7 @@
 
   <modules>
     <module>rdl/rdl-gen-athenz-server</module>
+    <module>rdl/rdl-gen-athenz-go-model</module>
     <module>rdl/rdl-gen-athenz-go-client</module>
     <module>core/zms</module>
     <module>core/zts</module>

--- a/rdl/rdl-gen-athenz-go-model/Makefile
+++ b/rdl/rdl-gen-athenz-go-model/Makefile
@@ -1,0 +1,14 @@
+#
+# Makefile to build Athenz Go Client RDL Code Generator
+# Prerequisite: Go development environment
+#
+# Copyright 2019 Oath Holdings, Inc.
+# Licensed under the Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0
+#
+
+all:
+	@echo "Building Athenz Go Client RDL generator..."
+	@./make_generator.sh
+
+clean:
+	rm -rf rdl-gen-athenz-go-model

--- a/rdl/rdl-gen-athenz-go-model/gomodel.go
+++ b/rdl/rdl-gen-athenz-go-model/gomodel.go
@@ -1,0 +1,1083 @@
+// Copyright 2015 Yahoo Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+
+	genutil "github.com/ardielle/ardielle-go/gen"
+	"github.com/ardielle/ardielle-go/rdl"
+)
+
+//
+// FullValidation - the generated validation method includes things like string pattern checks
+//
+var FullValidation bool = true
+var DefaultLibRdl = "github.com/ardielle/ardielle-go/rdl"
+
+type GeneratorParams struct {
+	Outdir         string
+	Banner         string
+	Namespace      string
+	UntaggedUnions []string
+	LibRdl         string
+	PrefixEnums    bool
+	PreciseTypes   bool
+	GenerateSchema bool
+}
+
+type modelGenerator struct {
+	registry       rdl.TypeRegistry
+	schema         *rdl.Schema
+	writer         *bufio.Writer
+	librdl         string
+	prefixEnums    bool
+	precise        bool
+	err            error
+	untaggedUnions []string
+	ns             string
+	rdl            bool
+}
+
+// GenerateGoModel generates the model code for the types defined in the RDL schema.
+func GenerateAthenzGoModel(schema *rdl.Schema, params *GeneratorParams) error {
+	name := strings.ToLower(string(schema.Name))
+	outdir := params.Outdir
+	if outdir == "" {
+		outdir = "."
+		name = name + "_model.go"
+	} else if strings.HasSuffix(outdir, ".go") {
+		name = filepath.Base(outdir)
+		outdir = filepath.Dir(outdir)
+	} else {
+		name = name + "_model.go"
+	}
+	err := os.MkdirAll(outdir, 0755)
+	if err != nil {
+		return err
+	}
+	filepath := outdir + "/" + name
+	out, file, _, err := genutil.OutputWriter(filepath, "", ".go")
+	if err != nil {
+		return err
+	}
+	if file != nil {
+		defer func() {
+			file.Close()
+			err := goFmt(filepath)
+			if err != nil {
+				fmt.Println("Warning: could not format go code:", err)
+			}
+		}()
+	}
+	gen := &modelGenerator{
+		registry:       rdl.NewTypeRegistry(schema),
+		schema:         schema,
+		writer:         out,
+		librdl:         params.LibRdl,
+		prefixEnums:    params.PrefixEnums,
+		precise:        params.PreciseTypes,
+		err:            nil,
+		untaggedUnions: params.UntaggedUnions,
+		ns:             params.Namespace,
+		rdl:            schema.Name == "rdl",
+	}
+	gen.emitHeader(params.Banner)
+	if gen.err == nil {
+		for _, t := range schema.Types {
+			gen.emitType(t)
+		}
+	}
+	out.Flush()
+	if gen.err == nil {
+		if params.GenerateSchema {
+			gen.err = GenerateGoSchema(params.Banner, schema, outdir, params.Namespace, params.LibRdl, params.PrefixEnums)
+		}
+	}
+	return gen.err
+}
+
+func (gen *modelGenerator) isUntaggedUnion(s rdl.TypeName) bool {
+	ss := string(s)
+	for _, st := range gen.untaggedUnions {
+		if ss == st {
+			return true
+		}
+	}
+	return false
+}
+
+func (gen *modelGenerator) emit(s string) {
+	if gen.err == nil {
+		_, err := gen.writer.WriteString(s)
+		if err != nil {
+			gen.err = err
+		}
+	}
+}
+
+func (gen *modelGenerator) structHasFieldDefault(t *rdl.StructTypeDef) bool {
+
+	flds := genutil.FlattenedFields(gen.registry, gen.registry.FindType(t.Type))
+	flds = append(flds, t.Fields...)
+
+	for _, f := range flds {
+		if !f.Optional {
+			switch gen.registry.FindBaseType(f.Type) {
+			case rdl.BaseTypeArray, rdl.BaseTypeMap, rdl.BaseTypeStruct:
+				return true
+			}
+		}
+		if f.Default != nil {
+			switch gen.registry.FindBaseType(f.Type) {
+			case rdl.BaseTypeString, rdl.BaseTypeSymbol, rdl.BaseTypeUUID, rdl.BaseTypeTimestamp:
+				switch s := (f.Default).(type) {
+				case string:
+					if s != "" {
+						return true
+					}
+				}
+			case rdl.BaseTypeEnum:
+				switch s := (f.Default).(type) {
+				case string:
+					if s != "" {
+						return true
+					}
+				}
+			case rdl.BaseTypeInt8, rdl.BaseTypeInt16, rdl.BaseTypeInt32, rdl.BaseTypeInt64, rdl.BaseTypeFloat32, rdl.BaseTypeFloat64:
+				switch n := f.Default.(type) {
+				case float64:
+					if n != 0 {
+						return true
+					}
+				}
+			case rdl.BaseTypeBool:
+				switch b := f.Default.(type) {
+				case bool:
+					if b {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
+func (gen *modelGenerator) requiredImports(t *rdl.Type, imports map[string]string, visited map[rdl.TypeName]rdl.TypeName) {
+	tName, _, _ := rdl.TypeInfo(t)
+	if _, ok := visited[tName]; ok {
+		return
+	}
+	visited[tName] = tName
+	if strings.HasPrefix(string(tName), "rdl.") && !gen.rdl {
+		imports[gen.librdl] = "rdl"
+	}
+	b := gen.registry.BaseType(t)
+	switch b {
+	case rdl.BaseTypeTimestamp, rdl.BaseTypeUUID:
+		if !gen.rdl {
+			imports[gen.librdl] = "rdl"
+		}
+	case rdl.BaseTypeEnum:
+		imports["encoding/json"] = ""
+		imports["fmt"] = ""
+		break
+	case rdl.BaseTypeUnion:
+		imports["encoding/json"] = ""
+		imports["fmt"] = ""
+		break
+	case rdl.BaseTypeArray:
+		if t.ArrayTypeDef != nil {
+			gen.requiredImports(gen.registry.FindType(t.ArrayTypeDef.Items), imports, visited)
+		}
+	case rdl.BaseTypeMap:
+		if t.MapTypeDef != nil {
+			gen.requiredImports(gen.registry.FindType(t.MapTypeDef.Keys), imports, visited)
+			gen.requiredImports(gen.registry.FindType(t.MapTypeDef.Items), imports, visited)
+		}
+	case rdl.BaseTypeStruct:
+		if !gen.rdl {
+			imports[gen.librdl] = "rdl"
+		}
+		imports["encoding/json"] = ""
+		if t.StructTypeDef != nil && t.StructTypeDef.Fields != nil {
+			for _, f := range t.StructTypeDef.Fields {
+				if !f.Optional {
+					switch gen.registry.FindBaseType(f.Type) {
+					case rdl.BaseTypeString, rdl.BaseTypeArray, rdl.BaseTypeMap, rdl.BaseTypeStruct:
+						imports["fmt"] = ""
+					}
+				}
+				if f.Items != "" {
+					gen.requiredImports(gen.registry.FindType(f.Items), imports, visited)
+				} else if f.Keys != "" {
+					gen.requiredImports(gen.registry.FindType(f.Keys), imports, visited)
+				} else {
+					t := gen.registry.FindType(f.Type)
+					if t != nil {
+						gen.requiredImports(t, imports, visited)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (gen *modelGenerator) emitHeader(banner string) {
+	imports := make(map[string]string, 0)
+	visited := make(map[rdl.TypeName]rdl.TypeName, 0)
+	for _, t := range gen.schema.Types {
+		gen.requiredImports(t, imports, visited)
+	}
+	gen.emit(GenerationHeader(banner))
+	gen.emit("\n\npackage " + GenerationPackage(gen.schema, gen.ns) + "\n")
+	if len(imports) > 0 {
+		rdlEmitted := false
+		jsonEmitted := false
+		fmtEmitted := false
+		var imp sort.StringSlice
+		for k := range imports {
+			if k == string(gen.schema.Name) {
+				continue
+			}
+			kk := fmt.Sprintf("%q", k)
+			if k == "fmt" {
+				fmtEmitted = true
+			} else if k == "encoding/json" {
+				jsonEmitted = true
+			}
+			n := imports[k]
+			if n != "" {
+				if n == "rdl" {
+					rdlEmitted = true
+				}
+				kk = n + " " + kk
+			}
+			imp = append(imp, kk)
+		}
+		imp.Sort()
+		gen.emit("\nimport (\n")
+		for _, k := range imp {
+			gen.emit("\t" + k + "\n")
+		}
+		gen.emit(")\n")
+		if rdlEmitted {
+			gen.emit("\nvar _ = rdl.Version\n")
+		}
+		if jsonEmitted {
+			if !rdlEmitted {
+				gen.emit("\n")
+			}
+			gen.emit("var _ = json.Marshal\n")
+		}
+		if fmtEmitted {
+			if !jsonEmitted && !rdlEmitted {
+				gen.emit("\n")
+			}
+			gen.emit("var _ = fmt.Printf\n")
+		}
+	}
+}
+
+func (gen *modelGenerator) emitTypeComment(t *rdl.Type) {
+	tName, _, tComment := rdl.TypeInfo(t)
+	s := string(tName) + " -"
+	if tComment != "" {
+		s += " " + tComment
+	}
+	gen.emit(FormatComment(s, 0, 80))
+}
+
+func GoType(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.TypeRef, keys rdl.TypeRef, precise bool, reference bool) string {
+	return goType(reg, rdlType, optional, items, keys, precise, reference)
+}
+
+func goType(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.TypeRef, keys rdl.TypeRef, precise bool, reference bool) string {
+	return goType2(reg, rdlType, optional, items, keys, precise, reference, "")
+}
+
+func GoType2(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.TypeRef, keys rdl.TypeRef, precise bool, reference bool, packageName string) string {
+	return goType2(reg, rdlType, optional, items, keys, precise, reference, packageName)
+}
+
+func goType2(reg rdl.TypeRegistry, rdlType rdl.TypeRef, optional bool, items rdl.TypeRef, keys rdl.TypeRef, precise bool, reference bool, packageName string) string {
+	rdlPrefix := "rdl."
+	if reg.Name() == "rdl" {
+		rdlPrefix = ""
+	}
+	cleanType := string(rdlType)
+	if !strings.HasPrefix(cleanType, "rdl.") {
+		cleanType = capitalize(strings.Replace(string(rdlType), ".", "_", -1))
+	}
+	prefix := ""
+	if optional {
+		prefix = "*"
+	}
+	t := reg.FindType(rdlType)
+	if t.Variant == 0 {
+		panic("Cannot find type '" + rdlType + "'")
+	}
+	lrdlType := strings.ToLower(string(rdlType))
+	if precise {
+		switch lrdlType {
+		case "string":
+			return "string"
+		case "symbol":
+			return rdlPrefix + "Symbol"
+		case "bool", "int32", "int64", "int16", "int8", "float64", "float32":
+			return prefix + strings.ToLower(cleanType)
+		default:
+			bt := reg.BaseType(t)
+			switch bt {
+			case rdl.BaseTypeString, rdl.BaseTypeSymbol:
+				return cleanType
+			case rdl.BaseTypeInt8, rdl.BaseTypeInt16, rdl.BaseTypeInt32, rdl.BaseTypeInt64, rdl.BaseTypeFloat32, rdl.BaseTypeFloat64, rdl.BaseTypeBool:
+				return prefix + cleanType
+			case rdl.BaseTypeTimestamp, rdl.BaseTypeUUID:
+				fullTypeName := rdlPrefix + cleanType
+				return prefix + fullTypeName
+			default:
+				if lrdlType == "struct" {
+					fullTypeName := rdlPrefix + cleanType
+					return prefix + fullTypeName
+				}
+			}
+		}
+	} else {
+		switch lrdlType {
+		case "timestamp":
+			return prefix + rdlPrefix + "Timestamp"
+		case "uuid":
+			return prefix + rdlPrefix + "UUID"
+		case "struct":
+			return prefix + rdlPrefix + "Struct"
+		}
+	}
+	bt := reg.BaseType(t)
+	switch bt {
+	case rdl.BaseTypeAny:
+		return "interface{}"
+	case rdl.BaseTypeString:
+		return "string"
+	case rdl.BaseTypeSymbol:
+		return rdlPrefix + "Symbol"
+	case rdl.BaseTypeBool:
+		return prefix + "bool"
+	case rdl.BaseTypeInt8, rdl.BaseTypeInt16, rdl.BaseTypeInt32, rdl.BaseTypeInt64, rdl.BaseTypeFloat32, rdl.BaseTypeFloat64:
+		return prefix + strings.ToLower(bt.String())
+	case rdl.BaseTypeArray:
+		if reference {
+			name := "Array"
+			if t.ArrayTypeDef != nil {
+				name = string(t.ArrayTypeDef.Name)
+			}
+			if name != "Array" {
+				return name
+			}
+		}
+		i := rdl.TypeRef("Any")
+		switch t.Variant {
+		case rdl.TypeVariantArrayTypeDef:
+			i = t.ArrayTypeDef.Items
+		default:
+			if items != "" {
+				i = items
+			}
+		}
+		gitems := goType2(reg, i, false, "", "", precise, reference, packageName)
+		return "[]" + gitems
+	case rdl.BaseTypeMap:
+		if reference {
+			//we check if we have defined a type, i.e. the type name is not "Map"
+			name := rdl.TypeName("Map")
+			if t.MapTypeDef != nil {
+				name = t.MapTypeDef.Name
+			} else if t.AliasTypeDef != nil {
+				name = t.AliasTypeDef.Name
+			}
+			if name != "Map" {
+				return string(name)
+			}
+		}
+		k := rdl.TypeRef("Any")
+		i := rdl.TypeRef("Any")
+		switch t.Variant {
+		case rdl.TypeVariantMapTypeDef:
+			k = t.MapTypeDef.Keys
+			i = t.MapTypeDef.Items
+		default:
+			if keys != "" {
+				k = keys
+			}
+			if items != "" {
+				i = items
+			}
+		}
+		gkeys := goType2(reg, k, false, "", "", precise, reference, packageName)
+		gitems := goType2(reg, i, false, "", "", precise, reference, packageName)
+		return "map[" + gkeys + "]" + gitems
+	case rdl.BaseTypeStruct:
+		switch t.Variant {
+		case rdl.TypeVariantAliasTypeDef:
+			if t.AliasTypeDef.Name == "Struct" {
+				return prefix + "map[string]interface{}"
+			}
+		}
+		if packageName != "" {
+			return "*" + packageName + "." + cleanType
+		}
+		return "*" + cleanType
+	case rdl.BaseTypeUnion:
+		return "*" + cleanType
+	case rdl.BaseTypeEnum:
+		return prefix + cleanType
+	case rdl.BaseTypeBytes:
+		return "[]byte"
+	default:
+		return prefix + cleanType
+	}
+}
+
+func (gen *modelGenerator) emitType(t *rdl.Type) {
+	if gen.err == nil {
+		tName, _, _ := rdl.TypeInfo(t)
+		if strings.HasPrefix(string(tName), "rdl.") {
+			return
+		}
+		tName = rdl.TypeName(goTypeName(tName))
+		bt := gen.registry.BaseType(t)
+		switch bt {
+		case rdl.BaseTypeAny:
+			gen.emit("\n")
+			gen.emitTypeComment(t)
+			gen.emit(fmt.Sprintf("type %s interface{}\n", tName))
+		case rdl.BaseTypeString, rdl.BaseTypeBool, rdl.BaseTypeInt8, rdl.BaseTypeInt16, rdl.BaseTypeInt32, rdl.BaseTypeInt64, rdl.BaseTypeFloat32, rdl.BaseTypeFloat64, rdl.BaseTypeSymbol:
+			if gen.precise {
+				gen.emit("\n")
+				gen.emitTypeComment(t)
+				gen.emit(fmt.Sprintf("type %s %s\n", tName, goType(gen.registry, rdl.TypeRef(bt.String()), false, "", "", gen.precise, false)))
+			}
+		case rdl.BaseTypeStruct:
+			gen.emit("\n")
+			gen.emitStruct(t)
+		case rdl.BaseTypeUnion:
+			gen.emit("\n")
+			gen.emitUnion(t)
+		case rdl.BaseTypeArray:
+			gen.emit("\n")
+			gen.emitArray(t)
+		case rdl.BaseTypeMap:
+			gen.emit("\n")
+			gen.emitMap(t)
+		case rdl.BaseTypeEnum:
+			gen.emit("\n")
+			gen.emitTypeComment(t)
+			gen.emitEnum(t)
+		}
+	}
+}
+
+func goTypeName(name rdl.TypeName) rdl.TypeName {
+	tokens := strings.Split(string(name), ".")
+	return rdl.TypeName(capitalize(strings.Join(tokens, "_")))
+}
+
+func (gen *modelGenerator) emitUnion(t *rdl.Type) {
+	tName, _, _ := rdl.TypeInfo(t)
+	ut := t.UnionTypeDef
+	uName := capitalize(string(tName))
+	gen.emit(fmt.Sprintf("//\n// %sVariantTag - generated to support %s\n//\n", uName, uName))
+	gen.emit(fmt.Sprintf("type %sVariantTag int\n\n", uName))
+	gen.emit("//\n// Supporting constants\n//\n")
+	gen.emit("const (\n")
+	gen.emit(fmt.Sprintf("\t_ %sVariantTag = iota\n", uName))
+	for _, v := range ut.Variants {
+		uV := capitalize(string(v))
+		gen.emit(fmt.Sprintf("\t%sVariant%s\n", uName, uV))
+	}
+	gen.emit(")\n\n")
+
+	maxKeyLen := len("Variant")
+	for _, v := range ut.Variants {
+		if len(v) > maxKeyLen {
+			maxKeyLen = len(v)
+		}
+	}
+	gen.emitTypeComment(t)
+	gen.emit(fmt.Sprintf("type %s struct {\n", uName))
+	s := leftJustified("Variant", maxKeyLen)
+	vtag := uName + "VariantTag"
+	gen.emit(fmt.Sprintf("\t%s %s `json:\"-\" rdl:\"union\"`\n", s, vtag))
+	maxVarLen := maxKeyLen + 1
+	if len(vtag) > maxVarLen {
+		maxVarLen = len(vtag)
+	}
+	for _, v := range ut.Variants {
+		uV := capitalize(string(v))
+		vType := goType(gen.registry, v, true, "", "", gen.precise, true)
+		tag := fmt.Sprintf("`json:\"%s,omitempty\"`", v)
+		s := leftJustified(uV, maxKeyLen)
+		gen.emit(fmt.Sprintf("\t%s %s %s\n", s, leftJustified(vType, maxVarLen), tag))
+	}
+	gen.emit("}\n\n")
+	gen.emit(fmt.Sprintf("func (u %s) String() string {\n", uName))
+	gen.emit("\tswitch u.Variant {\n")
+	for _, v := range ut.Variants {
+		uV := capitalize(string(v))
+		gen.emit(fmt.Sprintf("\tcase %sVariant%s:\n", uName, uV))
+		gen.emit(fmt.Sprintf("\t\treturn fmt.Sprintf(\"%%v\", u.%s)\n", uV))
+	}
+	gen.emit("\tdefault:\n")
+	gen.emit(fmt.Sprintf("\t\treturn \"<%s uninitialized>\"\n", uName))
+	gen.emit("\t}\n")
+	gen.emit("}\n\n")
+	gen.emit(fmt.Sprintf("//\n// Validate for %s\n//\n", uName))
+	gen.emit(fmt.Sprintf("func (p *%s) Validate() error {\n", uName))
+	gen.emit("\t")
+	for _, v := range ut.Variants {
+		gen.emit(fmt.Sprintf("if p.%s != nil {\n\t\tp.Variant = %sVariant%s\n\t} else ", v, uName, v))
+	}
+	gen.emit(fmt.Sprintf("{\n\t\treturn fmt.Errorf(\"%s: Missing required variant\")\n\t}\n", uName))
+	gen.emit("\treturn nil\n")
+	gen.emit("}\n")
+
+	if gen.isUntaggedUnion(tName) {
+		gen.emitUntaggedUnionSerializer(ut, tName)
+	} else {
+		gen.emit(fmt.Sprintf("\ntype raw%s %s\n\n", uName, uName))
+		gen.emit(fmt.Sprintf("//\n// UnmarshalJSON for %s\n//\n", uName))
+		gen.emit(fmt.Sprintf("func (p *%s) UnmarshalJSON(b []byte) error {\n", uName))
+		gen.emit(fmt.Sprintf("\tvar tmp raw%s\n", uName))
+		gen.emit("\tif err := json.Unmarshal(b, &tmp); err != nil {\n")
+		gen.emit("\t\treturn err\n")
+		gen.emit("\t}\n")
+		gen.emit(fmt.Sprintf("\t*p = %s(tmp)\n", uName))
+		gen.emit("\treturn p.Validate()\n")
+		gen.emit("}\n")
+	}
+}
+
+func (gen *modelGenerator) emitUntaggedUnionSerializer(ut *rdl.UnionTypeDef, uName rdl.TypeName) {
+	gen.emit(fmt.Sprintf("\nfunc check%sStructFields(repr map[string]interface{}, fields map[string]bool) bool {\n", uName))
+	gen.emit("\tfor name, required := range fields {\n")
+	gen.emit("\t\tif _, present := repr[name]; required && !present {\n")
+	gen.emit("\t\t\treturn false\n")
+	gen.emit("\t\t}\n")
+	gen.emit("\t}\n")
+	gen.emit("\tfor name := range repr {\n")
+	gen.emit("\t\tif _, ok := fields[name]; !ok {\n")
+	gen.emit("\t\t\treturn false\n")
+	gen.emit("\t\t}\n")
+	gen.emit("\t}\n")
+	gen.emit("\treturn true\n")
+	gen.emit("}\n\n")
+
+	for _, v := range ut.Variants {
+		uV := capitalize(string(v))
+		t := gen.registry.FindType(v)
+		switch t.Variant {
+		case rdl.TypeVariantStructTypeDef:
+			names := ""
+			for _, f := range genutil.FlattenedFields(gen.registry, t) {
+				s := fmt.Sprintf("%q", f.Name)
+				if !f.Optional && f.Default == nil {
+					s = s + ": true"
+				} else {
+					s = s + ": false"
+				}
+				if names == "" {
+					names = s
+				} else {
+					names = names + ", " + s
+				}
+			}
+			if names != "" {
+				names = "map[string]bool{" + names + "}"
+				gen.emit(fmt.Sprintf("func make%sVariant%s(b []byte, u *%s, fields map[string]interface{}) bool {\n", uName, uV, uName))
+				gen.emit(fmt.Sprintf("\tif check%sStructFields(fields, %s) {\n", uName, names))
+				gen.emit(fmt.Sprintf("\t\tvar o %s\n", uV))
+				gen.emit("\t\tif err := json.Unmarshal(b, &o); err == nil {\n")
+				gen.emit(fmt.Sprintf("\t\t\tup := new(%s)\n", uName))
+				gen.emit(fmt.Sprintf("\t\t\tup.Variant = %sVariant%s\n", uName, uV))
+				gen.emit(fmt.Sprintf("\t\t\tup.%s = &o\n", uV))
+				gen.emit("\t\t\t*u = *up\n")
+				gen.emit("\t\t\treturn true\n")
+				gen.emit("\t\t}\n")
+				gen.emit("\t}\n")
+				gen.emit("\treturn false\n")
+				gen.emit("}\n\n")
+			}
+		default:
+			gen.err = fmt.Errorf("Untagged union serializer only supported for struct type unions")
+			return
+		}
+	}
+
+	gen.emit(fmt.Sprintf("//\n// UnmarshalJSON for %s\n//\n", uName))
+	gen.emit(fmt.Sprintf("func (u *%s) UnmarshalJSON(b []byte) error {\n", uName))
+	gen.emit("\tvar tmp interface{}\n")
+	gen.emit("\tif err := json.Unmarshal(b, &tmp); err != nil {\n")
+	gen.emit("\t\treturn err\n")
+	gen.emit("\t}\n")
+	gen.emit("\tswitch v := tmp.(type) {\n")
+	gen.emit("\tcase map[string]interface{}:\n")
+	for _, v := range ut.Variants {
+		uV := capitalize(string(v))
+		gen.emit(fmt.Sprintf("\t\tif make%sVariant%s(b, u, v) {\n", uName, uV))
+		gen.emit("\t\t\treturn nil\n")
+		gen.emit("\t\t}\n")
+	}
+	gen.emit("\t}\n")
+	gen.emit(fmt.Sprintf("\treturn fmt.Errorf(\"Cannot unmarshal JSON to union type %s\")\n", uName))
+	gen.emit("}\n")
+
+	gen.emit(fmt.Sprintf("\n//\n// MarshalJSON for %s\n//\n", uName))
+	gen.emit(fmt.Sprintf("func (p %s) MarshalJSON() ([]byte, error) {\n", uName))
+	gen.emit("\tswitch p.Variant {\n")
+	for _, v := range ut.Variants {
+		uV := capitalize(string(v))
+		gen.emit(fmt.Sprintf("\tcase %sVariant%s:\n", uName, uV))
+		gen.emit(fmt.Sprintf("\t\treturn json.Marshal(p.%s)\n", uV))
+	}
+	gen.emit("\t}\n")
+	gen.emit(fmt.Sprintf("\treturn nil, fmt.Errorf(\"Cannot marshal uninitialized %s\")\n", uName))
+	gen.emit("}\n")
+}
+
+func (gen *modelGenerator) literal(lit interface{}) string {
+	switch v := lit.(type) {
+	case string:
+		return fmt.Sprintf("%q", v)
+	case int32:
+		return fmt.Sprintf("%d", v)
+	case int16:
+		return fmt.Sprintf("%d", v)
+	case int8:
+		return fmt.Sprintf("%d", v)
+	case int64:
+		return fmt.Sprintf("%d", v)
+	case float64:
+		return fmt.Sprintf("%g", v)
+	case float32:
+		return fmt.Sprintf("%g", v)
+	default: //bool, enum
+		return fmt.Sprintf("%v", lit)
+	}
+}
+
+func (gen *modelGenerator) emitArray(t *rdl.Type) {
+	if gen.err == nil {
+		switch t.Variant {
+		case rdl.TypeVariantArrayTypeDef:
+			at := t.ArrayTypeDef
+			gen.emitTypeComment(t)
+			ftype := goType(gen.registry, at.Type, false, at.Items, "", gen.precise, false)
+			gen.emit(fmt.Sprintf("type %s %s\n\n", at.Name, ftype))
+		default:
+			tName, tType, _ := rdl.TypeInfo(t)
+			gtype := goType(gen.registry, tType, false, "", "", gen.precise, false)
+			gen.emitTypeComment(t)
+			gen.emit(fmt.Sprintf("type %s %s\n\n", tName, gtype))
+		}
+	}
+}
+
+func (gen *modelGenerator) emitMap(t *rdl.Type) {
+	if gen.err == nil {
+		switch t.Variant {
+		case rdl.TypeVariantMapTypeDef:
+			mt := t.MapTypeDef
+			gen.emitTypeComment(t)
+			ftype := goType(gen.registry, mt.Type, false, mt.Items, mt.Keys, gen.precise, false)
+			gen.emit(fmt.Sprintf("type %s %s\n\n", mt.Name, ftype))
+		default:
+			tName, tType, _ := rdl.TypeInfo(t)
+			gtype := goType(gen.registry, tType, false, "string", "", gen.precise, false)
+			gen.emitTypeComment(t)
+			gen.emit(fmt.Sprintf("type %s %s\n\n", tName, gtype))
+		}
+	}
+}
+
+func (gen *modelGenerator) emitStruct(t *rdl.Type) {
+	if gen.err == nil {
+		switch t.Variant {
+		case rdl.TypeVariantStructTypeDef:
+			st := t.StructTypeDef
+			flattened := genutil.FlattenedFields(gen.registry, t)
+			gen.emitTypeComment(t)
+			gen.emitStructFields(flattened, st.Name, st.Comment)
+			init := gen.structHasFieldDefault(st)
+			gen.emit(fmt.Sprintf("\n//\n// New%s - creates an initialized %s instance, returns a pointer to it\n//\n", st.Name, st.Name))
+			gen.emit(fmt.Sprintf("func New%s(init ...*%s) *%s {\n", st.Name, st.Name, st.Name))
+			gen.emit(fmt.Sprintf("\tvar o *%s\n", st.Name))
+			gen.emit("\tif len(init) == 1 {\n")
+			gen.emit("\t\to = init[0]\n")
+			gen.emit("\t} else {\n")
+			gen.emit(fmt.Sprintf("\t\to = new(%s)\n", st.Name))
+			gen.emit("\t}\n")
+			if init {
+				gen.emit("\treturn o.Init()\n")
+			} else {
+				gen.emit(fmt.Sprintf("\treturn o\n"))
+			}
+			gen.emit("}\n")
+			if init {
+				gen.emitStructInitializer(st, flattened)
+			}
+			gen.emitStructUnmarshaller(st, init)
+			gen.emitStructValidator(st, flattened)
+		case rdl.TypeVariantAliasTypeDef:
+			gen.emitTypeComment(t)
+			gen.emit(fmt.Sprintf("type %s rdl.Struct\n\n", t.AliasTypeDef.Name))
+		default:
+			panic(fmt.Sprintf("Unreasonable struct typedef: %v", t.Variant))
+		}
+	}
+}
+
+func (gen *modelGenerator) emitStructValidator(st *rdl.StructTypeDef, flattened []*rdl.StructFieldDef) {
+	gen.emit("\n//\n// Validate - checks for missing required fields, etc\n//\n")
+	gen.emit(fmt.Sprintf("func (self *%s) Validate() error {\n", st.Name))
+	rdlPrefix := "rdl."
+	if gen.rdl {
+		rdlPrefix = ""
+	}
+	for _, f := range flattened {
+		fname := capitalize(string(f.Name))
+		ftype := string(f.Type)
+		bt := gen.registry.FindBaseType(f.Type)
+		switch bt {
+		case rdl.BaseTypeString, rdl.BaseTypeSymbol:
+			if !f.Optional {
+				gen.emit(fmt.Sprintf("\tif self.%s == \"\" {\n", fname))
+				gen.emit(fmt.Sprintf("\t\treturn fmt.Errorf(\"%s.%s is missing but is a required field\")\n", st.Name, f.Name))
+			}
+			if FullValidation {
+				if bt == rdl.BaseTypeString && fname != "String" {
+					if !f.Optional {
+						gen.emit("\t} else {\n")
+					} else {
+						gen.emit(fmt.Sprintf("\tif self.%s != \"\" {\n", fname))
+					}
+					gen.emit(fmt.Sprintf("\t\tval := %sValidate(%sSchema(), %q, self.%s)\n\t\tif !val.Valid {\n\t\t\treturn fmt.Errorf(\"%s.%s does not contain a valid %s (%%v)\", val.Error)\n\t\t}\n", rdlPrefix, capitalize(string(gen.schema.Name)), ftype, fname, st.Name, string(f.Name), ftype))
+				}
+			}
+			gen.emit("\t}\n")
+		case rdl.BaseTypeTimestamp:
+			if !f.Optional {
+				gen.emit(fmt.Sprintf("\tif self.%s.IsZero() {\n", fname))
+				gen.emit(fmt.Sprintf("\t\treturn fmt.Errorf(\"%s: Missing required field: %s\")\n", st.Name, f.Name))
+				gen.emit("\t}\n")
+			}
+		case rdl.BaseTypeArray, rdl.BaseTypeMap, rdl.BaseTypeStruct, rdl.BaseTypeUUID:
+			if !f.Optional {
+				gen.emit(fmt.Sprintf("\tif self.%s == nil {\n", fname))
+				gen.emit(fmt.Sprintf("\t\treturn fmt.Errorf(\"%s: Missing required field: %s\")\n", st.Name, f.Name))
+				gen.emit("\t}\n")
+			}
+		}
+	}
+	gen.emit("\treturn nil\n")
+	gen.emit("}\n")
+}
+
+func (gen *modelGenerator) emitStructInitializer(st *rdl.StructTypeDef, flattened []*rdl.StructFieldDef) {
+	gen.emit("\n//\n// Init - sets up the instance according to its default field values, if any\n//\n")
+	gen.emit(fmt.Sprintf("func (self *%s) Init() *%s {\n", st.Name, st.Name))
+	for _, f := range flattened {
+		fname := capitalize(string(f.Name))
+		isRdl := false
+		ftype := string(f.Type)
+		if strings.HasPrefix(ftype, "rdl.") {
+			isRdl = true
+			ftype = capitalize(ftype[4:])
+		}
+		if !f.Optional {
+			switch gen.registry.FindBaseType(f.Type) {
+			case rdl.BaseTypeArray:
+				ftype := goType(gen.registry, f.Type, false, f.Items, f.Keys, gen.precise, true)
+				gen.emit(fmt.Sprintf("\tif self.%s == nil {\n", fname))
+				gen.emit(fmt.Sprintf("\t\tself.%s = make(%s, 0)\n", fname, ftype))
+				gen.emit("\t}\n")
+			case rdl.BaseTypeMap:
+				ftype := goType(gen.registry, f.Type, false, f.Items, f.Keys, gen.precise, true)
+				gen.emit(fmt.Sprintf("\tif self.%s == nil {\n", fname))
+				gen.emit(fmt.Sprintf("\t\tself.%s = make(%s)\n", fname, ftype))
+				gen.emit("\t}\n")
+			case rdl.BaseTypeStruct:
+				gen.emit(fmt.Sprintf("\tif self.%s == nil {\n", fname))
+				if f.Type == "Struct" {
+					gen.emit(fmt.Sprintf("\t\tself.%s = make(rdl."+ftype+")\n", fname))
+				} else if isRdl {
+					gen.emit(fmt.Sprintf("\t\tself.%s = rdl.New%s()\n", fname, capitalize(ftype)))
+				} else {
+					gen.emit(fmt.Sprintf("\t\tself.%s = New%s()\n", fname, capitalize(ftype)))
+				}
+				gen.emit("\t}\n")
+			}
+		}
+		if f.Default != nil {
+			fdef := "nil" //the value present when not set
+			ndef := "nil" //the actual value to assign, if not already a zero value
+			pointerForOptional := true
+			switch gen.registry.FindBaseType(f.Type) {
+			case rdl.BaseTypeString, rdl.BaseTypeSymbol, rdl.BaseTypeUUID, rdl.BaseTypeTimestamp:
+				fdef = "\"\""
+				ndef = gen.literal(f.Default)
+				pointerForOptional = false
+			case rdl.BaseTypeInt8, rdl.BaseTypeInt16, rdl.BaseTypeInt32, rdl.BaseTypeInt64, rdl.BaseTypeFloat32, rdl.BaseTypeFloat64:
+				fdef = "0"
+				ndef = gen.literal(f.Default)
+			case rdl.BaseTypeBool:
+				ndef = gen.literal(f.Default)
+				if !f.Optional {
+					fdef = "false"
+				}
+			case rdl.BaseTypeEnum:
+				fdef = "0"
+				ndef = gen.literal(f.Default)
+				if gen.prefixEnums {
+					ndef = genutil.SnakeToCamel(ndef) //go conventions, should do this even without prefixEnums. Test here first.
+					ndef = capitalize(ftype) + ndef
+				}
+
+			}
+			if fdef != ndef {
+				//if f.Optional && fdef == "nil" {
+				if f.Optional && pointerForOptional {
+					gen.emit(fmt.Sprintf("\tif self.%s == nil {\n", fname))
+					gen.emit(fmt.Sprintf("\t\td := %s\n", ndef))
+					gen.emit(fmt.Sprintf("\t\tself.%s = &d\n", fname))
+				} else {
+					gen.emit(fmt.Sprintf("\tif self.%s == %s {\n", fname, fdef))
+					gen.emit(fmt.Sprintf("\t\tself.%s = %s\n", fname, ndef))
+				}
+				gen.emit("\t}\n")
+			}
+		}
+	}
+	gen.emit("\treturn self\n")
+	gen.emit("}\n")
+}
+
+func (gen *modelGenerator) emitStructUnmarshaller(st *rdl.StructTypeDef, init bool) {
+	name := capitalize(string(st.Name))
+	gen.emit(fmt.Sprintf("\ntype raw%s %s\n\n", name, name))
+	gen.emit(fmt.Sprintf("//\n// UnmarshalJSON is defined for proper JSON decoding of a %s\n//\n", name))
+	gen.emit(fmt.Sprintf("func (self *%s) UnmarshalJSON(b []byte) error {\n", name))
+	gen.emit(fmt.Sprintf("\tvar m raw%s\n", name))
+	gen.emit("\terr := json.Unmarshal(b, &m)\n")
+	gen.emit("\tif err == nil {\n")
+	gen.emit(fmt.Sprintf("\t\to := %s(m)\n", name))
+	if init {
+		gen.emit(fmt.Sprintf("\t\t*self = *((&o).Init())\n"))
+	} else {
+		gen.emit(fmt.Sprintf("\t\t*self = o\n"))
+	}
+	gen.emit(fmt.Sprintf("\t\terr = self.Validate()\n"))
+	gen.emit("\t}\n")
+	gen.emit("\treturn err\n")
+	gen.emit("}\n")
+}
+
+func (gen *modelGenerator) emitEnum(t *rdl.Type) {
+	if gen.err != nil {
+		return
+	}
+	et := t.EnumTypeDef
+	name := capitalize(string(et.Name))
+	gen.emit(fmt.Sprintf("type %s int\n\n", name))
+	gen.emit(fmt.Sprintf("//\n// %s constants\n//\n", name))
+	gen.emit("const (\n")
+	gen.emit(fmt.Sprintf("\t_ %s = iota\n", name))
+	maxKeyLen := 0
+	for _, elem := range et.Elements {
+		sym := string(elem.Symbol)
+		if gen.prefixEnums {
+			sym = genutil.SnakeToCamel(sym) //go conventions, should do this even without prefixEnums. Test here first.
+			sym = name + sym
+		}
+		if len(sym) > maxKeyLen {
+			maxKeyLen = len(sym)
+		}
+		gen.emit(fmt.Sprintf("\t%s\n", sym))
+	}
+	gen.emit(")\n\n")
+	gen.emit(fmt.Sprintf("var names%s = []string{\n", name))
+	for _, elem := range et.Elements {
+		symName := elem.Symbol
+		sym := string(symName)
+		if gen.prefixEnums {
+			sym = genutil.SnakeToCamel(sym) //go conventions, should do this even without prefixEnums. Test here first.
+			sym = name + sym
+		}
+		s := leftJustified(sym+":", maxKeyLen+1)
+		gen.emit(fmt.Sprintf("\t%s %q,\n", s, symName))
+	}
+	gen.emit("}\n\n")
+	gen.emit(fmt.Sprintf("//\n// New%s - return a string representation of the enum\n//\n", name))
+	gen.emit(fmt.Sprintf("func New%s(init ...interface{}) %s {\n", name, name))
+	gen.emit("\tif len(init) == 1 {\n")
+	gen.emit("\t\tswitch v := init[0].(type) {\n")
+	gen.emit(fmt.Sprintf("\t\tcase %s:\n", name))
+	gen.emit("\t\t\treturn v\n")
+	gen.emit("\t\tcase int:\n")
+	gen.emit(fmt.Sprintf("\t\t\treturn %s(v)\n", name))
+	gen.emit("\t\tcase int32:\n")
+	gen.emit(fmt.Sprintf("\t\t\treturn %s(v)\n", name))
+	gen.emit("\t\tcase string:\n")
+	gen.emit(fmt.Sprintf("\t\t\tfor i, s := range names%s {\n", name))
+	gen.emit("\t\t\t\tif s == v {\n")
+	gen.emit(fmt.Sprintf("\t\t\t\t\treturn %s(i)\n", name))
+	gen.emit("\t\t\t\t}\n")
+	gen.emit("\t\t\t}\n")
+	gen.emit("\t\tdefault:\n")
+	gen.emit(fmt.Sprintf("\t\t\tpanic(\"Bad init value for %s enum\")\n", name))
+	gen.emit("\t\t}\n")
+	gen.emit("\t}\n")
+	gen.emit(fmt.Sprintf("\treturn %s(0) //default to the first enum value\n", name))
+	gen.emit("}\n\n")
+	gen.emit("//\n// String - return a string representation of the enum\n//\n")
+	gen.emit(fmt.Sprintf("func (e %s) String() string {\n", name))
+	gen.emit(fmt.Sprintf("\treturn names%s[e]\n", name))
+	gen.emit("}\n\n")
+	gen.emit("//\n// SymbolSet - return an array of all valid string representations (symbols) of the enum\n//\n")
+	gen.emit(fmt.Sprintf("func (e %s) SymbolSet() []string {\n", name))
+	gen.emit(fmt.Sprintf("\treturn names%s\n", name))
+	gen.emit("}\n\n")
+	gen.emit(fmt.Sprintf("//\n// MarshalJSON is defined for proper JSON encoding of a %s\n//\n", name))
+	gen.emit(fmt.Sprintf("func (e %s) MarshalJSON() ([]byte, error) {\n", name))
+	gen.emit("\treturn json.Marshal(e.String())\n")
+	gen.emit("}\n\n")
+	gen.emit(fmt.Sprintf("//\n// UnmarshalJSON is defined for proper JSON decoding of a %s\n//\n", name))
+	gen.emit(fmt.Sprintf("func (e *%s) UnmarshalJSON(b []byte) error {\n", name))
+	gen.emit("\tvar j string\n")
+	gen.emit("\terr := json.Unmarshal(b, &j)\n")
+	gen.emit("\tif err == nil {\n")
+	gen.emit("\t\ts := string(j)\n")
+	gen.emit(fmt.Sprintf("\t\tfor v, s2 := range names%s {\n", name))
+	gen.emit("\t\t\tif s == s2 {\n")
+	gen.emit(fmt.Sprintf("\t\t\t\t*e = %s(v)\n", name))
+	gen.emit("\t\t\t\treturn nil\n")
+	gen.emit("\t\t\t}\n")
+	gen.emit("\t\t}\n")
+	gen.emit(fmt.Sprintf("\t\terr = fmt.Errorf(\"Bad enum symbol for type %s: %%s\", s)\n", name))
+	gen.emit("\t}\n")
+	gen.emit("\treturn err\n")
+	gen.emit("}\n")
+}
+
+func (gen *modelGenerator) emitStructFields(fields []*rdl.StructFieldDef, name rdl.TypeName, comment string) {
+	gen.emit(fmt.Sprintf("type %s struct {\n", name))
+	if fields != nil {
+		fnames := make([]string, 0, len(fields))
+		ftypes := make([]string, 0, len(fields))
+		nameWidth := 0
+		typeWidth := 0
+		hasComment := false
+		for _, f := range fields {
+			fname := capitalize(string(f.Name))
+			fnames = append(fnames, fname)
+			flen := len(fname)
+			if flen > nameWidth {
+				nameWidth = flen
+			}
+			optional := f.Optional
+			ftype := goType(gen.registry, f.Type, optional, f.Items, f.Keys, gen.precise, true)
+			ftypes = append(ftypes, ftype)
+			tlen := len(ftype)
+			if tlen > typeWidth {
+				typeWidth = tlen
+			}
+			if f.Comment != "" {
+				hasComment = true
+			}
+		}
+		i := 0
+		for _, f := range fields {
+			fname := fnames[i]
+			ftype := ftypes[i]
+			if !hasComment {
+				fname = leftJustified(fname, nameWidth+1)
+				ftype = leftJustified(ftype, typeWidth+1)
+			} else {
+				fname = fname + " "
+				ftype = ftype + " "
+			}
+			option := ""
+			optional := ""
+			if f.Optional {
+				// if the type specified is plain string
+				// then we're not going to include omitempty
+				// since we want to send empty strings to the
+				// server to disable the setting
+				if strings.ToLower(string(f.Type)) != "string" {
+					option = ",omitempty"
+				}
+				optional = " rdl:\"optional\""
+			} else if f.Default != nil {
+				defaultVal := fmt.Sprintf("%v", f.Default)
+				optional = fmt.Sprintf(" rdl:\"default=%s\"", defaultVal)
+				//omit empty only if the default value is the same as the zero value
+				v := reflect.ValueOf(f.Default)
+				if v.Interface() == reflect.Zero(v.Type()).Interface() {
+					//if f.Default.IsZero() {
+					option = ",omitempty"
+				}
+			}
+			jsonName := string(f.Name)
+			if ext, ok := f.Annotations["x_json_name"]; ok {
+				jsonName = string(ext)
+			}
+			fanno := "`json:\"" + jsonName + option + "\"" + optional + "`"
+			if f.Comment != "" {
+				gen.emit("\n" + genutil.FormatBlock(f.Comment, 0, 72, "\t// "))
+			}
+			gen.emit(fmt.Sprintf("\t%s%s%s\n", fname, ftype, fanno))
+			i++
+		}
+		gen.emit("}\n")
+	}
+}
+
+func goFmt(filename string) error {
+	return exec.Command("go", "fmt", filename).Run()
+}
+
+func GenerationHeader(banner string) string {
+	// Matches the auto-generated code header structure defined at
+	// https://github.com/golang/go/issues/13560#issuecomment-288457920
+	return fmt.Sprintf("//\n// Code generated by %s DO NOT EDIT.\n//", banner)
+}
+
+func GenerationPackage(schema *rdl.Schema, ns string) string {
+	pkg := "main"
+	if ns != "" {
+		pkg = ns
+	} else if schema.Name != "" {
+		pkg = strings.ToLower(string(schema.Name))
+	}
+	return pkg
+}
+
+func FormatComment(s string, leftCol int, rightCol int) string {
+	return genutil.FormatBlock(s, leftCol, rightCol, "// ")
+}
+
+func capitalize(text string) string {
+	return strings.ToUpper(text[0:1]) + text[1:]
+}
+
+func leftJustified(text string, width int) string {
+	return text + genutil.Spaces(width-len(text))
+}

--- a/rdl/rdl-gen-athenz-go-model/goschema.go
+++ b/rdl/rdl-gen-athenz-go-model/goschema.go
@@ -1,0 +1,374 @@
+// Copyright 2015 Yahoo Inc.
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	genutil "github.com/ardielle/ardielle-go/gen"
+	"github.com/ardielle/ardielle-go/rdl"
+)
+
+type schemaGenerator struct {
+	registry    rdl.TypeRegistry
+	schema      *rdl.Schema
+	name        string
+	writer      *bufio.Writer
+	err         error
+	banner      string
+	ns          string
+	librdl      string
+	rdlprefix   string
+	prefixEnums bool
+}
+
+// GenerateGoSchema generates the code to regenerate the Schema
+func GenerateGoSchema(banner string, schema *rdl.Schema, outdir string, ns string, librdl string, prefixEnums bool) error {
+	name := strings.ToLower(string(schema.Name))
+	if strings.HasSuffix(outdir, ".go") {
+		name = filepath.Base(outdir)
+		outdir = filepath.Dir(outdir)
+	} else {
+		name = name + "_schema.go"
+	}
+	err := os.MkdirAll(outdir, 0755)
+	if err != nil {
+		return err
+	}
+	filepath := outdir + "/" + name
+	out, file, _, err := genutil.OutputWriter(filepath, "", ".go")
+	if err != nil {
+		return err
+	}
+	if file != nil {
+		defer func() {
+			file.Close()
+			err := goFmt(filepath)
+			if err != nil {
+				fmt.Println("Warning: could not format go code:", err)
+			}
+		}()
+	}
+	rdlprefix := "rdl."
+	if schema.Name == "rdl" {
+		rdlprefix = ""
+	}
+	gen := &schemaGenerator{rdl.NewTypeRegistry(schema), schema, capitalize(string(schema.Name)), out, nil, banner, ns, librdl, rdlprefix, prefixEnums}
+	gen.emit(GenerationHeader(banner))
+	gen.emit("\n\npackage " + GenerationPackage(gen.schema, gen.ns) + "\n\n")
+	gen.emit("import (\n")
+	gen.emit("\t\"log\"\n")
+	gen.emit("\n")
+	if gen.schema.Name != "rdl" {
+		gen.emit("\trdl \"" + librdl + "\"\n")
+	}
+	gen.emit(")\n\n")
+	gen.emit("var schema *" + rdlprefix + "Schema\n\n")
+	gen.emit(fmt.Sprintf("func init() {\n\tsb := %sNewSchemaBuilder(%q)\n", rdlprefix, schema.Name))
+	if schema.Version != nil {
+		gen.emit(fmt.Sprintf("\tsb.Version(%d)\n", *schema.Version))
+	}
+	if schema.Namespace != "" {
+		gen.emit(fmt.Sprintf("\tsb.Namespace(%q)\n", schema.Namespace))
+	}
+	if schema.Comment != "" {
+		gen.emit(fmt.Sprintf("\tsb.Comment(%q)\n", schema.Comment))
+	}
+	gen.emit("\n")
+	if gen.err == nil {
+		for _, t := range schema.Types {
+			gen.emitType(t)
+		}
+	}
+	if gen.err == nil {
+		for _, r := range schema.Resources {
+			gen.emitResource(r)
+		}
+	}
+	gen.emit("\tvar err error\n")
+	gen.emit("\tschema, err = sb.BuildParanoid()\n")
+	gen.emit("\tif err != nil {\n")
+	gen.emit("\t  log.Fatalf(\"rdl: schema build failed: %s\", err)")
+	gen.emit("\t}\n")
+	gen.emit("}\n\n")
+	gen.emit(fmt.Sprintf("func %sSchema() *%sSchema {\n", capitalize(string(schema.Name)), rdlprefix))
+	gen.emit("\treturn schema\n")
+	gen.emit("}\n")
+	out.Flush()
+	return gen.err
+}
+
+func SafeTypeVarName(rtype rdl.TypeRef) rdl.TypeName {
+	tokens := strings.Split(string(rtype), ".")
+	return rdl.TypeName(capitalize(strings.Join(tokens, "")))
+}
+
+func (gen *schemaGenerator) emitResource(rez *rdl.Resource) {
+	rTypeName := rez.Type
+	if rez.Method == "PUT" || rez.Method == "POST" {
+		for _, ri := range rez.Inputs {
+			if !ri.PathParam && ri.QueryParam == "" && ri.Header == "" {
+				rTypeName = ri.Type
+				break
+			}
+		}
+	}
+	rVarName := SafeTypeVarName(rTypeName)
+	rname := fmt.Sprintf("m%s%s", capitalize(strings.ToLower(rez.Method)), rVarName)
+	if rez.Name != "" {
+		rname = "m" + capitalize(string(rez.Name))
+	}
+	gen.emit(fmt.Sprintf("\t%s := rdl.NewResourceBuilder(%q, %q, %q)\n", rname, rez.Type, rez.Method, rez.Path))
+	if rez.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", rname, rez.Comment))
+	}
+	if rez.Name != "" {
+		gen.emit(fmt.Sprintf("\t%s.Name(%q)\n", rname, rez.Name))
+	}
+	for _, ri := range rez.Inputs {
+		def := "nil"
+		if ri.Default != nil {
+			switch gen.registry.FindBaseType(ri.Type) {
+			case rdl.BaseTypeEnum:
+				def = fmt.Sprintf("%q", ri.Default)
+			default:
+				switch ri.Default.(type) {
+				case string:
+					def = fmt.Sprintf("%q", ri.Default)
+				default:
+					def = fmt.Sprint(ri.Default)
+				}
+			}
+		}
+		gen.emit(fmt.Sprintf("\t%s.Input(%q, %q, %v, %q, %q, %v, %v, %q)\n", rname, ri.Name, ri.Type, ri.PathParam, ri.QueryParam, ri.Header, ri.Optional, def, ri.Comment))
+	}
+	for _, ro := range rez.Outputs {
+		gen.emit(fmt.Sprintf("\t%s.Output(%q, %q, %q, %v, %q)\n", rname, ro.Name, ro.Type, ro.Header, ro.Optional, ro.Comment))
+	}
+	if rez.Auth != nil {
+		gen.emit(fmt.Sprintf("\t%s.Auth(%q, %q, %v, %q)\n", rname, rez.Auth.Action, rez.Auth.Resource, rez.Auth.Authenticate, rez.Auth.Domain))
+	}
+	if rez.Expected != "OK" {
+		gen.emit(fmt.Sprintf("\t%s.Expected(%q)\n", rname, rez.Expected))
+	}
+	//build a sorted order for the exceptions, to make them predictable. Go randomizes the order otherwise.
+	var syms []string
+	for sym, _ := range rez.Exceptions {
+		syms = append(syms, sym)
+	}
+	sort.Strings(syms)
+	for _, sym := range syms {
+		re := rez.Exceptions[sym]
+		gen.emit(fmt.Sprintf("\t%s.Exception(%q, %q, %q)\n", rname, sym, re.Type, re.Comment))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddResource(%s.Build())\n\n", rname))
+}
+
+func (gen *schemaGenerator) emitType(typedef *rdl.Type) {
+	switch typedef.Variant {
+	case rdl.TypeVariantAliasTypeDef:
+		gen.emitAliasType(typedef.AliasTypeDef)
+	case rdl.TypeVariantBytesTypeDef:
+		gen.emitBytesType(typedef.BytesTypeDef)
+	case rdl.TypeVariantNumberTypeDef:
+		gen.emitNumberType(typedef.NumberTypeDef)
+	case rdl.TypeVariantStringTypeDef:
+		gen.emitStringType(typedef.StringTypeDef)
+	case rdl.TypeVariantStructTypeDef:
+		gen.emitStructType(typedef.StructTypeDef)
+	case rdl.TypeVariantArrayTypeDef:
+		gen.emitArrayType(typedef.ArrayTypeDef)
+	case rdl.TypeVariantMapTypeDef:
+		gen.emitMapType(typedef.MapTypeDef)
+	case rdl.TypeVariantEnumTypeDef:
+		gen.emitEnumType(typedef.EnumTypeDef)
+	case rdl.TypeVariantUnionTypeDef:
+		gen.emitUnionType(typedef.UnionTypeDef)
+	default:
+		fmt.Println("[Warning: user type list contains a non user type:", typedef)
+	}
+}
+
+func (gen *schemaGenerator) emitStringType(typedef *rdl.StringTypeDef) {
+	varname := "t" + goTypeName(typedef.Name)
+	gen.emit(fmt.Sprintf("\t%s := %sNewStringTypeBuilder(%q)\n", varname, gen.rdlprefix, typedef.Name))
+	if typedef.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", varname, typedef.Comment))
+	}
+	if typedef.Pattern != "" {
+		gen.emit(fmt.Sprintf("\t%s.Pattern(%q)\n", varname, typedef.Pattern))
+	}
+	if typedef.MinSize != nil {
+		gen.emit(fmt.Sprintf("\t%s.MinSize(%d)\n", varname, *typedef.MinSize))
+	}
+	if typedef.MaxSize != nil {
+		gen.emit(fmt.Sprintf("\t%s.MaxSize(%d)\n", varname, *typedef.MaxSize))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddType(%s.Build())\n\n", varname))
+}
+
+func (gen *schemaGenerator) emitBytesType(typedef *rdl.BytesTypeDef) {
+	varname := "t" + goTypeName(typedef.Name)
+	gen.emit(fmt.Sprintf("\t%s := %sNewBytesTypeBuilder(%q)\n", varname, gen.rdlprefix, typedef.Name))
+	if typedef.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", varname, typedef.Comment))
+	}
+	if typedef.MinSize != nil {
+		gen.emit(fmt.Sprintf("\t%s.MinSize(%d)\n", varname, *typedef.MinSize))
+	}
+	if typedef.MaxSize != nil {
+		gen.emit(fmt.Sprintf("\t%s.MaxSize(%d)\n", varname, *typedef.MaxSize))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddType(%s.Build())\n\n", varname))
+}
+
+func numericValueString(n rdl.Number) string {
+	switch n.Variant {
+	case rdl.NumberVariantInt8:
+		return fmt.Sprint(*n.Int8)
+	case rdl.NumberVariantInt16:
+		return fmt.Sprint(*n.Int16)
+	case rdl.NumberVariantInt32:
+		return fmt.Sprint(*n.Int32)
+	case rdl.NumberVariantInt64:
+		return fmt.Sprint(*n.Int64)
+	case rdl.NumberVariantFloat32:
+		return fmt.Sprint(*n.Float32)
+	case rdl.NumberVariantFloat64:
+		return fmt.Sprint(*n.Float64)
+	}
+	return ""
+}
+
+func (gen *schemaGenerator) emitNumberType(typedef *rdl.NumberTypeDef) {
+	varname := "t" + goTypeName(typedef.Name)
+	gen.emit(fmt.Sprintf("\t%s := %sNewNumberTypeBuilder(%q, %q)\n", varname, gen.rdlprefix, typedef.Type, typedef.Name))
+	if typedef.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", varname, typedef.Comment))
+	}
+	if typedef.Min != nil {
+		gen.emit(fmt.Sprintf("\t%s.Min(%v)\n", varname, numericValueString(*typedef.Min)))
+	}
+	if typedef.Max != nil {
+		gen.emit(fmt.Sprintf("\t%s.Max(%v)\n", varname, numericValueString(*typedef.Max)))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddType(%s.Build())\n\n", varname))
+}
+
+func (gen *schemaGenerator) emitAliasType(typedef *rdl.AliasTypeDef) {
+	varname := "t" + goTypeName(typedef.Name)
+	gen.emit(fmt.Sprintf("\t%s := %sNewAliasTypeBuilder(%q, %q)\n", varname, gen.rdlprefix, typedef.Type, typedef.Name))
+	if typedef.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", varname, typedef.Comment))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddType(%s.Build())\n\n", varname))
+}
+
+func (gen *schemaGenerator) emitStructType(typedef *rdl.StructTypeDef) {
+	varname := "t" + goTypeName(typedef.Name)
+	gen.emit(fmt.Sprintf("\t%s := %sNewStructTypeBuilder(%q, %q)\n", varname, gen.rdlprefix, typedef.Type, typedef.Name))
+	if typedef.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", varname, typedef.Comment))
+	}
+	for _, f := range typedef.Fields {
+		if f.Type == "Array" {
+			if f.Items != "" {
+				gen.emit(fmt.Sprintf("\t%s.ArrayField(%q, %q, %v, %q)\n", varname, f.Name, f.Items, f.Optional, f.Comment))
+				continue
+			}
+		} else if f.Type == "Map" {
+			if f.Keys != "" && f.Items != "" {
+				gen.emit(fmt.Sprintf("\t%s.MapField(%q, %q, %q, %v, %q)\n", varname, f.Name, f.Keys, f.Items, f.Optional, f.Comment))
+				continue
+			}
+		}
+		def := "nil"
+		if f.Default != nil {
+			switch gen.registry.FindBaseType(f.Type) {
+			case rdl.BaseTypeEnum:
+				if gen.prefixEnums {
+					def = fmt.Sprint(f.Default)
+					def = genutil.SnakeToCamel(def)
+					def = capitalize(string(f.Type)) + def
+				} else {
+					def = fmt.Sprint(f.Default)
+				}
+			default:
+				switch f.Default.(type) {
+				case string:
+					def = fmt.Sprintf("%q", f.Default)
+				default:
+					def = fmt.Sprint(f.Default)
+				}
+			}
+		}
+		gen.emit(fmt.Sprintf("\t%s.Field(%q, %q, %v, %v, %q)\n", varname, f.Name, f.Type, f.Optional, def, f.Comment))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddType(%s.Build())\n\n", varname))
+}
+
+func (gen *schemaGenerator) emitArrayType(typedef *rdl.ArrayTypeDef) {
+	varname := "t" + goTypeName(typedef.Name)
+	gen.emit(fmt.Sprintf("\t%s := %sNewArrayTypeBuilder(%q, %q)\n", varname, gen.rdlprefix, typedef.Type, typedef.Name))
+	if typedef.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", varname, typedef.Comment))
+	}
+	if typedef.Items != "" {
+		gen.emit(fmt.Sprintf("\t%s.Items(%q)\n", varname, typedef.Items))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddType(%s.Build())\n\n", varname))
+}
+
+func (gen *schemaGenerator) emitMapType(typedef *rdl.MapTypeDef) {
+	varname := "t" + goTypeName(typedef.Name)
+	gen.emit(fmt.Sprintf("\t%s := %sNewMapTypeBuilder(%q, %q)\n", varname, gen.rdlprefix, typedef.Type, typedef.Name))
+	if typedef.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", varname, typedef.Comment))
+	}
+	if typedef.Keys != "" {
+		gen.emit(fmt.Sprintf("\t%s.Keys(%q)\n", varname, typedef.Keys))
+	}
+	if typedef.Items != "" {
+		gen.emit(fmt.Sprintf("\t%s.Items(%q)\n", varname, typedef.Items))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddType(%s.Build())\n\n", varname))
+}
+
+func (gen *schemaGenerator) emitEnumType(typedef *rdl.EnumTypeDef) {
+	varname := "t" + goTypeName(typedef.Name)
+	gen.emit(fmt.Sprintf("\t%s := %sNewEnumTypeBuilder(%q, %q)\n", varname, gen.rdlprefix, typedef.Type, typedef.Name))
+	if typedef.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", varname, typedef.Comment))
+	}
+	for _, f := range typedef.Elements {
+		gen.emit(fmt.Sprintf("\t%s.Element(%q, %q)\n", varname, f.Symbol, f.Comment))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddType(%s.Build())\n\n", varname))
+}
+
+func (gen *schemaGenerator) emitUnionType(typedef *rdl.UnionTypeDef) {
+	varname := "t" + goTypeName(typedef.Name)
+	gen.emit(fmt.Sprintf("\t%s := %sNewUnionTypeBuilder(%q, %q)\n", varname, gen.rdlprefix, typedef.Type, typedef.Name))
+	if typedef.Comment != "" {
+		gen.emit(fmt.Sprintf("\t%s.Comment(%q)\n", varname, typedef.Comment))
+	}
+	for _, variant := range typedef.Variants {
+		gen.emit(fmt.Sprintf("\t%s.Variant(%q)\n", varname, variant))
+	}
+	gen.emit(fmt.Sprintf("\tsb.AddType(%s.Build())\n\n", varname))
+}
+
+func (gen *schemaGenerator) emit(s string) {
+	if gen.err == nil {
+		_, err := gen.writer.WriteString(s)
+		if err != nil {
+			gen.err = err
+		}
+	}
+}

--- a/rdl/rdl-gen-athenz-go-model/main.go
+++ b/rdl/rdl-gen-athenz-go-model/main.go
@@ -1,0 +1,62 @@
+// Copyright 2015 Yahoo Inc. https://github.com/ardielle
+//           2019 Oath Holdings Inc. Modified to generate go client code for Athenz Clients
+// Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.
+
+package main
+
+import (
+	"bufio"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/ardielle/ardielle-go/rdl"
+)
+
+type clientGenerator struct {
+	registry    rdl.TypeRegistry
+	schema      *rdl.Schema
+	name        string
+	writer      *bufio.Writer
+	err         error
+	banner      string
+	prefixEnums bool
+	precise     bool
+	ns          string
+	librdl      string
+}
+
+const RdlGoImport = "github.com/ardielle/ardielle-go/rdl"
+
+func main() {
+	banner := "rdl (development version)"
+	if rdl.Version != "" {
+		banner = fmt.Sprintf("rdl %s", rdl.Version)
+	}
+
+	pOutdir := flag.String("o", ".", "Output directory")
+	pBase := flag.String("b", "", "Base Path")
+	pSchemaFile := flag.String("s", "", "RDL source file")
+	flag.Parse()
+
+	schema, err := rdl.ParseRDLFile(*pSchemaFile, false, false, false)
+	if err == nil {
+		generateGoModel(banner, schema, *pOutdir, "", *pBase)
+		os.Exit(0)
+	}
+	fmt.Fprintf(os.Stderr, "*** %v\n", err)
+	os.Exit(1)
+}
+
+func generateGoModel(banner string, schema *rdl.Schema, outdir string, ns string, base string) error {
+	return GenerateAthenzGoModel(schema, &GeneratorParams{
+                Outdir:         outdir,
+                Banner:         banner,
+		Namespace:      "",
+                LibRdl:         RdlGoImport,
+	        PrefixEnums:    false,
+                PreciseTypes:   true,
+		UntaggedUnions: []string{},
+                GenerateSchema: true,
+        })
+}

--- a/rdl/rdl-gen-athenz-go-model/make_generator.sh
+++ b/rdl/rdl-gen-athenz-go-model/make_generator.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# For Athenz Go clients we're using our own generator. This is a go utility
+# so the system must have go installed. This is required when changes
+# are made to the RDL and the corresponding resource files must be
+# generated. Otherwise, the client has all the auto-generated code already
+# checked-in into git.
+
+if [ ! -z "${TRAVIS_PULL_REQUEST}" ] || [ ! -z "${TRAVIS_TAG}" ]; then
+    echo >&2 "------------------------------------------------------------------------";
+    echo >&2 "SOURCE NOTICE";
+    echo >&2 "------------------------------------------------------------------------";
+    echo >&2 "Automated Build. Skipping source generation...";
+    exit 0;
+fi
+
+command -v go >/dev/null 2>&1 || {
+    echo >&2 "------------------------------------------------------------------------";
+    echo >&2 "SOURCE WARNING";
+    echo >&2 "------------------------------------------------------------------------";
+    echo >&2 "Please install go compiler from https://golang.org";
+    echo >&2 "Skipping rdl go model generator build...";
+    exit 0;
+}
+
+if [ -z "${GOPATH}" ]; then
+    echo >&2 "GOPATH is not set. please configure this environment variable"
+    exit 1;
+fi
+
+go get -u github.com/ardielle/ardielle-go/...
+go build
+cp rdl-gen-athenz-go-model ${GOPATH}/bin/rdl-gen-athenz-go-model
+
+# Copyright 2019 Oath Holdings Inc.
+# Licensed under the terms of the Apache version 2.0 license. See LICENSE file for terms.

--- a/rdl/rdl-gen-athenz-go-model/pom.xml
+++ b/rdl/rdl-gen-athenz-go-model/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2019 Oath Holdings, Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.yahoo.athenz</groupId>
+    <artifactId>athenz</artifactId>
+    <version>1.9.10-SNAPSHOT</version>
+    <relativePath>../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>rdl-gen-athenz-go-model</artifactId>
+  <packaging>jar</packaging>
+  <name>rdl-gen-athenz-go-model</name>
+  <description>Athenz Go Model RDL Code generator</description>
+
+  <properties>
+    <maven.install.skip>true</maven.install.skip>
+    <checkstyle.skip>true</checkstyle.skip>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.1.1</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>make</executable>
+          <arguments>
+            <argument>PKG_VERSION=${project.parent.version}</argument>
+            <argument>clean</argument>
+            <argument>all</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.4</version>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+            <phase />
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -167,34 +167,6 @@ public class ZMSUtils {
         return roleName.matches(rezPattern);
     }
     
-    public static void validateRoleStructure(final Role role, final String caller,
-            final String domainName) {
-        
-        if ((role.getMembers() != null && !role.getMembers().isEmpty()) 
-                && (role.getRoleMembers() != null && !role.getRoleMembers().isEmpty())) {
-            throw ZMSUtils.requestError("validateRoleMembers: Role cannot have both members and roleMembers set", caller);
-        }
-        
-        // if this is a delegated role then validate that it's not
-        // delegated back to itself and there are no members since
-        // those 2 fields are mutually exclusive
-        
-        if (role.getTrust() != null && !role.getTrust().isEmpty()) {
-            
-            if (role.getRoleMembers() != null && !role.getRoleMembers().isEmpty()) {
-                throw ZMSUtils.requestError("validateRoleMembers: Role cannot have both roleMembers and delegated domain set", caller);
-            }
-            
-            if (role.getMembers() != null && !role.getMembers().isEmpty()) {
-                throw ZMSUtils.requestError("validateRoleMembers: Role cannot have both members and delegated domain set", caller);
-            }
-            
-            if (domainName.equals(role.getTrust())) {
-                throw ZMSUtils.requestError("validateRoleMembers: Role cannot be delegated to itself", caller);
-            }
-        }
-    }
-    
     public static void removeMembers(List<RoleMember> originalRoleMembers, List<RoleMember> removeRoleMembers) {
         if (removeRoleMembers == null || originalRoleMembers == null) {
             return;

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -159,59 +159,6 @@ public class ZMSUtilsTest {
         assertTrue(ZMSUtils.assumeRoleResourceMatch("domain1:role.role1", assertion));
     }
     
-    @DataProvider(name = "roles")
-    public static Object[][] getRoles() {
-        String domainName = "test_domain";
-
-        Role role1 = new Role();
-        String memberName = "member";
-        RoleMember roleMember = new RoleMember().setMemberName(memberName);
-        
-        Role role2 = new Role();
-        role2.setMembers(Collections.singletonList(memberName));
-        role2.setRoleMembers(Collections.singletonList(roleMember));
-        
-        Role role3 = new Role();
-        role3.setRoleMembers(Collections.singletonList(roleMember));
-        
-        Role role4 = new Role();
-        role4.setRoleMembers(Collections.singletonList(roleMember));
-        role4.setTrust("trust");
-        
-        Role role5 = new Role();
-        role5.setMembers(Collections.singletonList(memberName));
-        role5.setTrust("trust");
-        
-        Role role6 = new Role();
-        role6.setTrust("trust");
-        
-        return new Object[][] {
-            {domainName, role1, false}, 
-            {domainName, role2, true}, 
-            {domainName, role3, false}, 
-            {domainName, role4, true},
-            {domainName, role5, true}, 
-            {"trust", role6, true}, 
-            {"test_domain", role6, false}, 
-        };
-    }
-
-    @Test(dataProvider = "roles")
-    public void testValidateRoleMembers(String domainName, Role role, boolean expectedFailure) {
-        try {
-            ZMSUtils.validateRoleStructure(role, null, domainName);
-            if (expectedFailure) {
-                fail();
-            }
-        } catch (ResourceException e) {
-            if (expectedFailure) {
-                assertEquals(e.getCode(), 400);
-            } else {
-                fail("should not have failed with ResourceException");
-            }
-        }
-    }
-    
     @DataProvider(name = "members")
     public static Object[][] getMembers() {
         return new Object[][] {


### PR DESCRIPTION
1) new rdl go model generator that skips omit empty option when dealing with string attributes. this allows sending a json object with an empty value
2) update the option user authority and notify roles attributes in role meta as being string and adding validation in the zms server code for those attributes.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
