### PR TITLE
provide option to override service signer key id for role certificates

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -152,6 +152,7 @@ public final class ZTSConsts {
     public static final String DB_PROP_VERIFY_SERVER_CERT = "verifyServerCertificate";
 
     public static final String ZTS_SERVICE           = "zts";
+    public static final String ZTS_VALUE_TRUE        = "true";
     public static final String ZTS_UNKNOWN_DOMAIN    = "unknown_domain";
 
     public static final int ZTS_HTTPS_PORT_DEFAULT   = 4443;
@@ -211,6 +212,7 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_STATUS_CHECKER_FACTORY_CLASS = "athenz.zts.status_checker_factory_class";
     public static final String ZTS_PROP_USER_AUTHORITY_CLASS = "athenz.zts.user_authority_class";
     public static final String ZTS_ISSUE_ROLE_CERT_TAG = "zts.IssueRoleCerts";
+    public static final String ZTS_ROLE_CERT_USE_DOMAIN_SIGNER_KEY_ID_TAG = "zts.RoleCertUseDomainSignerKeyId";
 
     public static final String ZTS_PROP_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY = "athenz.zts.cert_priority_min_percent_low_priority";
     public static final String ZTS_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY_DEFAULT = "75";


### PR DESCRIPTION
# Description

When the service is configured with a signer key id, then all role certificates issued to that service are signed by that key id. There might be edge use cases where the role certificates for a specific domain should be signed with a different key. To support such use cases the following steps can be followed:

1. configure that domain with a signer key id.
2. set the zts.RoleCertUseDomainSignerKeyId=true tag on that domain

So when services asking for a role certificate for this domain, they'll be signed with the key configured in step 1 as long as the tag described in step 2 is configured as such.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

