### PR TITLE
sia option to require successful role certs during startup

### DIFF
--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -393,6 +393,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 	spiffeTrustDomain := ""
 	addlSanDNSEntries := make([]string, 0)
 	runAfterFailExit := false
+	roleCertsRequired := false
 
 	var storeTokenOption *int
 	if config != nil {
@@ -409,6 +410,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		accessManagement = config.AccessManagement
 		storeTokenOption = config.StoreTokenOption
 		runAfterFailExit = config.RunAfterFailExit
+		roleCertsRequired = config.RoleCertsRequired
 
 		if config.RefreshInterval > 0 {
 			refreshInterval = config.RefreshInterval
@@ -659,6 +661,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		StoreTokenOption:       storeTokenOption,
 		AddlSanDNSEntries:      addlSanDNSEntries,
 		RunAfterFailExit:       runAfterFailExit,
+		RoleCertsRequired:      roleCertsRequired,
 		OTel:                   oTelCfg,
 	}, nil
 }

--- a/libs/go/sia/config/config.go
+++ b/libs/go/sia/config/config.go
@@ -110,6 +110,7 @@ type Config struct {
 	SpiffeTrustDomain string                   `json:"spiffe_trust_domain,omitempty"`        //spiffe trust domain - if configured generate full spiffe uri with namespace
 	StoreTokenOption  *int                     `json:"store_token_option,omitempty"`         //store access token option
 	RunAfterFailExit  bool                     `json:"run_after_fail_exit,omitempty"`        //exit process if run_after script fails
+	RoleCertsRequired bool                     `json:"role_certs_required,omitempty"`        //role certs are required for system operations, fail if not successful
 	OTel              OTel                     `json:"otel"`                                 //OpenTelemetry configuration
 }
 
@@ -220,6 +221,7 @@ type Options struct {
 	OmitDomain             bool              //attestation role only includes service name
 	StoreTokenOption       *int              //store access token option
 	RunAfterFailExit       bool              //exit process if run_after script fails
+	RoleCertsRequired      bool              //role certs are required for system operations, fail if not successful
 	OTel                   OTel              //openTelemetry configuration
 }
 

--- a/libs/go/sia/host/utils/utils_test.go
+++ b/libs/go/sia/host/utils/utils_test.go
@@ -42,7 +42,7 @@ func TestGetK8SHostnames(test *testing.T) {
 		siaPodNamespace string
 		siaPodService   string
 		siaPodSubdomain string
-		podIpSandns			bool
+		podIpSandns     bool
 		sanDNSList      []string
 	}{
 		{"no-entries", "", "", "", "", "", false, []string{}},

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -458,6 +458,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 	spiffeTrustDomain := ""
 	addlSanDNSEntries := make([]string, 0)
 	runAfterFailExit := false
+	roleCertsRequired := false
 
 	var storeTokenOption *int
 	if config != nil {
@@ -474,6 +475,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		accessManagement = config.AccessManagement
 		storeTokenOption = config.StoreTokenOption
 		runAfterFailExit = config.RunAfterFailExit
+		roleCertsRequired = config.RoleCertsRequired
 
 		if config.RefreshInterval > 0 {
 			refreshInterval = config.RefreshInterval
@@ -732,6 +734,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		StoreTokenOption:       storeTokenOption,
 		AddlSanDNSEntries:      addlSanDNSEntries,
 		RunAfterFailExit:       runAfterFailExit,
+		RoleCertsRequired:      roleCertsRequired,
 		OTel:                   oTelCfg,
 	}, nil
 }

--- a/utils/hostdoc/hostdoc_test.go
+++ b/utils/hostdoc/hostdoc_test.go
@@ -37,37 +37,37 @@ func TestProcess(t *testing.T) {
 	}{
 		{
 			name: "test with single service",
-			args: args {
+			args: args{
 				docFile: filepath.Join("testdata", "host_document"),
-				domain: true,
+				domain:  true,
 			},
-			want: "athenz.examples",
+			want:    "athenz.examples",
 			wantErr: false,
 		},
 		{
 			name: "test for primary service with multiple services",
-			args: args {
+			args: args{
 				docFile: filepath.Join("testdata", "host_document.services"),
 				primary: true,
 			},
-			want: "httpd",
+			want:    "httpd",
 			wantErr: false,
 		},
 		{
 			name: "test for service with multiple services",
-			args: args {
+			args: args{
 				docFile: filepath.Join("testdata", "host_document.services"),
 				service: true,
 			},
-			want: "httpd,ftpd",
+			want:    "httpd,ftpd",
 			wantErr: false,
 		},
 		{
 			name: "test no selection",
-			args: args {
+			args: args{
 				docFile: filepath.Join("testdata", "host_document"),
 			},
-			want: "",
+			want:    "",
 			wantErr: true,
 		},
 	}

--- a/utils/zpe-updater/util/canonicalstring_test.go
+++ b/utils/zpe-updater/util/canonicalstring_test.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/AthenZ/athenz/clients/go/zts"
+	"github.com/stretchr/testify/assert"
 )
 
 var signedPolicyData *zts.SignedPolicyData


### PR DESCRIPTION
# Description

During sia startup, the agent only verifies that service identity certificates are successfully fetched and if yes, it notifies systemd that it's up and running. While it reports any failures with role certificates, it doesn't stop the process from running.

However, there might be cases, where having the role certificate is as important as the service certificate so any failure must stop the agent from running. For these edge cases, there is a new option for sia_config that can be specified:

"role_certs_required": true

if specified, the agent will try to fetch the role certificates during startup, it will retry every 20 secs for up to 3 minutes, and if it still fails, it will return failure to systemd. The retry logic is required for the use case where the role is authorized in ZMS and it would take a couple of minutes for the change to propagate to ZTS servers to authorize the issuance of the role certificate.
 
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

