### PR TITLE
handle setting role/group audit enable use case

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -31,7 +31,6 @@ import com.yahoo.athenz.zms.store.ObjectStoreConnection;
 import com.yahoo.athenz.zms.utils.ZMSUtils;
 import com.yahoo.rdl.JSON;
 import com.yahoo.rdl.Timestamp;
-import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -3249,12 +3249,12 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             throw ZMSUtils.requestError("Principal " + memberName + " is not valid", caller);
         }
 
-        if (!userAuthorityFilterPresent(userAuthorityFilter, group.getUserAuthorityFilter())) {
+        if (ZMSUtils.userAuthorityAttrMissing(userAuthorityFilter, group.getUserAuthorityFilter())) {
             throw ZMSUtils.requestError("Group " + memberName + " does not have same user authority filter "
                     + userAuthorityFilter + " configured", caller);
         }
 
-        if (!userAuthorityFilterPresent(userAuthorityExpiration, group.getUserAuthorityExpiration())) {
+        if (ZMSUtils.userAuthorityAttrMissing(userAuthorityExpiration, group.getUserAuthorityExpiration())) {
             throw ZMSUtils.requestError("Group " + memberName + " does not have same user authority expiration "
                     + userAuthorityExpiration + " configured", caller);
         }
@@ -7673,51 +7673,16 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 throw ZMSUtils.requestError("Invalid group member " + memberName + " in the role", caller);
             }
 
-            if (!userAuthorityFilterPresent(userAuthorityFilter, group.getUserAuthorityFilter())) {
+            if (ZMSUtils.userAuthorityAttrMissing(userAuthorityFilter, group.getUserAuthorityFilter())) {
                 throw ZMSUtils.requestError("Group " + memberName + " does not have same user authority filter "
                         + userAuthorityFilter + " configured", caller);
             }
 
-            if (!userAuthorityFilterPresent(userAuthorityExpiration, group.getUserAuthorityExpiration())) {
+            if (ZMSUtils.userAuthorityAttrMissing(userAuthorityExpiration, group.getUserAuthorityExpiration())) {
                 throw ZMSUtils.requestError("Group " + memberName + " does not have same user authority expiration "
                         + userAuthorityExpiration + " configured", caller);
             }
         }
-    }
-
-    boolean userAuthorityFilterPresent(final String roleFilter, final String groupMemberFilter) {
-
-        // if the role filter is empty then there is nothing to check
-
-        if (StringUtil.isEmpty(roleFilter)) {
-            return true;
-        }
-
-        // if the group filter is empty then it's a failure
-        // since we know that our role filter is not empty
-
-        if (StringUtil.isEmpty(groupMemberFilter)) {
-            return false;
-        }
-
-        // we'll just compare the values as is in case there
-        // is a match and no further processing is necessary
-
-        if (roleFilter.equals(groupMemberFilter)) {
-            return true;
-        }
-
-        // we need to tokenize our filter values and compare. we want to
-        // make sure all role filter values are present in the group
-
-        Set<String> groupValues = new HashSet<>(Arrays.asList(groupMemberFilter.split(",")));
-        for (String filter : roleFilter.split(",")) {
-            if (!groupValues.contains(filter)) {
-                return false;
-            }
-        }
-
-        return true;
     }
 
     Group getGroup(final String groupFullName) {

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/store/jdbc/JDBCConnection.java
@@ -459,7 +459,7 @@ public class JDBCConnection implements ObjectStoreConnection {
             + "WHERE role_member.principal_id=? AND role_member.active=true AND role.name='admin' ) "
             + "order by do.name, grp.name, principal.name;";
     private static final String SQL_GET_EXPIRED_PENDING_GROUP_MEMBERS = "SELECT d.name, r.name, p.name, pgm.expiration, pgm.audit_ref, pgm.req_time, pgm.req_principal "
-            + "FROM principal p JOIN pending_princpial_group_member pgm "
+            + "FROM principal p JOIN pending_principal_group_member pgm "
             + "ON pgm.principal_id=p.principal_id JOIN principal_group grp ON pgm.group_id=grp.group_id JOIN domain d ON d.domain_id=grp.domain_id "
             + "WHERE pgm.req_time < (CURRENT_TIME - INTERVAL ? DAY);";
     private static final String SQL_AUDIT_ENABLED_PENDING_GROUP_MEMBERSHIP_REMINDER_ENTRIES = "SELECT distinct d.org, d.name FROM pending_principal_group_member pgm "

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/ZMSUtils.java
@@ -15,11 +15,11 @@
  */
 package com.yahoo.athenz.zms.utils;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.zms.*;
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -443,5 +443,40 @@ public class ZMSUtils {
 
         String lowerCasedDomain = resource.substring(0, delimiterIndex).toLowerCase();
         return lowerCasedDomain + resource.substring(delimiterIndex);
+    }
+
+    public static boolean userAuthorityAttrMissing(final String origAttrList, final String checkAttrList) {
+
+        // if the original attr list is empty then there is nothing to check
+
+        if (StringUtil.isEmpty(origAttrList)) {
+            return false;
+        }
+
+        // if the check attribute list is empty then it's a failure
+        // since we know that our original attr is not empty
+
+        if (StringUtil.isEmpty(checkAttrList)) {
+            return true;
+        }
+
+        // we'll just compare the values as is in case there
+        // is a match and no further processing is necessary
+
+        if (origAttrList.equals(checkAttrList)) {
+            return false;
+        }
+
+        // we need to tokenize our attr values and compare. we want to
+        // make sure all original attribute values are present in the check list
+
+        Set<String> checkValues = new HashSet<>(Arrays.asList(checkAttrList.split(",")));
+        for (String attr : origAttrList.split(",")) {
+            if (!checkValues.contains(attr)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -40,7 +40,6 @@ import com.yahoo.athenz.zms.notification.PutRoleMembershipNotificationTask;
 import com.yahoo.athenz.zms.status.MockStatusCheckerThrowException;
 import com.yahoo.athenz.zms.status.MockStatusCheckerNoException;
 import com.yahoo.athenz.zms.store.ObjectStoreConnection;
-import org.eclipse.jetty.util.StringUtil;
 import org.mockito.Mockito;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -10457,10 +10456,13 @@ public class ZMSImplTest {
         String unsignedCreds = "v=U1;d=user;n=user2";
         final Principal rsrcPrince = SimplePrincipal.create("user", "user2",
                 unsignedCreds + ";s=signature", 0, certificateAuthority);
+        assertNotNull(rsrcPrince);
 
-        assertEquals(zms.evaluateAccess(domain, "user.user1", "read", "coretech:resource1", null, null, rsrcPrince), AccessStatus.ALLOWED);
+        assertEquals(zms.evaluateAccess(domain, "user.user1", "read", "coretech:resource1", null, null, rsrcPrince),
+                AccessStatus.ALLOWED);
         ((SimplePrincipal)rsrcPrince).setMtlsRestricted(true);
-        assertEquals(zms.evaluateAccess(domain, "user.user1", "read", "coretech:resource1", null, null, rsrcPrince), AccessStatus.DENIED);
+        assertEquals(zms.evaluateAccess(domain, "user.user1", "read", "coretech:resource1", null, null, rsrcPrince),
+                AccessStatus.DENIED);
     }
 
     @Test
@@ -19389,13 +19391,13 @@ public class ZMSImplTest {
 
         // valid users no exception
 
-        zms.validateRoleMemberPrincipal("user.joe", Principal.Type.USER.getValue(), null, null, "unittest");
-        zms.validateRoleMemberPrincipal("user.jane", Principal.Type.USER.getValue(), null, null, "unittest");
+        zms.validateRoleMemberPrincipal("user.joe", Principal.Type.USER.getValue(), null, null, null, "unittest");
+        zms.validateRoleMemberPrincipal("user.jane", Principal.Type.USER.getValue(), null, null, null, "unittest");
 
         // invalid user request error
 
         try {
-            zms.validateRoleMemberPrincipal("user.john", Principal.Type.USER.getValue(), null, null, "unittest");
+            zms.validateRoleMemberPrincipal("user.john", Principal.Type.USER.getValue(), null, null, null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
@@ -19403,24 +19405,32 @@ public class ZMSImplTest {
 
         // non - user principals by default are accepted
 
-        zms.validateRoleMemberPrincipal("coretech.api", Principal.Type.SERVICE.getValue(), null, null, "unittest");
+        zms.validateRoleMemberPrincipal("coretech.api", Principal.Type.SERVICE.getValue(),
+                null, null, null, "unittest");
 
         // valid employee and contractor users
 
-        zms.validateRoleMemberPrincipal("user.joe", Principal.Type.USER.getValue(), "employee", null, "unittest");
-        zms.validateRoleMemberPrincipal("user.jane", Principal.Type.USER.getValue(), "employee", null, "unittest");
-        zms.validateRoleMemberPrincipal("user.jack", Principal.Type.USER.getValue(), "contractor", null, "unittest");
+        zms.validateRoleMemberPrincipal("user.joe", Principal.Type.USER.getValue(), "employee",
+                null, null, "unittest");
+        zms.validateRoleMemberPrincipal("user.jane", Principal.Type.USER.getValue(), "employee",
+                null, null, "unittest");
+        zms.validateRoleMemberPrincipal("user.jack", Principal.Type.USER.getValue(), "contractor",
+                null, null, "unittest");
 
         // valid multiple attribute users
 
-        zms.validateRoleMemberPrincipal("user.joe", Principal.Type.USER.getValue(), "employee,local", null, "unittest");
-        zms.validateRoleMemberPrincipal("user.jane", Principal.Type.USER.getValue(), "employee,local", null, "unittest");
-        zms.validateRoleMemberPrincipal("user.jack", Principal.Type.USER.getValue(), "contractor,local", null, "unittest");
+        zms.validateRoleMemberPrincipal("user.joe", Principal.Type.USER.getValue(), "employee,local",
+                null, null, "unittest");
+        zms.validateRoleMemberPrincipal("user.jane", Principal.Type.USER.getValue(), "employee,local",
+                null, null, "unittest");
+        zms.validateRoleMemberPrincipal("user.jack", Principal.Type.USER.getValue(), "contractor,local",
+                null, null, "unittest");
 
         // invalid employee type
 
         try {
-            zms.validateRoleMemberPrincipal("user.jack", Principal.Type.USER.getValue(), "employee", null, "unittest");
+            zms.validateRoleMemberPrincipal("user.jack", Principal.Type.USER.getValue(), "employee",
+                    null, null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
@@ -19429,7 +19439,8 @@ public class ZMSImplTest {
         // invalid multiple types
 
         try {
-            zms.validateRoleMemberPrincipal("user.jack", Principal.Type.USER.getValue(), "local,employee", null, "unittest");
+            zms.validateRoleMemberPrincipal("user.jack", Principal.Type.USER.getValue(), "local,employee",
+                    null, null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
@@ -19445,13 +19456,16 @@ public class ZMSImplTest {
 
         // wildcards are always valid with no exception
 
-        zms.validateRoleMemberPrincipal("athenz.api*", Principal.Type.SERVICE.getValue(), null, null, "unittest");
-        zms.validateRoleMemberPrincipal("coretech.*", Principal.Type.SERVICE.getValue(), null, null, "unittest");
+        zms.validateRoleMemberPrincipal("athenz.api*", Principal.Type.SERVICE.getValue(),
+                null, null, null, "unittest");
+        zms.validateRoleMemberPrincipal("coretech.*", Principal.Type.SERVICE.getValue(),
+                null, null, null, "unittest");
 
         // should get back invalid request since service does not exist
 
         try {
-            zms.validateRoleMemberPrincipal("coretech.api", Principal.Type.SERVICE.getValue(), "employee", null, "unittest");
+            zms.validateRoleMemberPrincipal("coretech.api", Principal.Type.SERVICE.getValue(), "employee",
+                    null, null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
@@ -19460,7 +19474,8 @@ public class ZMSImplTest {
         // invalid service request error
 
         try {
-            zms.validateRoleMemberPrincipal("coretech", Principal.Type.SERVICE.getValue(), null, null, "unittest");
+            zms.validateRoleMemberPrincipal("coretech", Principal.Type.SERVICE.getValue(),
+                    null, null, null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
@@ -19482,12 +19497,14 @@ public class ZMSImplTest {
 
         // known service - no exception
 
-        zms.validateRoleMemberPrincipal("coretech.api", Principal.Type.SERVICE.getValue(), null,  null, "unittest");
+        zms.validateRoleMemberPrincipal("coretech.api", Principal.Type.SERVICE.getValue(),
+                null, null,  null, "unittest");
 
         // unknown service - exception
 
         try {
-            zms.validateRoleMemberPrincipal("coretech.backend", Principal.Type.SERVICE.getValue(), null, null, "unittest");
+            zms.validateRoleMemberPrincipal("coretech.backend", Principal.Type.SERVICE.getValue(),
+                    null, null, null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
@@ -19503,12 +19520,14 @@ public class ZMSImplTest {
 
         // coretech is now accepted
 
-        zms.validateRoleMemberPrincipal("coretech.backend", Principal.Type.SERVICE.getValue(), null, null, "unittest");
+        zms.validateRoleMemberPrincipal("coretech.backend", Principal.Type.SERVICE.getValue(),
+                null, null, null, "unittest");
 
         // but coretech2 is rejected
 
         try {
-            zms.validateRoleMemberPrincipal("coretech2.backend", Principal.Type.SERVICE.getValue(), null, null, "unittest");
+            zms.validateRoleMemberPrincipal("coretech2.backend", Principal.Type.SERVICE.getValue(),
+                    null, null, null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
@@ -19516,7 +19535,7 @@ public class ZMSImplTest {
 
         // user principals by default are accepted
 
-        zms.validateRoleMemberPrincipal("user.john", Principal.Type.USER.getValue(), null, null, "unittest");
+        zms.validateRoleMemberPrincipal("user.john", Principal.Type.USER.getValue(), null, null, null, "unittest");
 
         // reset our setting
 
@@ -24146,6 +24165,7 @@ public class ZMSImplTest {
         zms.userAuthority = authority;
 
         TopLevelDomain dom1 = createTopLevelDomainObject(domainName, "Test Domain1", "testOrg", adminUser);
+        dom1.setAuditEnabled(true);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
 
         Group group = createGroupObject(domainName, groupName, "user.john", "user.jane");
@@ -24153,12 +24173,13 @@ public class ZMSImplTest {
 
         // both null is good
 
-        zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), null, null, "unittest");
+        zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), null, null, null, "unittest");
 
         // with user authority we have failure
 
         try {
-            zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), "OnShore-US", null, "unittest");
+            zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), "OnShore-US",
+                    null, null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertTrue(ex.getMessage().contains("does not have same user authority filter"));
@@ -24169,13 +24190,14 @@ public class ZMSImplTest {
 
         // now without user expiry we have success
 
-        zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), "OnShore-US", null, "unittest");
+        zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), "OnShore-US",
+                null, null, "unittest");
 
         // with expiry it's failure
 
         try {
             zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), "OnShore-US",
-                    "elevated-clearance", "unittest");
+                    "elevated-clearance", null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertTrue(ex.getMessage().contains("does not have same user authority expiration"));
@@ -24189,12 +24211,13 @@ public class ZMSImplTest {
         // now we have success
 
         zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), "OnShore-US",
-                "elevated-clearance", "unittest");
+                "elevated-clearance", null, "unittest");
 
         // with different values we have failures again
 
         try {
-            zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), "OnShore-UK", null, "unittest");
+            zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), "OnShore-UK",
+                    null, null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertTrue(ex.getMessage().contains("does not have same user authority filter"));
@@ -24202,13 +24225,99 @@ public class ZMSImplTest {
 
         try {
             zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), "OnShore-US",
-                    "elevated-l2-clearance", "unittest");
+                    "elevated-l2-clearance", null, "unittest");
             fail();
         } catch (ResourceException ex) {
             assertTrue(ex.getMessage().contains("does not have same user authority expiration"));
         }
 
+        // if we ask for the audit enabled flag we should get failure
+
+        try {
+            zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), null, null, true, "unittest");
+            fail();
+        } catch (ResourceException ex) {
+            assertTrue(ex.getMessage().contains("must be audit enabled"));
+        }
+
+        // if we pass false then we're good
+
+        zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), null, null, false, "unittest");
+
+        // now let's set the group as audit enabled and try again
+
+        GroupSystemMeta gsm = new GroupSystemMeta().setAuditEnabled(true);
+        zms.putGroupSystemMeta(mockDomRsrcCtx, domainName, groupName, "auditenabled", auditRef, gsm);
+
+        zms.validateGroupPrincipal(ZMSUtils.groupResourceName(domainName, groupName), null, null, true, "unittest");
+
         zms.userAuthority = savedAuthority;
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
+    }
+
+    @Test
+    public void testPutRoleSystemMetaWithGroups() {
+
+        final String domainName = "role-system-audit-enabled";
+        final String roleName1 = "role1";
+        final String groupName1 = "group1";
+        final String groupName2 = "group2";
+
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
+                "Role System Meta Test Domain1", "testOrg", "user.user1");
+        zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
+
+        DomainMeta meta = new DomainMeta().setAuditEnabled(true);
+        zms.putDomainSystemMeta(mockDomRsrcCtx, domainName, "auditenabled", auditRef, meta);
+
+        Group group1 = createGroupObject(domainName, groupName1, "user.john", "user.jane");
+        zms.putGroup(mockDomRsrcCtx, domainName, groupName1, auditRef, group1);
+
+        Group group2 = createGroupObject(domainName, groupName2, "user.john", "user.jane");
+        zms.putGroup(mockDomRsrcCtx, domainName, groupName2, auditRef, group2);
+
+        Role role1 = createRoleObject(domainName, roleName1, null, "user.john",
+                ZMSUtils.groupResourceName(domainName, groupName1));
+        zms.putRole(mockDomRsrcCtx, domainName, roleName1, auditRef, role1);
+
+        // if we try to put the audit enabled flag on the role
+        // it should be rejected since the group doesn't have audit flag
+
+        RoleSystemMeta rsm = createRoleSystemMetaObject(true);
+        try {
+            zms.putRoleSystemMeta(mockDomRsrcCtx, domainName, roleName1, "auditenabled", auditRef, rsm);
+            fail();
+        } catch (ResourceException ex) {
+            assertTrue(ex.getMessage().contains("must have audit flag enabled"));
+        }
+
+        // now let's set the audit enabled flag on the group
+
+        GroupSystemMeta gsm = new GroupSystemMeta().setAuditEnabled(true);
+        zms.putGroupSystemMeta(mockDomRsrcCtx, domainName, groupName1, "auditenabled", auditRef, gsm);
+
+        // now let's try our set system role meta operation
+
+        zms.putRoleSystemMeta(mockDomRsrcCtx, domainName, roleName1, "auditenabled", auditRef, rsm);
+
+        // now we're going to add group2 as a member which should be rejected
+        // since it's not audit enabled
+
+        Membership mbr = new Membership().setMemberName(ZMSUtils.groupResourceName(domainName, groupName2));
+        try {
+            zms.putMembership(mockDomRsrcCtx, domainName, roleName1,
+                    ZMSUtils.groupResourceName(domainName, groupName2), auditRef, mbr);
+            fail();
+        } catch (ResourceException ex) {
+            assertTrue(ex.getMessage().contains("must be audit enabled"));
+        }
+
+        // now let's add the audit flag on the group and our put membership should work
+
+        zms.putGroupSystemMeta(mockDomRsrcCtx, domainName, groupName2, "auditenabled", auditRef, gsm);
+        zms.putMembership(mockDomRsrcCtx, domainName, roleName1,
+                ZMSUtils.groupResourceName(domainName, groupName2), auditRef, mbr);
+
         zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -2772,6 +2772,8 @@ public class ZMSImplTest {
     public void testCreateNormalizedGroupMemberRole() {
 
         final String domainName = "group-member-role";
+        final String roleName = "role1";
+
         TopLevelDomain dom1 = createTopLevelDomainObject(domainName, "Test Domain1", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
 
@@ -2788,13 +2790,13 @@ public class ZMSImplTest {
         roleMembers.add(new RoleMember().setMemberName(domainName + ":group.group1"));
         roleMembers.add(new RoleMember().setMemberName("coretech:group.dev-team"));
 
-        Role role1 = createRoleObject(domainName, "Role1", null, roleMembers);
-        zms.putRole(mockDomRsrcCtx, domainName, "Role1", auditRef, role1);
+        Role role1 = createRoleObject(domainName, roleName, null, roleMembers);
+        zms.putRole(mockDomRsrcCtx, domainName, roleName, auditRef, role1);
 
-        Role role = zms.getRole(mockDomRsrcCtx, domainName, "Role1", false, false, false);
+        Role role = zms.getRole(mockDomRsrcCtx, domainName, roleName, false, false, false);
         assertNotNull(role);
 
-        assertEquals(role.getName(), domainName + ":role.Role1".toLowerCase());
+        assertEquals(role.getName(), ZMSUtils.roleResourceName(domainName, roleName));
         List<RoleMember> members = role.getRoleMembers();
         assertNotNull(members);
         assertEquals(members.size(), 2);
@@ -2803,6 +2805,8 @@ public class ZMSImplTest {
         checkList.add("coretech:group.dev-team");
         checkRoleMember(checkList, members);
 
+        zms.deleteRole(mockDomRsrcCtx, domainName, roleName, auditRef);
+
         zms.deleteTopLevelDomain(mockDomRsrcCtx, "coretech", auditRef);
         zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
     }
@@ -2810,24 +2814,22 @@ public class ZMSImplTest {
     @Test
     public void testCreateNormalizedCombinedMemberRole() {
 
-        TopLevelDomain dom1 = createTopLevelDomainObject("CreateNormalizedCombinedMemberRoleDom1",
-                "Test Domain1", "testOrg", adminUser);
+        final String domainName = "normalized-combined-member-role";
+        final String roleName = "role1";
+
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName, "Test Domain1", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
 
-        TopLevelDomain dom2 = createTopLevelDomainObject("coretech",
-                "Test Domain2", "testOrg", adminUser);
+        TopLevelDomain dom2 = createTopLevelDomainObject("coretech", "Test Domain2", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom2);
         
-        SubDomain subDom2 = createSubDomainObject("storage", "coretech",
-                "Test Domain2", "testOrg", adminUser);
+        SubDomain subDom2 = createSubDomainObject("storage", "coretech", "Test Domain2", "testOrg", adminUser);
         zms.postSubDomain(mockDomRsrcCtx, "coretech", auditRef, subDom2);
         
-        SubDomain subDom3 = createSubDomainObject("user1", "user",
-                "Test Domain2", "testOrg", adminUser);
+        SubDomain subDom3 = createSubDomainObject("user1", "user", "Test Domain2", "testOrg", adminUser);
         zms.postSubDomain(mockDomRsrcCtx, "user", auditRef, subDom3);
         
-        SubDomain subDom4 = createSubDomainObject("dom1", "user.user1",
-                "Test Domain2", "testOrg", adminUser);
+        SubDomain subDom4 = createSubDomainObject("dom1", "user.user1", "Test Domain2", "testOrg", adminUser);
         zms.postSubDomain(mockDomRsrcCtx, "user.user1", auditRef, subDom4);
 
         Group group1 = createGroupObject("coretech.storage", "dev-team", "user.joe", "user.jane");
@@ -2843,14 +2845,13 @@ public class ZMSImplTest {
         roleMembers.add(new RoleMember().setMemberName("user.user1.dom1.api"));
         roleMembers.add(new RoleMember().setMemberName("coretech.storage:group.dev-team"));
 
-        Role role1 = createRoleObject("CreateNormalizedCombinedMemberRoleDom1", "Role1", 
-                null, roleMembers);
-        zms.putRole(mockDomRsrcCtx, "CreateNormalizedCombinedMemberRoleDom1", "Role1", auditRef, role1);
+        Role role1 = createRoleObject(domainName, roleName, null, roleMembers);
+        zms.putRole(mockDomRsrcCtx, domainName, roleName, auditRef, role1);
 
-        Role role = zms.getRole(mockDomRsrcCtx, "CreateNormalizedCombinedMemberRoleDom1", "Role1", false, false, false);
+        Role role = zms.getRole(mockDomRsrcCtx, domainName, roleName, false, false, false);
         assertNotNull(role);
 
-        assertEquals(role.getName(), "CreateNormalizedCombinedMemberRoleDom1:role.Role1".toLowerCase());
+        assertEquals(role.getName(), ZMSUtils.roleResourceName(domainName, roleName));
         List<RoleMember> members = role.getRoleMembers();
         assertNotNull(members);
         assertEquals(members.size(), 5);
@@ -2862,11 +2863,13 @@ public class ZMSImplTest {
         checkList.add("coretech.storage:group.dev-team");
         checkRoleMember(checkList, members);
 
+        zms.deleteRole(mockDomRsrcCtx, domainName, roleName, auditRef);
+
         zms.deleteSubDomain(mockDomRsrcCtx, "user.user1", "dom1", auditRef);
         zms.deleteSubDomain(mockDomRsrcCtx, "user", "user1", auditRef);
         zms.deleteSubDomain(mockDomRsrcCtx, "coretech", "storage", auditRef);
         zms.deleteTopLevelDomain(mockDomRsrcCtx, "coretech", auditRef);
-        zms.deleteTopLevelDomain(mockDomRsrcCtx,"CreateNormalizedCombinedMemberRoleDom1", auditRef);
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
     }
     
     @Test
@@ -21929,7 +21932,7 @@ public class ZMSImplTest {
         TopLevelDomain dom1 = createTopLevelDomainObject(domainName1, "Test Domain1", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
 
-        TopLevelDomain dom2 = createTopLevelDomainObject(domainName2, "Test Domain1", "testOrg", adminUser);
+        TopLevelDomain dom2 = createTopLevelDomainObject(domainName2, "Test Domain2", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom2);
 
         Group group1 = createGroupObject(domainName1, groupName1, "user.joe", "user.jane");
@@ -24452,4 +24455,71 @@ public class ZMSImplTest {
         zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName, auditRef);
     }
 
+    @Test
+    public void testDeleteDomainWithGroupConsistency() {
+
+        final String domainName1 = "delete-group1";
+        final String domainName2 = "delete-group2";
+        final String domainName3 = "delete-group3";
+        final String groupName1 = "group1";
+        final String groupName2 = "group2";
+        final String groupName3 = "group3";
+        final String roleName1 = "role1";
+        final String roleName2 = "role2";
+        final String roleName3 = "role3";
+
+        TopLevelDomain dom1 = createTopLevelDomainObject(domainName1, "Test Domain1", "testOrg", adminUser);
+        zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom1);
+
+        TopLevelDomain dom2 = createTopLevelDomainObject(domainName2, "Test Domain2", "testOrg", adminUser);
+        zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom2);
+
+        TopLevelDomain dom3 = createTopLevelDomainObject(domainName3, "Test Domain3", "testOrg", adminUser);
+        zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, dom3);
+
+        Group group1 = createGroupObject(domainName1, groupName1, "user.joe", "user.jane");
+        zms.putGroup(mockDomRsrcCtx, domainName1, groupName1, auditRef, group1);
+
+        Group group2 = createGroupObject(domainName1, groupName2, "user.joe", "user.jane");
+        zms.putGroup(mockDomRsrcCtx, domainName1, groupName2, auditRef, group2);
+
+        Group group3 = createGroupObject(domainName3, groupName3, "user.joe", "user.jane");
+        zms.putGroup(mockDomRsrcCtx, domainName3, groupName3, auditRef, group3);
+
+        // add group2 as a member to roles in 2 different domains
+
+        Role role1 = createRoleObject(domainName1, roleName1, null, "user.john",
+                ZMSUtils.groupResourceName(domainName1, groupName2));
+        zms.putRole(mockDomRsrcCtx, domainName1, roleName1, auditRef, role1);
+
+        Role role2 = createRoleObject(domainName2, roleName2, null, "user.john",
+                ZMSUtils.groupResourceName(domainName1, groupName2));
+        zms.putRole(mockDomRsrcCtx, domainName2, roleName2, auditRef, role2);
+
+        Role role3 = createRoleObject(domainName3, roleName3, null, "user.john",
+                ZMSUtils.groupResourceName(domainName3, groupName3));
+        zms.putRole(mockDomRsrcCtx, domainName2, roleName2, auditRef, role2);
+
+        // we should be able to delete domain3 without any issues since
+        // group3 is included in the same domain only
+
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName3, auditRef);
+
+        // we should not able to delete domain1 since the group from domain1
+        // is included in both domain1 and domain2. our error message should
+        // only include reference from domain2
+
+        try {
+            zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName1, auditRef);
+            fail();
+        } catch (ResourceException ex) {
+            assertFalse(ex.getMessage().contains(ZMSUtils.roleResourceName(domainName1, roleName1)));
+            assertTrue(ex.getMessage().contains(ZMSUtils.roleResourceName(domainName2, roleName2)));
+        }
+
+        // after we delete domain2 we can delete domain1 successfully
+
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName2, auditRef);
+        zms.deleteTopLevelDomain(mockDomRsrcCtx, domainName1, auditRef);
+    }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/ZMSUtilsTest.java
@@ -433,4 +433,37 @@ public class ZMSUtilsTest {
         assertEquals(ZMSUtils.lowerDomainInResource(""), "");
         assertNull(ZMSUtils.lowerDomainInResource(null));
     }
+
+    @Test
+    public void testUserAuthorityAttrPresent() {
+
+        // empty role filter cases
+
+        assertFalse(ZMSUtils.userAuthorityAttrMissing(null, "test1"));
+        assertFalse(ZMSUtils.userAuthorityAttrMissing("", "test1"));
+
+        // if role filter is not empty but group is - then failure
+
+        assertTrue(ZMSUtils.userAuthorityAttrMissing("test1", null));
+        assertTrue(ZMSUtils.userAuthorityAttrMissing("test1", ""));
+
+        // values match
+
+        assertFalse(ZMSUtils.userAuthorityAttrMissing("test1", "test1"));
+        assertFalse(ZMSUtils.userAuthorityAttrMissing("test1,test2", "test1,test2"));
+
+        // array value match
+
+        assertFalse(ZMSUtils.userAuthorityAttrMissing("test2,test3,test1", "test1,test3,test2"));
+
+        // subset values match
+
+        assertFalse(ZMSUtils.userAuthorityAttrMissing("test2,test3", "test1,test3,test2"));
+        assertFalse(ZMSUtils.userAuthorityAttrMissing("test3", "test1,test3,test2"));
+
+        // mismatch values
+
+        assertTrue(ZMSUtils.userAuthorityAttrMissing("test1", "test2"));
+        assertTrue(ZMSUtils.userAuthorityAttrMissing("test2,test3,test1", "test4,test3,test2"));
+    }
 }


### PR DESCRIPTION
when setting role as audit enabled, we make sure all the group members are audit enabled as well.

we won't allow a role to be set as audit enabled if the group member is not, and we won't allow adding a group member to a role that is audit enabled but the group is not.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
