### PR TITLE
introduce authority id field in access logs

### DIFF
--- a/containers/jetty/pom.xml
+++ b/containers/jetty/pom.xml
@@ -39,7 +39,7 @@
   </dependencyManagement>
 
   <properties>
-    <code.coverage.min>0.08</code.coverage.min>
+    <code.coverage.min>0.72</code.coverage.min>
   </properties>
 
   <dependencies>

--- a/containers/jetty/src/main/java/com/yahoo/athenz/container/log/AthenzRequestLog.java
+++ b/containers/jetty/src/main/java/com/yahoo/athenz/container/log/AthenzRequestLog.java
@@ -27,6 +27,7 @@ import org.eclipse.jetty.http.HttpHeader;
 public class AthenzRequestLog extends NCSARequestLog {
 
     private static final String REQUEST_PRINCIPAL      = "com.yahoo.athenz.auth.principal";
+    private static final String REQUEST_AUTHORITY_ID   = "com.yahoo.athenz.auth.authority_id";
     private static final String REQUEST_URI_SKIP_QUERY = "com.yahoo.athenz.uri.skip_query";
     private static final String REQUEST_URI_ADDL_QUERY = "com.yahoo.athenz.uri.addl_query";
 
@@ -95,6 +96,11 @@ public class AthenzRequestLog extends NCSARequestLog {
         append(buf, (principal == null) ? null : principal.toString());
     }
 
+    private void logAuthorityId(StringBuilder buf, Request request) {
+        final Object authId = request.getAttribute(REQUEST_AUTHORITY_ID);
+        append(buf, (authId == null) ? "Auth-None" : authId.toString());
+    }
+
     private void append(StringBuilder buf, String str) {
         if (str != null && !str.isEmpty()) {
             buf.append(str);
@@ -147,6 +153,9 @@ public class AthenzRequestLog extends NCSARequestLog {
 
             buf.append(' ');
             buf.append(System.currentTimeMillis() - request.getTimeStamp());
+
+            buf.append(' ');
+            logAuthorityId(buf, request);
 
             write(buf.toString());
 

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/Authority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/Authority.java
@@ -43,6 +43,16 @@ public interface Authority {
     void initialize();
 
     /**
+     * @return the string to be included as the identifier for the
+     *  authority which will be logged in the server access log file
+     *  as the last field so we know what authority was responsible
+     *  for authenticating the principal.
+     */
+    default String getID() {
+        return "Auth-ID";
+    }
+
+    /**
      * @return credentials source - headers or certificate with headers being default
      */
     default CredSource getCredSource() {

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/CertificateAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/CertificateAuthority.java
@@ -58,6 +58,11 @@ public class CertificateAuthority implements Authority {
     }
 
     @Override
+    public String getID() {
+        return "Auth-X509";
+    }
+
+    @Override
     public String getDomain() {
         return null;
     }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/KerberosAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/KerberosAuthority.java
@@ -118,6 +118,11 @@ public class KerberosAuthority implements Authority {
         login(false);
     }
 
+    @Override
+    public String getID() {
+        return "Auth-KERB";
+    }
+
     @SuppressWarnings({ "unchecked", "rawtypes" })
     public synchronized void login(boolean logoutFirst) {
 

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/LDAPAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/LDAPAuthority.java
@@ -48,6 +48,11 @@ public class LDAPAuthority implements Authority {
     }
 
     @Override
+    public String getID() {
+        return "Auth-LDAP";
+    }
+
+    @Override
     public String getDomain() {
         return "user";
     }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/PrincipalAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/PrincipalAuthority.java
@@ -69,7 +69,12 @@ public class PrincipalAuthority implements Authority, AuthorityKeyStore {
             allowedOffset = 300;
         }
     }
-    
+
+    @Override
+    public String getID() {
+        return "Auth-NTOKEN";
+    }
+
     @Override
     public void initialize() {
     }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/RoleAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/RoleAuthority.java
@@ -57,7 +57,12 @@ public class RoleAuthority implements Authority, AuthorityKeyStore {
             allowedOffset = 300;
         }
     }
-    
+
+    @Override
+    public String getID() {
+        return "Auth-ROLE";
+    }
+
     @Override
     public void initialize() {
     }

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/UserAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/UserAuthority.java
@@ -49,6 +49,11 @@ public class UserAuthority implements Authority {
     }
 
     @Override
+    public String getID() {
+        return "Auth-UNIX";
+    }
+
+    @Override
     public String getDomain() {
         return "user";
     }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/ServerCommonConsts.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/ServerCommonConsts.java
@@ -36,6 +36,9 @@ public final class ServerCommonConsts {
     public static final String PROP_ATHENZ_CONF             = "athenz.athenz_conf";
     public static final String ZTS_PROP_FILE_NAME           = "athenz.zts.prop_file";
 
+    public static final String REQUEST_PRINCIPAL    = "com.yahoo.athenz.auth.principal";
+    public static final String REQUEST_AUTHORITY_ID = "com.yahoo.athenz.auth.authority_id";
+
     // for tests
     public static final String ZTS_PROP_AWS_PUBLIC_CERT = "athenz.zts.aws_public_cert";
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
@@ -18,13 +18,13 @@ package com.yahoo.athenz.zms;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.Authorizer;
 import com.yahoo.athenz.auth.Principal;
+import com.yahoo.athenz.common.ServerCommonConsts;
 import com.yahoo.athenz.common.server.rest.Http;
 
 public class RsrcCtxWrapper implements ResourceContext {
-
-    private static final String ZMS_REQUEST_PRINCIPAL   = "com.yahoo.athenz.auth.principal";
 
     private final com.yahoo.athenz.common.server.rest.ResourceContext ctx;
     private Object timerMetric;
@@ -104,9 +104,17 @@ public class RsrcCtxWrapper implements ResourceContext {
         if (principal == null) {
             return;
         }
-        ctx.request().setAttribute(ZMS_REQUEST_PRINCIPAL, principal.getFullName());
+        ctx.request().setAttribute(ServerCommonConsts.REQUEST_PRINCIPAL, principal.getFullName());
+        logAuthorityId(principal.getAuthority());
     }
-    
+
+    public void logAuthorityId(Authority authority) {
+        if (authority == null) {
+            return;
+        }
+        ctx.request().setAttribute(ServerCommonConsts.REQUEST_AUTHORITY_ID, authority.getID());
+    }
+
     void throwZmsException(com.yahoo.athenz.common.server.rest.ResourceException restExc) {
 
         // first check to see if this is an auth failure and if

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/RsrcCtxWrapperTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/RsrcCtxWrapperTest.java
@@ -175,6 +175,7 @@ public class RsrcCtxWrapperTest {
 
         wrapper.logPrincipal(principal);
         assertEquals(servletRequest.getAttribute("com.yahoo.athenz.auth.principal"), "hockey.kings");
+        assertEquals(servletRequest.getAttribute("com.yahoo.athenz.auth.authority_id"), "Auth-NTOKEN");
     }
 
     @Test

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
@@ -15,8 +15,10 @@
  */
 package com.yahoo.athenz.zts;
 
+import com.yahoo.athenz.auth.Authority;
 import com.yahoo.athenz.auth.Authorizer;
 import com.yahoo.athenz.auth.Principal;
+import com.yahoo.athenz.common.ServerCommonConsts;
 import com.yahoo.athenz.common.server.rest.Http;
 import com.yahoo.athenz.common.metrics.Metric;
 import org.slf4j.Logger;
@@ -27,7 +29,6 @@ import javax.servlet.http.HttpServletResponse;
 
 public class RsrcCtxWrapper implements ResourceContext {
 
-    private static final String ZTS_REQUEST_PRINCIPAL   = "com.yahoo.athenz.auth.principal";
     private static final Logger LOG = LoggerFactory.getLogger(RsrcCtxWrapper.class);
 
     com.yahoo.athenz.common.server.rest.ResourceContext ctx;
@@ -117,15 +118,23 @@ public class RsrcCtxWrapper implements ResourceContext {
             return;
         }
         logPrincipal(principal.getFullName());
+        logAuthorityId(principal.getAuthority());
     }
     
     public void logPrincipal(final String principal) {
         if (principal == null) {
             return;
         }
-        ctx.request().setAttribute(ZTS_REQUEST_PRINCIPAL, principal);
+        ctx.request().setAttribute(ServerCommonConsts.REQUEST_PRINCIPAL, principal);
     }
-    
+
+    public void logAuthorityId(Authority authority) {
+        if (authority == null) {
+            return;
+        }
+        ctx.request().setAttribute(ServerCommonConsts.REQUEST_AUTHORITY_ID, authority.getID());
+    }
+
     public void throwZtsException(com.yahoo.athenz.common.server.rest.ResourceException restExc) {
 
         metric.increment("authfailure");

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
@@ -293,6 +293,7 @@ public class RsrcCtxWrapperTest {
 
         wrapper.logPrincipal(principal);
         assertEquals(servletRequest.getAttribute("com.yahoo.athenz.auth.principal"), "hockey.kings");
+        assertEquals(servletRequest.getAttribute("com.yahoo.athenz.auth.authority_id"), "Auth-NTOKEN");
     }
 
     @Test


### PR DESCRIPTION
when debugging or looking at principals this will show what authority was responsible for authenticating the principal.

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
