### PR TITLE
fix: add .npmignore to exclude files

### DIFF
--- a/clients/nodejs/zpe/.npmignore
+++ b/clients/nodejs/zpe/.npmignore
@@ -1,0 +1,8 @@
+/.eslintcodecache
+/.nyc_output
+/artifacts
+/eslint.json
+/Gruntfile.js
+/Makefile
+/pom.xml
+/test

--- a/clients/nodejs/zts/.npmignore
+++ b/clients/nodejs/zts/.npmignore
@@ -1,0 +1,8 @@
+/.eslintcodecache
+/.nyc_output
+/artifacts
+/eslint.json
+/Gruntfile.js
+/Makefile
+/pom.xml
+/test

--- a/libs/nodejs/auth_core/.npmignore
+++ b/libs/nodejs/auth_core/.npmignore
@@ -1,0 +1,8 @@
+/.eslintcodecache
+/.nyc_output
+/artifacts
+/eslint.json
+/Gruntfile.js
+/Makefile
+/pom.xml
+/test


### PR DESCRIPTION
Looks like we're packing a lot of extraneous files when publishing to npm.

```
$ npm pack && tar -tf athenz-zts-client-1.0.0.tgz 
athenz-zts-client-1.0.0.tgz
package/.eslintcodecache
package/Makefile
package/artifacts/coverage/lcov-report/base.css
package/artifacts/coverage/lcov-report/prettify.css
package/artifacts/coverage/lcov-report/zts/config/config.js.html
package/artifacts/coverage/lcov-report/zts/config/default-config.js.html
package/artifacts/coverage/lcov-report/index.html
package/artifacts/coverage/lcov-report/zts/config/index.html
package/artifacts/coverage/lcov-report/zts/index.html
package/artifacts/coverage/lcov-report/zts/libs/index.html
package/artifacts/coverage/lcov-report/zts/index.js.html
package/artifacts/coverage/lcov-report/zts/libs/rdl-rest.js.html
package/artifacts/coverage/lcov.info
package/artifacts/coverage/lcov-report/block-navigation.js
package/config/config.js
package/config/default-config.js
package/Gruntfile.js
package/test/config/helpers.js
package/test/config/IdentityMock.js
package/index.js
package/test/unit/index.js
package/test/config/KeyStore.js
package/test/config/mock.js
package/artifacts/coverage/lcov-report/prettify.js
package/libs/rdl-rest.js
package/test/config/RdlMock.js
package/test/config/RoleTokenMock.js
package/test/config/SiaProviderMock.js
package/artifacts/coverage/lcov-report/sorter.js
package/.nyc_output/06d1740506a3a6404b65c014daf46cf9.json
package/.nyc_output/17cbea95d9cf252a7e205f65f5f9aa7b.json
package/.nyc_output/27a7c529fe2f9ba37d6284060872f924.json
package/.nyc_output/61d9a9e42c83652d31e82e575f0b2767.json
package/.nyc_output/d4f04669eb42f4ac222dbbbadfc3a836.json
package/.nyc_output/dba118731e218f92578a4b645e71385d.json
package/eslint.json
package/.nyc_output/fa40fd22f17ae1c28264e9ca51420c05.json
package/package.json
package/config/zts.json
package/README.md
package/artifacts/coverage/lcov-report/sort-arrow-sprite.png
package/athenz-zts-client-1.0.0.tgz
package/pom.xml
package/artifacts/test/xunit.xml
```

-----

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
