### PR TITLE
Fix expand roles in UI

### DIFF
--- a/ui/src/components/role/RoleMemberDetails.js
+++ b/ui/src/components/role/RoleMemberDetails.js
@@ -204,8 +204,16 @@ export default class RoleMemberDetails extends React.Component {
     }
 
     loadRole() {
+        var expandDueToDelegate =
+            this.state.trust && this.state.trust.length > 0;
         this.props.api
-            .getRole(this.props.domain, this.props.role, true, true, true)
+            .getRole(
+                this.props.domain,
+                this.props.role,
+                true,
+                expandDueToDelegate,
+                true
+            )
             .then((role) => {
                 let justificationRequired =
                     this.props.justificationRequired ||


### PR DESCRIPTION
Should only expand delegated roles so groups will always appear by name


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
