### PR TITLE
putRoleMeta can now be called by principals

### DIFF
--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -1203,7 +1203,7 @@ func init() {
 	mPutRoleMeta.Input("roleName", "EntityName", true, "", "", false, nil, "name of the role")
 	mPutRoleMeta.Input("auditRef", "String", false, "", "Y-Audit-Ref", false, nil, "Audit param required(not empty) if domain auditEnabled is true.")
 	mPutRoleMeta.Input("detail", "RoleMeta", false, "", "", false, nil, "RoleMeta object with updated attribute values")
-	mPutRoleMeta.Auth("update", "{domainName}:role.{roleName}", false, "")
+	mPutRoleMeta.Auth("", "", true, "")
 	mPutRoleMeta.Expected("NO_CONTENT")
 	mPutRoleMeta.Exception("BAD_REQUEST", "ResourceError", "")
 	mPutRoleMeta.Exception("CONFLICT", "ResourceError", "")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -1257,7 +1257,7 @@ public class ZMSSchema {
             .pathParam("roleName", "EntityName", "name of the role")
             .headerParam("Y-Audit-Ref", "auditRef", "String", null, "Audit param required(not empty) if domain auditEnabled is true.")
             .input("detail", "RoleMeta", "RoleMeta object with updated attribute values")
-            .auth("update", "{domainName}:role.{roleName}")
+            .auth("", "", true)
             .expected("NO_CONTENT")
             .exception("BAD_REQUEST", "ResourceError", "")
 

--- a/core/zms/src/main/rdl/Role.rdli
+++ b/core/zms/src/main/rdl/Role.rdli
@@ -257,7 +257,7 @@ resource Role PUT "/domain/{domainName}/role/{roleName}/meta" {
     EntityName roleName; //name of the role
     String auditRef (header="Y-Audit-Ref"); //Audit param required(not empty) if domain auditEnabled is true.
     RoleMeta detail; //RoleMeta object with updated attribute values
-    authorize ("update", "{domainName}:role.{roleName}");
+    authenticate;
     expected NO_CONTENT;
     exceptions {
         ResourceError NOT_FOUND;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSResources.java
@@ -1299,7 +1299,7 @@ public class ZMSResources {
         ResourceContext context = null;
         try {
             context = this.delegate.newResourceContext(this.request, this.response, "putRoleMeta");
-            context.authorize("update", "" + domainName + ":role." + roleName + "", null);
+            context.authenticate();
             this.delegate.putRoleMeta(context, domainName, roleName, auditRef, detail);
         } catch (ResourceException e) {
             code = e.getCode();


### PR DESCRIPTION
with authorization:
("update", "{domainName}:role.{roleName}") or
("update_meta", "{domainName}:role.{roleName}")

Signed-off-by: Ofer Levi <ofer.levi@verizonmedia.com>