### PR TITLE
skip db call for domain tags for domain mod list with meta only

### DIFF
--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -25303,7 +25303,7 @@ public class ZMSImplTest {
             "10.11.12.13", "GET", null);
         ResourceContext rsrcCtx = createResourceContext(sysPrincipal);
 
-        Response response = zms.getSignedDomains(rsrcCtx, null, null, null, null, null);
+        Response response = zms.getSignedDomains(rsrcCtx, domainName, null, null, null, null);
         SignedDomains sdoms = (SignedDomains) response.getEntity();
         assertNotNull(sdoms);
 
@@ -25315,7 +25315,7 @@ public class ZMSImplTest {
         assertEquals(signedDomainTags, simpleDomainTag());
 
         // test with meta only
-        response = zms.getSignedDomains(rsrcCtx, null, "true", "all", null, null);
+        response = zms.getSignedDomains(rsrcCtx, domainName, "true", "all", null, null);
         sdoms = (SignedDomains) response.getEntity();
         assertNotNull(sdoms);
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/store/impl/jdbc/JDBCConnectionTest.java
@@ -5656,8 +5656,8 @@ public class JDBCConnectionTest {
     public void testListModifiedDomains() throws Exception {
 
         JDBCConnection jdbcConn = new JDBCConnection(mockConn, true);
-        Mockito.when(mockResultSet.next()).thenReturn(true).thenReturn(false) // 3 domains without tags
-            .thenReturn(true).thenReturn(false).thenReturn(true).thenReturn(false);
+        Mockito.when(mockResultSet.next()).thenReturn(true) // 3 domains without tags
+            .thenReturn(true).thenReturn(true).thenReturn(false);
         Mockito.when(mockResultSet.getString(ZMSConsts.DB_COLUMN_NAME))
             .thenReturn("domain1").thenReturn("domain2").thenReturn("domain3"); // 3 domains
         Mockito.when(mockResultSet.getString(ZMSConsts.DB_COLUMN_ACCOUNT))


### PR DESCRIPTION
when get modified domain is executed with meta only, the server must return the mod domain list as quickly as possible. there is no need to fetch domain tags for every domain (single db calls turns into 10K db calls with 10K domains).

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
