### PR TITLE
Ignore ConditionalCheckFailedException when updating

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnection.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/impl/DynamoDBCertRecordStoreConnection.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 import com.amazonaws.services.dynamodbv2.document.*;
 import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec;
 import com.amazonaws.services.dynamodbv2.document.utils.ValueMap;
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
 import com.amazonaws.services.dynamodbv2.model.ReturnValue;
 import com.yahoo.athenz.common.server.cert.CertRecordStoreConnection;
 import com.yahoo.athenz.common.server.cert.X509CertRecord;
@@ -283,6 +284,8 @@ public class DynamoDBCertRecordStoreConnection implements CertRecordStoreConnect
                     X509CertRecord x509CertRecord = itemToX509CertRecord(updatedItem);
                     updatedRecords.add(x509CertRecord);
                 }
+            } catch (ConditionalCheckFailedException ex) {
+                // This error appears when the update didn't work because it was already updated by another server. We can ignore it.
             } catch (Exception ex) {
                 LOGGER.error("DynamoDB updateLastNotified failed for item: {}, error: {}", item.toString(), ex.getMessage());
             }


### PR DESCRIPTION
notification server and time in records. This error will appear after we try to update a record
that was already upated by a different zts server.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
