### PR TITLE
subdomain delete check - master copy

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -1964,9 +1964,9 @@ public class DBService implements RolesProvider {
         }
     }
     
-    List<String> listDomains(String prefix, long modifiedSince) {
+    List<String> listDomains(String prefix, long modifiedSince, boolean masterCopy) {
         
-        try (ObjectStoreConnection con = store.getConnection(true, false)) {
+        try (ObjectStoreConnection con = store.getConnection(true, masterCopy)) {
             return con.listDomains(prefix, modifiedSince);
         }
     }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -970,7 +970,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         final String caller = "initstore";
 
-        List<String> domains = dbService.listDomains(null, 0);
+        List<String> domains = dbService.listDomains(null, 0, true);
         if (domains.size() > 0 && domains.contains(SYS_AUTH)) {
             return;
         }
@@ -1120,7 +1120,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         } else if (roleMember != null || roleName != null) {
             dlist = dbService.lookupDomainByRole(normalizeDomainAliasUser(roleMember), roleName);
         } else {
-            dlist = listDomains(limit, skip, prefix, depth, modTime);
+            dlist = listDomains(limit, skip, prefix, depth, modTime, false);
         }
 
         metric.stopTiming(timerMetric, null, principalDomain);
@@ -1299,7 +1299,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             throw ZMSUtils.requestError("Cannot delete reserved system domain", caller);
         }
 
-        DomainList subDomainList = listDomains(null, null, domainName + ".", null, 0);
+        DomainList subDomainList = listDomains(null, null, domainName + ".", null, 0, true);
         if (subDomainList.getNames().size() > 0) {
             throw ZMSUtils.requestError(caller + ": Cannot delete domain " +
                     domainName + ": " + subDomainList.getNames().size() + " subdomains of it exist", caller);
@@ -1333,7 +1333,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         // retrieve the number of domains with this prefix
 
-        DomainList dlist = listDomains(null, null, userDomainCheck, null, 0);
+        DomainList dlist = listDomains(null, null, userDomainCheck, null, 0, true);
         if (dlist.getNames().size() < virtualDomainLimit) {
             return false;
         }
@@ -7009,11 +7009,11 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         return countDots(name) > depth;
     }
     
-    DomainList listDomains(Integer limit, String skip, String prefix, Integer depth, long modTime) {
+    DomainList listDomains(Integer limit, String skip, String prefix, Integer depth, long modTime, boolean masterCopy) {
             
         //note: we don't use the store's options, because we also need to filter on depth
         
-        List<String> allDomains = dbService.listDomains(prefix, modTime);
+        List<String> allDomains = dbService.listDomains(prefix, modTime, masterCopy);
         List<String> names = new ArrayList<>();
         
         for (String name : allDomains) {
@@ -7608,7 +7608,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         // for now we're going to verify our database connectivity
         // in case of failure we're going to return not found
 
-        DomainList dlist = listDomains(null, null, null, null, 0);
+        DomainList dlist = listDomains(null, null, null, null, 0, false);
         if (dlist.getNames() == null || dlist.getNames().isEmpty()) {
             throw ZMSUtils.notFoundError("Error - no domains available", caller);
         }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -3097,7 +3097,7 @@ public class DBServiceTest {
         assertNotNull(list.getNames());
         assertTrue(list.getNames().contains(domainName));
 
-        List<String> doms = zms.dbService.listDomains(null, 0);
+        List<String> doms = zms.dbService.listDomains(null, 0, false);
         
         // all domains have admin role
         

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -9692,7 +9692,7 @@ public class ZMSImplTest {
                 "Test Domain2", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom2);
 
-        DomainList domList = zms.listDomains(null, null, null, null, 0);
+        DomainList domList = zms.listDomains(null, null, null, null, 0, false);
         assertNotNull(domList);
 
         assertTrue(domList.getNames().contains("ListDom1".toLowerCase()));
@@ -9713,7 +9713,7 @@ public class ZMSImplTest {
                 "Test Domain2", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom2);
 
-        DomainList domList = zms.listDomains(1, null, null, null, 0);
+        DomainList domList = zms.listDomains(1, null, null, null, 0, false);
         assertEquals(1, domList.getNames().size());
 
         zms.deleteTopLevelDomain(mockDomRsrcCtx, "LimitDom1", auditRef);
@@ -9735,16 +9735,16 @@ public class ZMSImplTest {
                 "Test Domain3", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom3);
 
-        DomainList domList = zms.listDomains(null, null, null, null, 0);
+        DomainList domList = zms.listDomains(null, null, null, null, 0, false);
         int size = domList.getNames().size();
         assertTrue(size > 3);
 
         // ask for only for 2 domains back
-        domList = zms.listDomains(2, null, null, null, 0);
+        domList = zms.listDomains(2, null, null, null, 0, false);
         assertEquals(domList.getNames().size(), 2);
 
         // ask for the remaining domains
-        DomainList remList = zms.listDomains(null, domList.getNext(), null, null, 0);
+        DomainList remList = zms.listDomains(null, domList.getNext(), null, null, 0, false);
         assertEquals(remList.getNames().size(), size - 2);
 
         zms.deleteTopLevelDomain(mockDomRsrcCtx, "SkipDom1", auditRef);
@@ -9766,7 +9766,7 @@ public class ZMSImplTest {
                 "Test Domain2", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom2);
 
-        DomainList domList = zms.listDomains(null, null, "prefix", null, 0);
+        DomainList domList = zms.listDomains(null, null, "prefix", null, 0, false);
 
         assertFalse(domList.getNames().contains(noPrefixDom));
         assertTrue(domList.getNames().contains(prefixDom));
@@ -9790,7 +9790,7 @@ public class ZMSImplTest {
                 "DepthDom1.DepthDom2", "Test Domain3", "testOrg", adminUser);
         zms.postSubDomain(mockDomRsrcCtx, "DepthDom1.DepthDom2", auditRef, dom3);
 
-        DomainList domList = zms.listDomains(null, null, null, 1, 0);
+        DomainList domList = zms.listDomains(null, null, null, 1, 0, false);
 
         assertTrue(domList.getNames().contains("DepthDom1".toLowerCase()));
         assertTrue(domList.getNames().contains("DepthDom1.DepthDom2".toLowerCase()));


### PR DESCRIPTION
when deleting a subdomain, list the domains from the master db so that we don't miss any newly created subdomains that should have blocked the domain from being deleted.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
