### PR TITLE
extend gcp identity validation to remove identical athenz service name check

### DIFF
--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPProvider.java
@@ -438,7 +438,14 @@ public class InstanceGCPProvider implements InstanceProvider {
             // multiple gcp services are allowed to assume the same athenz service
 
             Principal principal = SimplePrincipal.create(instanceDomain, instanceService, (String) null);
-            final String resource = instanceDomain + ":" + attestedServiceName;
+
+            // for the resource we're going to use the same resource as we do for the
+            // gcp.assume_service action: {athenz-domain}:services/{gcp-service-name}
+
+            if (!attestedServiceName.startsWith(gcpProject + ".")) {
+                throw error("Attested service name: " + attestedServiceName + " does not start with expected project name: " + gcpProject);
+            }
+            final String resource = instanceDomain + ":services/" + attestedServiceName.substring(gcpProject.length() + 1);
             boolean accessCheck = authorizer.access(GCP_ASSUME_IDENTITY_ACTION, resource, principal, null);
             if (!accessCheck) {
                 throw error("Service name mismatch: attested=" + attestedServiceName + " vs. requested=" + serviceName);

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceGCPProviderTest.java
@@ -533,7 +533,7 @@ public class InstanceGCPProviderTest {
         Principal principal = SimplePrincipal.create("my.domain", "my-authorized-service", (String) null);
 
         Authorizer authorizerMock = Mockito.mock(Authorizer.class);
-        Mockito.when(authorizerMock.access(eq("gcp.assume_identity"), eq("my.domain:my-gcp-project.my-service"),
+        Mockito.when(authorizerMock.access(eq("gcp.assume_identity"), eq("my.domain:services/my-service"),
                         eq(principal), eq(null))).thenReturn(true);
 
         InstanceGCPProvider provider = new InstanceGCPProvider();
@@ -569,12 +569,12 @@ public class InstanceGCPProviderTest {
     }
 
     @Test
-    public void testConfirmInstanceWithNoServiceNameAuthorization() throws ProviderResourceException {
+    public void testConfirmInstanceWithNoServiceNameAuthorization() {
 
         Principal principal = SimplePrincipal.create("my.domain", "my-authorized-service", (String) null);
 
         Authorizer authorizerMock = Mockito.mock(Authorizer.class);
-        Mockito.when(authorizerMock.access(eq("gcp.assume_identity"), eq("my.domain:my-gcp-project.my-service"),
+        Mockito.when(authorizerMock.access(eq("gcp.assume_identity"), eq("my.domain:services/my-service"),
                 eq(principal), eq(null))).thenReturn(false);
 
         InstanceGCPProvider provider = new InstanceGCPProvider();
@@ -606,7 +606,52 @@ public class InstanceGCPProviderTest {
         try {
             provider.confirmInstance(confirmation);
             fail();
-        } catch(Exception ignored) {}
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Service name mismatch"));
+        }
+
+        System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
+        provider.close();
+    }
+
+    @Test
+    public void testConfirmInstanceWithNMismatchProjectName() {
+
+        Principal principal = SimplePrincipal.create("my.domain", "my-authorized-service", (String) null);
+
+        InstanceGCPProvider provider = new InstanceGCPProvider();
+        System.setProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET, "60");
+        provider.initialize("provider", "com.yahoo.athenz.instance.provider.impl.InstanceGCPProvider", null, null);
+
+        GoogleIdToken.Payload dummyPayload = createRecentPayload(true);
+        InstanceGCPUtils gcpUtilsMock = Mockito.mock(InstanceGCPUtils.class);
+        Mockito.when(gcpUtilsMock.validateGCPIdentityToken(anyString(), any(StringBuilder.class))).thenReturn(dummyPayload);
+        Mockito.when(gcpUtilsMock.getProjectIdFromAttestedData(any())).thenReturn("my-gcp-project");
+        Mockito.when(gcpUtilsMock.getGCPRegionFromZone(any())).thenReturn("us-west1");
+        Mockito.when(gcpUtilsMock.getServiceNameFromAttestedData(any())).thenReturn("my-test-gcp-project.my-service");
+        Mockito.doCallRealMethod().when(gcpUtilsMock).populateAttestationData(any(GoogleIdToken.Payload.class), any(GCPDerivedAttestationData.class));
+        provider.setInstanceGcpUtils(gcpUtilsMock);
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setAttestationData("{\"identityToken\": \"abc\"}");
+        confirmation.setDomain("my.domain");
+        confirmation.setService("my-authorized-service");
+        confirmation.setProvider("gcp.us-west1");
+
+        Map<String, String> attrs = new HashMap<>();
+        attrs.put(ZTS_INSTANCE_GCP_PROJECT, "my-gcp-project");
+        attrs.put(ZTS_INSTANCE_SAN_DNS, "my-authorized-service.my-domain.gcp.athenz.cloud,3692465099344887023.instanceid.athenz.gcp.athenz.cloud");
+        attrs.put(ZTS_INSTANCE_SAN_URI, "spiffe://my-domain/sa/my-authorized-service");
+        confirmation.setAttributes(attrs);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("does not start with expected project name: my-gcp-project"));
+        }
 
         System.clearProperty(InstanceGCPProvider.GCP_PROP_BOOT_TIME_OFFSET);
         provider.close();


### PR DESCRIPTION
# Description

Addresses issue: https://github.com/AthenZ/athenz/issues/3078

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

