### PR TITLE
Don't send multipart/alternative emails

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationService.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/notification/impl/EmailNotificationService.java
@@ -130,32 +130,15 @@ public class EmailNotificationService implements NotificationService {
         message.setFrom(new InternetAddress(from));
         message.setRecipients(javax.mail.Message.RecipientType.BCC, InternetAddress.parse(String.join(",", recipients)));
 
-        // Create a multipart/alternative child container.
-        MimeMultipart msgBody = new MimeMultipart("alternative");
-
-        // Create a wrapper for the HTML and text parts.
-        MimeBodyPart wrap = new MimeBodyPart();
-
-        // Set the text part.
-        MimeBodyPart textPart = new MimeBodyPart();
-        textPart.setContent(body, "text/plain; charset=" + CHARSET_UTF_8);
-
         // Set the HTML part.
         MimeBodyPart htmlPart = new MimeBodyPart();
         htmlPart.setContent(body, "text/html; charset=" + CHARSET_UTF_8);
 
-        // Add the text and HTML parts to the child container.
-        msgBody.addBodyPart(textPart);
-        msgBody.addBodyPart(htmlPart);
-
-        // Add the child container to the wrapper object.
-        wrap.setContent(msgBody);
-
         // Create a multipart/mixed parent container.
         MimeMultipart msgParent = new MimeMultipart("related");
 
-        // Add the multipart/alternative part to the message.
-        msgParent.addBodyPart(wrap);
+        // Add the body to the message.
+        msgParent.addBodyPart(htmlPart);
 
         // Add the parent container to the message.
         message.setContent(msgParent);


### PR DESCRIPTION
multipart/alternative mails are designed to hold different
representations of the same content; this is commonly used to send
text/html emails with a text/plain fallback for mail readers that
don't understand HTML.

The current Athenz notifications send multipart/alternative mails with
both HTML and plain-text parts; however, the plain-text part contains
the same HTML source as the HTML part.

Instead of properly supporting multipart/alternative mails (by using two
separate templates, one for plain-text and one for HTML), this commit
takes the much simpler approach of sending only text/html emails.

- - -

Here's the structure of an HTML-only email I found in my inbox:
```http
Date: ...
From: ...
To: ...
Message-ID: ...
Subject: ...
Content-Type: multipart/related; boundary="----=_Part_16755_452334716.1603498815527"

------=_Part_16755_452334716.1603498815527
Content-Type: text/html; charset=UTF-8
Content-Disposition: inline
Content-Transfer-Encoding: Quoted-printable

<html>
...
</html>
------=_Part_16755_452334716.1603498815527
Content-Type: image/png; name=image1.png
Content-Transfer-Encoding: base64
Content-ID: <image1>
Content-Disposition: inline; filename=image1.png

...
------=_Part_16755_452334716.1603498815527
Content-Type: image/jpeg; name=image2.jpg
Content-Transfer-Encoding: base64
Content-ID: <image2>
Content-Disposition: inline; filename=image2.jpg


...
------=_Part_16755_452334716.1603498815527--
```

- - -

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
