### PR TITLE
fix: clear role members when set to trust role

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -5168,7 +5168,7 @@ public class DBService implements RolesProvider, DomainProvider {
                 firstEntry = auditLogSeparator(auditDetails, firstEntry);
                 auditDetails.append(" \"add-role\": ");
                 if (!processRole(con, originalRole, domainName, roleName, templateRole,
-                        admin, null, auditRef, true, auditDetails)) {
+                        admin, null, auditRef, StringUtil.isEmpty(templateRole.getTrust()), auditDetails)) {
                     return false;
                 }
 
@@ -5460,7 +5460,7 @@ public class DBService implements RolesProvider, DomainProvider {
 
         List<RoleMember> roleMembers = role.getRoleMembers();
         List<RoleMember> newMembers = new ArrayList<>();
-        if (roleMembers != null && !roleMembers.isEmpty()) {
+        if (StringUtil.isEmpty(templateRoleTrust) && roleMembers != null && !roleMembers.isEmpty()) {
             for (RoleMember roleMember : roleMembers) {
                 RoleMember newRoleMember = new RoleMember();
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBServiceTest.java
@@ -4086,8 +4086,8 @@ public class DBServiceTest {
     @Test
     public void testApplySolutionTemplateUpdateRoleByTrustRole() throws ServerResourceException {
 
-        String caller = "testApplySolutionTemplateRoleWithBothTrustAndMembers";
-        String domainName = "solutiontemplate-withtrustrole";
+        String caller = "testApplySolutionTemplateUpdateRoleByTrustRole";
+        String domainName = "solutiontemplate-updatetrustrole";
         TopLevelDomain dom1 = createTopLevelDomainObject(domainName,
                 "Test Domain1", "testOrg", adminUser);
         zms.postTopLevelDomain(mockDomRsrcCtx, auditRef, null, dom1);

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -23821,7 +23821,7 @@ public class ZMSImplTest {
         RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
 
         DomainTemplateDetailsList serverTemplateDetailsList = zmsImpl.getServerTemplateDetailsList(ctx);
-        assertEquals(serverTemplateDetailsList.getMetaData().size(), 15);
+        assertEquals(serverTemplateDetailsList.getMetaData().size(), 17);
         TemplateMetaData vipTemplateMetaData = null;
         for (TemplateMetaData templateMetaData : serverTemplateDetailsList.getMetaData()) {
             if (templateMetaData.getTemplateName().equals("vipng")) {
@@ -23840,7 +23840,7 @@ public class ZMSImplTest {
         RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
 
         DomainTemplateDetailsList serverTemplateDetailsList = zmsImpl.getServerTemplateDetailsList(ctx);
-        assertEquals(serverTemplateDetailsList.getMetaData().size(), 15);
+        assertEquals(serverTemplateDetailsList.getMetaData().size(), 17);
         List<TemplateMetaData> templates = serverTemplateDetailsList.getMetaData();
 
         String previousTemplateName = "";

--- a/servers/zms/src/test/resources/solution_templates.json
+++ b/servers/zms/src/test/resources/solution_templates.json
@@ -657,6 +657,43 @@
             ],
             "policies": [
             ]
+        },
+        "template_role_with_both_trust_and_members": {
+            "metadata":
+            {
+                "latestVersion": 1,
+                "timestamp": "2024-02-15T00:00:00.000Z",
+                "description": "TemplateRoleTest",
+                "autoUpdate": false
+            },
+            "roles": [
+                {
+                    "name": "_domain_:role.trust-and-members",
+                    "description": "Role for Testing",
+                    "trust": "sys.network",
+                    "roleMembers": [
+                            {
+                                "memberName": "sys.builder"
+                            }
+                    ]
+                }
+            ]
+        },
+        "template_trust_role": {
+            "metadata":
+            {
+                "latestVersion": 1,
+                "timestamp": "2024-02-15T00:00:00.000Z",
+                "description": "TemplateRoleTest",
+                "autoUpdate": false
+            },
+            "roles": [
+                {
+                    "name": "_domain_:role.target-role",
+                    "description": "Role for Testing",
+                    "trust": "sys.network"
+                }
+            ]
         }
     }
 }


### PR DESCRIPTION
# Description
When creating or editing a Role with the Trust field set via SolutionTemplate, a role is created that has both Trust and role members. We confirmed the problem mainly in the following two patterns:

* Adding a SolutionTemplate that sets both RoleMember and Trust to the server and using it.
* Applying a SolutionTemplate that sets Trust to an already-created role that already has members.

This change fixes the issue so that it does not occur in the patterns described above.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

