### PR TITLE
Lock next.js version. optimizer depenency of new version causes crashes

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -66,7 +66,7 @@
         "moment": "^2.27.0",
         "moment-timezone": "^0.5.31",
         "multer": "^1.3.0",
-        "next": "^9.4.4",
+        "next": "9.4.4",
         "next-compose-plugins": "^2.1.1",
         "next-routes": "^1.4.2",
         "passport": "^0.4.1",


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
