### PR TITLE
defaulting spiffe to true for zts-rolecert and zts-svccert

### DIFF
--- a/utils/zts-rolecert/zts-rolecert.go
+++ b/utils/zts-rolecert/zts-rolecert.go
@@ -50,7 +50,7 @@ func main() {
 	flag.StringVar(&subjO, "subj-o", "Oath Inc.", "Subject O/Organization field")
 	flag.StringVar(&subjOU, "subj-ou", "Athenz", "Subject OU/OrganizationalUnit field")
 	flag.StringVar(&ip, "ip", "", "IP address")
-	flag.BoolVar(&spiffe, "spiffe", false, "include spiffe uri in csr")
+	flag.BoolVar(&spiffe, "spiffe", true, "include spiffe uri in csr")
 	flag.BoolVar(&csr, "csr", false, "request csr only")
 	flag.IntVar(&expiryTime, "expiry-time", 0, "expiry time in minutes")
 	flag.BoolVar(&proxy, "proxy", true, "enable proxy mode for request")

--- a/utils/zts-svccert/zts-svccert.go
+++ b/utils/zts-svccert/zts-svccert.go
@@ -36,7 +36,7 @@ func main() {
 	var csr, spiffe bool
 	var expiryTime int
 	flag.BoolVar(&csr, "csr", false, "request csr only")
-	flag.BoolVar(&spiffe, "spiffe", false, "include spiffe uri in csr")
+	flag.BoolVar(&spiffe, "spiffe", true, "include spiffe uri in csr")
 	flag.IntVar(&expiryTime, "expiry-time", 0, "expiry time in minutes")
 	flag.StringVar(&certFile, "cert-file", "", "output certificate file")
 	flag.StringVar(&signerCertFile, "signer-cert-file", "", "output signer certificate file")


### PR DESCRIPTION
<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

@havetisyan @abvaidya  please review

Have tested the change locally and spiffe URIs are being added without specifying the spiffe flag
Is there any documentation that needs to be updated to reflect this change?