### PR TITLE
Fix panic in zts-rolecert.

### DIFF
--- a/provider/aws/sia-ec2/authn.go
+++ b/provider/aws/sia-ec2/authn.go
@@ -403,6 +403,9 @@ func extractProviderFromCert(certFile string) string {
 	}
 	var block *pem.Block
 	block, _ = pem.Decode(data)
+	if block == nil {
+		return ""
+	}
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		return ""

--- a/utils/zts-rolecert/zts-rolecert.go
+++ b/utils/zts-rolecert/zts-rolecert.go
@@ -130,6 +130,10 @@ func extractServiceDetailsFromCert(certFile string) (string, string, error) {
 		return "", "", err
 	}
 	block, _ := pem.Decode(data)
+	if block == nil {
+		return "", "", fmt.Errorf("cannot decode pem from certificate file: %s", certFile)
+	}
+
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		return "", "", err

--- a/utils/zts-rolecert/zts-rolecert_test.go
+++ b/utils/zts-rolecert/zts-rolecert_test.go
@@ -32,3 +32,12 @@ func TestExtractServiceDetailsFromCertInvalidFile(test *testing.T) {
 		return
 	}
 }
+
+func TestExtractServiceDetailsFromEmptyFile(test *testing.T) {
+
+	_, _, err := extractServiceDetailsFromCert("data/empty.pem")
+	if err == nil {
+		test.Errorf("incorrectly processed unknown file")
+		return
+	}
+}


### PR DESCRIPTION
If the service cert cannot be parsed for some reason, you get an
unhelpful panic. In my case, somehow the service cert was empty.

pem.Decode() returns nil if it can't find a cert inside the bytearray it is passed.
https://golang.org/pkg/encoding/pem/#Decode

Most places in the code check for this condition already. I only found this in one other place, also fixed in this PR.

```
$ zts-rolecert -svc-key-file /path/to/service.key -svc-cert-file /path/to/empty_cert.pem \
    -zts http://zts  -dns-domain dns.domain \
    -role-domain some.domain -role-name some.role \
    -role-key-file /path/to/role.key \
    -role-cert-file /path/to/output.pem
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x72c0d6]

goroutine 1 [running]:
main.extractServiceDetailsFromCert(0x7ffd54f5de56, 0xc, 0x5, 0x1, 0x7ec9c7, 0x1d, 0xa, 0x0)
```


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
