### PR TITLE
maintain timestamp when cert record hostname/ip changes

### DIFF
--- a/libs/java/server_common/pom.xml
+++ b/libs/java/server_common/pom.xml
@@ -27,7 +27,7 @@
   <packaging>jar</packaging>
 
   <properties>
-    <code.coverage.min>0.00</code.coverage.min>
+    <code.coverage.min>0.82</code.coverage.min>
   </properties>
 
   <dependencies>

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/X509CertRecord.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/X509CertRecord.java
@@ -33,6 +33,7 @@ public class X509CertRecord {
     private String lastNotifiedServer;
     private Date expiryTime;
     private String hostName;
+    private Date svcDataUpdateTime;
 
     public X509CertRecord() {
     }
@@ -147,5 +148,13 @@ public class X509CertRecord {
 
     public void setHostName(String hostName) {
         this.hostName = hostName;
+    }
+
+    public Date getSvcDataUpdateTime() {
+        return svcDataUpdateTime;
+    }
+
+    public void setSvcDataUpdateTime(Date svcDataUpdateTime) {
+        this.svcDataUpdateTime = svcDataUpdateTime;
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/X509CertRecordTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/X509CertRecordTest.java
@@ -44,6 +44,7 @@ public class X509CertRecordTest {
         certRecord.setLastNotifiedServer("server");
         certRecord.setLastNotifiedTime(now);
         certRecord.setExpiryTime(now);
+        certRecord.setSvcDataUpdateTime(now);
 
         assertEquals(certRecord.getService(), "cn");
         assertEquals(certRecord.getProvider(), "ostk");
@@ -59,5 +60,6 @@ public class X509CertRecordTest {
         assertEquals(certRecord.getLastNotifiedTime(), now);
         assertEquals(certRecord.getLastNotifiedServer(), "server");
         assertEquals(certRecord.getHostName(), "host");
+        assertEquals(certRecord.getSvcDataUpdateTime(), now);
     }
 }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/InstanceCertManager.java
@@ -565,7 +565,7 @@ public class InstanceCertManager {
         if (certStore == null) {
             return false;
         }
-        
+
         boolean result;
         try (CertRecordStoreConnection storeConnection = certStore.getConnection()) {
             result = storeConnection.updateX509CertRecord(certRecord);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -11282,4 +11282,34 @@ public class ZTSImplTest {
                 eq(null),
                 eq(null), eq(httpStatus), eq(null));
     }
+
+    @Test
+    public void testProcessCertRecordChange() {
+        X509CertRecord certRecord = new X509CertRecord();
+        certRecord.setCurrentIP("10.10.11.12");
+        certRecord.setHostName("host1.localhost");
+        certRecord.setSvcDataUpdateTime(null);
+
+        zts.processCertRecordChange(certRecord, "10.10.11.12", "host1.localhost");
+        assertNull(certRecord.getSvcDataUpdateTime());
+
+        zts.processCertRecordChange(certRecord, "10.10.11.13", "host1.localhost");
+        assertNotNull(certRecord.getSvcDataUpdateTime());
+
+        certRecord.setSvcDataUpdateTime(null);
+        zts.processCertRecordChange(certRecord, "10.10.11.12", "host2.localhost");
+        assertNotNull(certRecord.getSvcDataUpdateTime());
+    }
+
+    @Test
+    public void testCertRecordChanged() {
+        assertFalse(zts.certRecordChanged(null, null));
+        assertTrue(zts.certRecordChanged(null, ""));
+        assertTrue(zts.certRecordChanged("", null));
+        assertFalse(zts.certRecordChanged("", ""));
+        assertFalse(zts.certRecordChanged("test1", "test1"));
+        assertTrue(zts.certRecordChanged("test1", "test2"));
+        assertTrue(zts.certRecordChanged("test1", ""));
+        assertTrue(zts.certRecordChanged("", "test2"));
+    }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnectionTest.java
@@ -237,6 +237,7 @@ public class DynamoDBCertRecordStoreConnectionTest {
         certRecord.setLastNotifiedServer("last-notified-server");
         certRecord.setExpiryTime(now);
         certRecord.setHostName("hostname");
+        certRecord.setSvcDataUpdateTime(now);
 
         UpdateItemSpec item = new UpdateItemSpec()
                 .withPrimaryKey("primaryKey", "athenz.provider:cn:1234")
@@ -255,7 +256,8 @@ public class DynamoDBCertRecordStoreConnectionTest {
                         new AttributeUpdate("lastNotifiedTime").put(certRecord.getLastNotifiedTime().getTime()),
                         new AttributeUpdate("lastNotifiedServer").put(certRecord.getLastNotifiedServer()),
                         new AttributeUpdate("expiryTime").put(certRecord.getExpiryTime().getTime()),
-                        new AttributeUpdate("hostName").put(certRecord.getHostName()));
+                        new AttributeUpdate("hostName").put(certRecord.getHostName()),
+                        new AttributeUpdate("svcDataUpdateTime").put(certRecord.getSvcDataUpdateTime().getTime()));
 
         Mockito.doReturn(updateOutcome).when(table).updateItem(item);
         boolean requestSuccess = dbConn.updateX509CertRecord(certRecord);


### PR DESCRIPTION
this allows to keep track of when an instance was registered and when either service/ip changes in case another service is looking for changes in the dynamo db (no point of looking at cert records where it just refreshed the cert and no changes were made).

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
