### PR TITLE
expose x509/ssh key id for instance register/refresh operations

### DIFF
--- a/clients/go/zts/model.go
+++ b/clients/go/zts/model.go
@@ -1139,6 +1139,11 @@ type RoleCertificateRequest struct {
 	// previous role certificate not after date
 	//
 	PrevCertNotAfter *rdl.Timestamp `json:"prevCertNotAfter,omitempty" rdl:"optional"`
+
+	//
+	// requested x509 cert signer key id
+	//
+	X509CertSignerKeyId SimpleName `json:"x509CertSignerKeyId,omitempty" rdl:"optional"`
 }
 
 // NewRoleCertificateRequest - creates an initialized RoleCertificateRequest instance, returns a pointer to it
@@ -1180,6 +1185,12 @@ func (self *RoleCertificateRequest) Validate() error {
 		val := rdl.Validate(ZTSSchema(), "EntityName", self.ProxyForPrincipal)
 		if !val.Valid {
 			return fmt.Errorf("RoleCertificateRequest.proxyForPrincipal does not contain a valid EntityName (%v)", val.Error)
+		}
+	}
+	if self.X509CertSignerKeyId != "" {
+		val := rdl.Validate(ZTSSchema(), "SimpleName", self.X509CertSignerKeyId)
+		if !val.Valid {
+			return fmt.Errorf("RoleCertificateRequest.x509CertSignerKeyId does not contain a valid SimpleName (%v)", val.Error)
 		}
 	}
 	return nil
@@ -1499,6 +1510,11 @@ type InstanceRefreshRequest struct {
 	// azure / openstack etc.
 	//
 	Cloud SimpleName `json:"cloud,omitempty" rdl:"optional"`
+
+	//
+	// requested x509 cert signer key id
+	//
+	X509CertSignerKeyId SimpleName `json:"x509CertSignerKeyId,omitempty" rdl:"optional"`
 }
 
 // NewInstanceRefreshRequest - creates an initialized InstanceRefreshRequest instance, returns a pointer to it
@@ -1552,6 +1568,12 @@ func (self *InstanceRefreshRequest) Validate() error {
 		val := rdl.Validate(ZTSSchema(), "SimpleName", self.Cloud)
 		if !val.Valid {
 			return fmt.Errorf("InstanceRefreshRequest.cloud does not contain a valid SimpleName (%v)", val.Error)
+		}
+	}
+	if self.X509CertSignerKeyId != "" {
+		val := rdl.Validate(ZTSSchema(), "SimpleName", self.X509CertSignerKeyId)
+		if !val.Valid {
+			return fmt.Errorf("InstanceRefreshRequest.x509CertSignerKeyId does not contain a valid SimpleName (%v)", val.Error)
 		}
 	}
 	return nil
@@ -2947,6 +2969,16 @@ type InstanceRegisterInformation struct {
 	// azure / openstack etc.
 	//
 	Cloud SimpleName `json:"cloud,omitempty" rdl:"optional"`
+
+	//
+	// requested x509 cert signer key id
+	//
+	X509CertSignerKeyId SimpleName `json:"x509CertSignerKeyId,omitempty" rdl:"optional"`
+
+	//
+	// requested ssh cert signer key id
+	//
+	SshCertSignerKeyId SimpleName `json:"sshCertSignerKeyId,omitempty" rdl:"optional"`
 }
 
 // NewInstanceRegisterInformation - creates an initialized InstanceRegisterInformation instance, returns a pointer to it
@@ -3040,6 +3072,18 @@ func (self *InstanceRegisterInformation) Validate() error {
 			return fmt.Errorf("InstanceRegisterInformation.cloud does not contain a valid SimpleName (%v)", val.Error)
 		}
 	}
+	if self.X509CertSignerKeyId != "" {
+		val := rdl.Validate(ZTSSchema(), "SimpleName", self.X509CertSignerKeyId)
+		if !val.Valid {
+			return fmt.Errorf("InstanceRegisterInformation.x509CertSignerKeyId does not contain a valid SimpleName (%v)", val.Error)
+		}
+	}
+	if self.SshCertSignerKeyId != "" {
+		val := rdl.Validate(ZTSSchema(), "SimpleName", self.SshCertSignerKeyId)
+		if !val.Valid {
+			return fmt.Errorf("InstanceRegisterInformation.sshCertSignerKeyId does not contain a valid SimpleName (%v)", val.Error)
+		}
+	}
 	return nil
 }
 
@@ -3109,6 +3153,16 @@ type InstanceRefreshInformation struct {
 	// azure / openstack etc.
 	//
 	Cloud SimpleName `json:"cloud,omitempty" rdl:"optional"`
+
+	//
+	// requested x509 cert signer key id
+	//
+	X509CertSignerKeyId SimpleName `json:"x509CertSignerKeyId,omitempty" rdl:"optional"`
+
+	//
+	// requested ssh cert signer key id
+	//
+	SshCertSignerKeyId SimpleName `json:"sshCertSignerKeyId,omitempty" rdl:"optional"`
 }
 
 // NewInstanceRefreshInformation - creates an initialized InstanceRefreshInformation instance, returns a pointer to it
@@ -3172,6 +3226,18 @@ func (self *InstanceRefreshInformation) Validate() error {
 		val := rdl.Validate(ZTSSchema(), "SimpleName", self.Cloud)
 		if !val.Valid {
 			return fmt.Errorf("InstanceRefreshInformation.cloud does not contain a valid SimpleName (%v)", val.Error)
+		}
+	}
+	if self.X509CertSignerKeyId != "" {
+		val := rdl.Validate(ZTSSchema(), "SimpleName", self.X509CertSignerKeyId)
+		if !val.Valid {
+			return fmt.Errorf("InstanceRefreshInformation.x509CertSignerKeyId does not contain a valid SimpleName (%v)", val.Error)
+		}
+	}
+	if self.SshCertSignerKeyId != "" {
+		val := rdl.Validate(ZTSSchema(), "SimpleName", self.SshCertSignerKeyId)
+		if !val.Valid {
+			return fmt.Errorf("InstanceRefreshInformation.sshCertSignerKeyId does not contain a valid SimpleName (%v)", val.Error)
 		}
 	}
 	return nil

--- a/clients/go/zts/zts_schema.go
+++ b/clients/go/zts/zts_schema.go
@@ -196,6 +196,7 @@ func init() {
 	tRoleCertificateRequest.Field("expiryTime", "Int64", false, nil, "request an expiry time for the role certificate")
 	tRoleCertificateRequest.Field("prevCertNotBefore", "Timestamp", true, nil, "previous role certificate not before date")
 	tRoleCertificateRequest.Field("prevCertNotAfter", "Timestamp", true, nil, "previous role certificate not after date")
+	tRoleCertificateRequest.Field("x509CertSignerKeyId", "SimpleName", true, nil, "requested x509 cert signer key id")
 	sb.AddType(tRoleCertificateRequest.Build())
 
 	tRoleAccess := rdl.NewStructTypeBuilder("Struct", "RoleAccess")
@@ -235,6 +236,7 @@ func init() {
 	tInstanceRefreshRequest.Field("keyId", "String", true, nil, "public key identifier")
 	tInstanceRefreshRequest.Field("namespace", "SimpleName", true, nil, "spiffe/k8s namespace value")
 	tInstanceRefreshRequest.Field("cloud", "SimpleName", true, nil, "optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.")
+	tInstanceRefreshRequest.Field("x509CertSignerKeyId", "SimpleName", true, nil, "requested x509 cert signer key id")
 	sb.AddType(tInstanceRefreshRequest.Build())
 
 	tAWSRoleName := rdl.NewStringTypeBuilder("AWSRoleName")
@@ -400,6 +402,8 @@ func init() {
 	tInstanceRegisterInformation.Field("athenzJWKModified", "Timestamp", true, nil, "return the public keys file only if modified after the given timestamp")
 	tInstanceRegisterInformation.Field("namespace", "SimpleName", true, nil, "spiffe/k8s namespace value")
 	tInstanceRegisterInformation.Field("cloud", "SimpleName", true, nil, "optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.")
+	tInstanceRegisterInformation.Field("x509CertSignerKeyId", "SimpleName", true, nil, "requested x509 cert signer key id")
+	tInstanceRegisterInformation.Field("sshCertSignerKeyId", "SimpleName", true, nil, "requested ssh cert signer key id")
 	sb.AddType(tInstanceRegisterInformation.Build())
 
 	tInstanceRefreshInformation := rdl.NewStructTypeBuilder("Struct", "InstanceRefreshInformation")
@@ -415,6 +419,8 @@ func init() {
 	tInstanceRefreshInformation.Field("athenzJWKModified", "Timestamp", true, nil, "return the public keys file only if modified after the given timestamp")
 	tInstanceRefreshInformation.Field("namespace", "SimpleName", true, nil, "spiffe/k8s namespace value")
 	tInstanceRefreshInformation.Field("cloud", "SimpleName", true, nil, "optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.")
+	tInstanceRefreshInformation.Field("x509CertSignerKeyId", "SimpleName", true, nil, "requested x509 cert signer key id")
+	tInstanceRefreshInformation.Field("sshCertSignerKeyId", "SimpleName", true, nil, "requested ssh cert signer key id")
 	sb.AddType(tInstanceRefreshInformation.Build())
 
 	tInstanceRegisterToken := rdl.NewStructTypeBuilder("Struct", "InstanceRegisterToken")

--- a/core/zts/src/main/java/com/yahoo/athenz/zts/InstanceRefreshInformation.java
+++ b/core/zts/src/main/java/com/yahoo/athenz/zts/InstanceRefreshInformation.java
@@ -49,6 +49,12 @@ public class InstanceRefreshInformation {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String cloud;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String x509CertSignerKeyId;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String sshCertSignerKeyId;
 
     public InstanceRefreshInformation setAttestationData(String attestationData) {
         this.attestationData = attestationData;
@@ -134,6 +140,20 @@ public class InstanceRefreshInformation {
     public String getCloud() {
         return cloud;
     }
+    public InstanceRefreshInformation setX509CertSignerKeyId(String x509CertSignerKeyId) {
+        this.x509CertSignerKeyId = x509CertSignerKeyId;
+        return this;
+    }
+    public String getX509CertSignerKeyId() {
+        return x509CertSignerKeyId;
+    }
+    public InstanceRefreshInformation setSshCertSignerKeyId(String sshCertSignerKeyId) {
+        this.sshCertSignerKeyId = sshCertSignerKeyId;
+        return this;
+    }
+    public String getSshCertSignerKeyId() {
+        return sshCertSignerKeyId;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -176,6 +196,12 @@ public class InstanceRefreshInformation {
                 return false;
             }
             if (cloud == null ? a.cloud != null : !cloud.equals(a.cloud)) {
+                return false;
+            }
+            if (x509CertSignerKeyId == null ? a.x509CertSignerKeyId != null : !x509CertSignerKeyId.equals(a.x509CertSignerKeyId)) {
+                return false;
+            }
+            if (sshCertSignerKeyId == null ? a.sshCertSignerKeyId != null : !sshCertSignerKeyId.equals(a.sshCertSignerKeyId)) {
                 return false;
             }
         }

--- a/core/zts/src/main/java/com/yahoo/athenz/zts/InstanceRefreshRequest.java
+++ b/core/zts/src/main/java/com/yahoo/athenz/zts/InstanceRefreshRequest.java
@@ -26,6 +26,9 @@ public class InstanceRefreshRequest {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String cloud;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String x509CertSignerKeyId;
 
     public InstanceRefreshRequest setCsr(String csr) {
         this.csr = csr;
@@ -62,6 +65,13 @@ public class InstanceRefreshRequest {
     public String getCloud() {
         return cloud;
     }
+    public InstanceRefreshRequest setX509CertSignerKeyId(String x509CertSignerKeyId) {
+        this.x509CertSignerKeyId = x509CertSignerKeyId;
+        return this;
+    }
+    public String getX509CertSignerKeyId() {
+        return x509CertSignerKeyId;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -83,6 +93,9 @@ public class InstanceRefreshRequest {
                 return false;
             }
             if (cloud == null ? a.cloud != null : !cloud.equals(a.cloud)) {
+                return false;
+            }
+            if (x509CertSignerKeyId == null ? a.x509CertSignerKeyId != null : !x509CertSignerKeyId.equals(a.x509CertSignerKeyId)) {
                 return false;
             }
         }

--- a/core/zts/src/main/java/com/yahoo/athenz/zts/InstanceRegisterInformation.java
+++ b/core/zts/src/main/java/com/yahoo/athenz/zts/InstanceRegisterInformation.java
@@ -48,6 +48,12 @@ public class InstanceRegisterInformation {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public String cloud;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String x509CertSignerKeyId;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String sshCertSignerKeyId;
 
     public InstanceRegisterInformation setProvider(String provider) {
         this.provider = provider;
@@ -154,6 +160,20 @@ public class InstanceRegisterInformation {
     public String getCloud() {
         return cloud;
     }
+    public InstanceRegisterInformation setX509CertSignerKeyId(String x509CertSignerKeyId) {
+        this.x509CertSignerKeyId = x509CertSignerKeyId;
+        return this;
+    }
+    public String getX509CertSignerKeyId() {
+        return x509CertSignerKeyId;
+    }
+    public InstanceRegisterInformation setSshCertSignerKeyId(String sshCertSignerKeyId) {
+        this.sshCertSignerKeyId = sshCertSignerKeyId;
+        return this;
+    }
+    public String getSshCertSignerKeyId() {
+        return sshCertSignerKeyId;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -205,6 +225,12 @@ public class InstanceRegisterInformation {
                 return false;
             }
             if (cloud == null ? a.cloud != null : !cloud.equals(a.cloud)) {
+                return false;
+            }
+            if (x509CertSignerKeyId == null ? a.x509CertSignerKeyId != null : !x509CertSignerKeyId.equals(a.x509CertSignerKeyId)) {
+                return false;
+            }
+            if (sshCertSignerKeyId == null ? a.sshCertSignerKeyId != null : !sshCertSignerKeyId.equals(a.sshCertSignerKeyId)) {
                 return false;
             }
         }

--- a/core/zts/src/main/java/com/yahoo/athenz/zts/RoleCertificateRequest.java
+++ b/core/zts/src/main/java/com/yahoo/athenz/zts/RoleCertificateRequest.java
@@ -27,6 +27,9 @@ public class RoleCertificateRequest {
     @RdlOptional
     @JsonInclude(JsonInclude.Include.NON_EMPTY)
     public Timestamp prevCertNotAfter;
+    @RdlOptional
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    public String x509CertSignerKeyId;
 
     public RoleCertificateRequest setCsr(String csr) {
         this.csr = csr;
@@ -63,6 +66,13 @@ public class RoleCertificateRequest {
     public Timestamp getPrevCertNotAfter() {
         return prevCertNotAfter;
     }
+    public RoleCertificateRequest setX509CertSignerKeyId(String x509CertSignerKeyId) {
+        this.x509CertSignerKeyId = x509CertSignerKeyId;
+        return this;
+    }
+    public String getX509CertSignerKeyId() {
+        return x509CertSignerKeyId;
+    }
 
     @Override
     public boolean equals(Object another) {
@@ -84,6 +94,9 @@ public class RoleCertificateRequest {
                 return false;
             }
             if (prevCertNotAfter == null ? a.prevCertNotAfter != null : !prevCertNotAfter.equals(a.prevCertNotAfter)) {
+                return false;
+            }
+            if (x509CertSignerKeyId == null ? a.x509CertSignerKeyId != null : !x509CertSignerKeyId.equals(a.x509CertSignerKeyId)) {
                 return false;
             }
         }

--- a/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
+++ b/core/zts/src/main/java/com/yahoo/athenz/zts/ZTSSchema.java
@@ -167,7 +167,8 @@ public class ZTSSchema {
             .field("proxyForPrincipal", "EntityName", true, "this request is proxy for this principal")
             .field("expiryTime", "Int64", false, "request an expiry time for the role certificate")
             .field("prevCertNotBefore", "Timestamp", true, "previous role certificate not before date")
-            .field("prevCertNotAfter", "Timestamp", true, "previous role certificate not after date");
+            .field("prevCertNotAfter", "Timestamp", true, "previous role certificate not after date")
+            .field("x509CertSignerKeyId", "SimpleName", true, "requested x509 cert signer key id");
 
         sb.structType("RoleAccess")
             .arrayField("roles", "EntityName", false, "");
@@ -200,7 +201,8 @@ public class ZTSSchema {
             .field("expiryTime", "Int32", true, "in minutes how long token should be valid for")
             .field("keyId", "String", true, "public key identifier")
             .field("namespace", "SimpleName", true, "spiffe/k8s namespace value")
-            .field("cloud", "SimpleName", true, "optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.");
+            .field("cloud", "SimpleName", true, "optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.")
+            .field("x509CertSignerKeyId", "SimpleName", true, "requested x509 cert signer key id");
 
         sb.stringType("AWSRoleName")
             .comment("AWS role name without the path")
@@ -345,7 +347,9 @@ public class ZTSSchema {
             .field("athenzJWK", "Bool", true, "if true, return an Athenz JWK public keys file")
             .field("athenzJWKModified", "Timestamp", true, "return the public keys file only if modified after the given timestamp")
             .field("namespace", "SimpleName", true, "spiffe/k8s namespace value")
-            .field("cloud", "SimpleName", true, "optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.");
+            .field("cloud", "SimpleName", true, "optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.")
+            .field("x509CertSignerKeyId", "SimpleName", true, "requested x509 cert signer key id")
+            .field("sshCertSignerKeyId", "SimpleName", true, "requested ssh cert signer key id");
 
         sb.structType("InstanceRefreshInformation")
             .field("attestationData", "String", true, "identity attestation data including document with its signature containing attributes like IP address, instance-id, account#, etc.")
@@ -359,7 +363,9 @@ public class ZTSSchema {
             .field("athenzJWK", "Bool", true, "if true, return an Athenz JWK public keys file")
             .field("athenzJWKModified", "Timestamp", true, "return the public keys file only if modified after the given timestamp")
             .field("namespace", "SimpleName", true, "spiffe/k8s namespace value")
-            .field("cloud", "SimpleName", true, "optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.");
+            .field("cloud", "SimpleName", true, "optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.")
+            .field("x509CertSignerKeyId", "SimpleName", true, "requested x509 cert signer key id")
+            .field("sshCertSignerKeyId", "SimpleName", true, "requested ssh cert signer key id");
 
         sb.structType("InstanceRegisterToken")
             .field("provider", "ServiceName", false, "provider service name")

--- a/core/zts/src/main/rdl/Identity.rdli
+++ b/core/zts/src/main/rdl/Identity.rdli
@@ -11,6 +11,7 @@ type InstanceRefreshRequest Struct {
      String keyId (optional); //public key identifier
      SimpleName namespace (optional); //spiffe/k8s namespace value
      SimpleName cloud (optional); //optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.
+     SimpleName x509CertSignerKeyId (optional); //requested x509 cert signer key id
 }
 
 // Refresh Service tokens into TLS Certificate

--- a/core/zts/src/main/rdl/Instance.rdli
+++ b/core/zts/src/main/rdl/Instance.rdli
@@ -21,6 +21,8 @@ type InstanceRegisterInformation Struct {
     Timestamp athenzJWKModified (optional); //return the public keys file only if modified after the given timestamp
     SimpleName namespace (optional); //spiffe/k8s namespace value
     SimpleName cloud (optional); //optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.
+    SimpleName x509CertSignerKeyId (optional); //requested x509 cert signer key id
+    SimpleName sshCertSignerKeyId (optional); //requested ssh cert signer key id
 }
 
 type InstanceRefreshInformation Struct {
@@ -36,6 +38,8 @@ type InstanceRefreshInformation Struct {
     Timestamp athenzJWKModified (optional); //return the public keys file only if modified after the given timestamp
     SimpleName namespace (optional); //spiffe/k8s namespace value
     SimpleName cloud (optional); //optional cloud name where the instance is bootstrapped. e.g. aws / gcp / azure / openstack etc.
+    SimpleName x509CertSignerKeyId (optional); //requested x509 cert signer key id
+    SimpleName sshCertSignerKeyId (optional); //requested ssh cert signer key id
 }
 
 type InstanceRegisterToken Struct {

--- a/core/zts/src/main/rdl/RoleCert.tdl
+++ b/core/zts/src/main/rdl/RoleCert.tdl
@@ -16,6 +16,7 @@ type RoleCertificateRequest Struct {
     Int64 expiryTime; //request an expiry time for the role certificate
     Timestamp prevCertNotBefore (optional); //previous role certificate not before date
     Timestamp prevCertNotAfter (optional); //previous role certificate not after date
+    SimpleName x509CertSignerKeyId (optional); //requested x509 cert signer key id
 }
 
 type RoleAccess Struct {

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRefreshInformationTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRefreshInformationTest.java
@@ -46,6 +46,8 @@ public class InstanceRefreshInformationTest {
         i1.setAthenzJWKModified(start);
         i1.setNamespace("default");
         i1.setCloud("aws");
+        i1.setX509CertSignerKeyId("x509KeyId");
+        i1.setSshCertSignerKeyId("sshKeyId");
 
         i2.setAttestationData("doc");
         i2.setCsr("sample_csr");
@@ -59,6 +61,8 @@ public class InstanceRefreshInformationTest {
         i2.setAthenzJWKModified(start);
         i2.setNamespace("default");
         i2.setCloud("aws");
+        i2.setX509CertSignerKeyId("x509KeyId");
+        i2.setSshCertSignerKeyId("sshKeyId");
 
         // getter assertion
         assertEquals(i1.getAttestationData(), "doc");
@@ -73,6 +77,8 @@ public class InstanceRefreshInformationTest {
         assertEquals(i1.getAthenzJWKModified(), start);
         assertEquals(i1.getNamespace(), "default");
         assertEquals(i1.getCloud(), "aws");
+        assertEquals(i1.getX509CertSignerKeyId(), "x509KeyId");
+        assertEquals(i1.getSshCertSignerKeyId(), "sshKeyId");
 
         assertEquals(i2, i1);
         assertEquals(i2, i2);
@@ -162,6 +168,20 @@ public class InstanceRefreshInformationTest {
         i2.setCloud("gcp");
         assertNotEquals(i1, i2);
         i2.setCloud("aws");
+        assertEquals(i1, i2);
+
+        i2.setX509CertSignerKeyId(null);
+        assertNotEquals(i1, i2);
+        i2.setX509CertSignerKeyId("keyid");
+        assertNotEquals(i1, i2);
+        i2.setX509CertSignerKeyId("x509KeyId");
+        assertEquals(i1, i2);
+
+        i2.setSshCertSignerKeyId(null);
+        assertNotEquals(i1, i2);
+        i2.setSshCertSignerKeyId("keyid");
+        assertNotEquals(i1, i2);
+        i2.setSshCertSignerKeyId("sshKeyId");
         assertEquals(i1, i2);
     }
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRefreshRequestTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRefreshRequestTest.java
@@ -31,6 +31,7 @@ public class InstanceRefreshRequestTest {
         i1.setKeyId("v0");
         i1.setNamespace("default");
         i1.setCloud("aws");
+        i1.setX509CertSignerKeyId("x509KeyId");
 
         InstanceRefreshRequest i2 = new InstanceRefreshRequest();
         i2.setCsr("test_csr");
@@ -38,6 +39,7 @@ public class InstanceRefreshRequestTest {
         i2.setKeyId("v0");
         i2.setNamespace("default");
         i2.setCloud("aws");
+        i2.setX509CertSignerKeyId("x509KeyId");
 
         // getter
         assertEquals(i1.getCsr(), "test_csr");
@@ -45,6 +47,7 @@ public class InstanceRefreshRequestTest {
         assertEquals(i1.getKeyId(), "v0");
         assertEquals(i1.getNamespace(), "default");
         assertEquals(i1.getCloud(), "aws");
+        assertEquals(i1.getX509CertSignerKeyId(), "x509KeyId");
 
         assertEquals(i1, i1);
         assertEquals(i2, i1);
@@ -79,6 +82,13 @@ public class InstanceRefreshRequestTest {
         i2.setCloud("gcp");
         assertNotEquals(i1, i2);
         i2.setCloud("aws");
+        assertEquals(i1, i2);
+
+        i2.setX509CertSignerKeyId(null);
+        assertNotEquals(i1, i2);
+        i2.setX509CertSignerKeyId("keyid");
+        assertNotEquals(i1, i2);
+        i2.setX509CertSignerKeyId("x509KeyId");
         assertEquals(i1, i2);
 
         assertNotEquals("data", i1);

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRegisterInformationTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/InstanceRegisterInformationTest.java
@@ -49,6 +49,8 @@ public class InstanceRegisterInformationTest {
         i1.setAthenzJWKModified(start);
         i1.setNamespace("default");
         i1.setCloud("aws");
+        i1.setX509CertSignerKeyId("x509KeyId");
+        i1.setSshCertSignerKeyId("sshKeyId");
 
         i2.setProvider("provider");
         i2.setAttestationData("doc");
@@ -65,6 +67,8 @@ public class InstanceRegisterInformationTest {
         i2.setAthenzJWKModified(start);
         i2.setNamespace("default");
         i2.setCloud("aws");
+        i2.setX509CertSignerKeyId("x509KeyId");
+        i2.setSshCertSignerKeyId("sshKeyId");
 
         // getter assertion
         assertEquals(i1.getAttestationData(), "doc");
@@ -82,6 +86,8 @@ public class InstanceRegisterInformationTest {
         assertEquals(i1.getAthenzJWKModified(), start);
         assertEquals(i1.getNamespace(), "default");
         assertEquals(i1.getCloud(), "aws");
+        assertEquals(i1.getX509CertSignerKeyId(), "x509KeyId");
+        assertEquals(i1.getSshCertSignerKeyId(), "sshKeyId");
 
         assertEquals(i2, i1);
         assertEquals(i2, i2);
@@ -192,6 +198,20 @@ public class InstanceRegisterInformationTest {
         i2.setCloud("gcp");
         assertNotEquals(i1, i2);
         i2.setCloud("aws");
+        assertEquals(i1, i2);
+
+        i2.setX509CertSignerKeyId(null);
+        assertNotEquals(i1, i2);
+        i2.setX509CertSignerKeyId("keyid");
+        assertNotEquals(i1, i2);
+        i2.setX509CertSignerKeyId("x509KeyId");
+        assertEquals(i1, i2);
+
+        i2.setSshCertSignerKeyId(null);
+        assertNotEquals(i1, i2);
+        i2.setSshCertSignerKeyId("keyid");
+        assertNotEquals(i1, i2);
+        i2.setSshCertSignerKeyId("sshKeyId");
         assertEquals(i1, i2);
     }
 }

--- a/core/zts/src/test/java/com/yahoo/athenz/zts/RoleCertificateRequestTest.java
+++ b/core/zts/src/test/java/com/yahoo/athenz/zts/RoleCertificateRequestTest.java
@@ -32,6 +32,7 @@ public class RoleCertificateRequestTest {
         data1.setPrevCertNotBefore(Timestamp.fromMillis(100));
         data1.setPrevCertNotAfter(Timestamp.fromMillis(100));
         data1.setExpiryTime(200);
+        data1.setX509CertSignerKeyId("keyid");
 
         RoleCertificateRequest data2 = new RoleCertificateRequest();
         data2.setCsr("csr1");
@@ -39,16 +40,18 @@ public class RoleCertificateRequestTest {
         data2.setPrevCertNotBefore(Timestamp.fromMillis(100));
         data2.setPrevCertNotAfter(Timestamp.fromMillis(100));
         data2.setExpiryTime(200);
+        data2.setX509CertSignerKeyId("keyid");
 
         assertEquals(data1, data1);
         assertEquals(data1, data2);
 
         // verify getters
-        assertEquals("csr1", data2.getCsr());
-        assertEquals(200, data2.getExpiryTime());
+        assertEquals(data2.getCsr(), "csr1");
+        assertEquals(data2.getExpiryTime(), 200);
         assertEquals(Timestamp.fromMillis(100), data2.getPrevCertNotAfter());
         assertEquals(Timestamp.fromMillis(100), data2.getPrevCertNotBefore());
-        assertEquals("proxy", data2.getProxyForPrincipal());
+        assertEquals(data2.getProxyForPrincipal(), "proxy");
+        assertEquals(data2.getX509CertSignerKeyId(), "keyid");
 
         data2.setExpiryTime(101);
         assertNotEquals(data1, data2);
@@ -77,6 +80,12 @@ public class RoleCertificateRequestTest {
         data2.setPrevCertNotAfter(null);
         assertNotEquals(data1, data2);
         data2.setPrevCertNotAfter(Timestamp.fromMillis(100));
+
+        data2.setX509CertSignerKeyId("keyid2");
+        assertNotEquals(data1, data2);
+        data2.setX509CertSignerKeyId(null);
+        assertNotEquals(data1, data2);
+        data2.setX509CertSignerKeyId("keyid");
 
         assertNotEquals(data1, null);
         assertNotEquals("data", data2);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -15339,8 +15339,13 @@ public class ZTSImplTest {
 
         // unknown domains return null
 
-        assertNull(ztsImpl.getPrincipalDomainSignerKeyId(null, "unknown_domain", "service1", false));
-        assertNull(ztsImpl.getPrincipalDomainSignerKeyId(null, "unknown_domain", "service1", true));
+        assertNull(ztsImpl.getPrincipalDomainSignerKeyId(null, "unknown_domain", "service1", null, false));
+        assertNull(ztsImpl.getPrincipalDomainSignerKeyId(null, "unknown_domain", "service1", null, true));
+
+        // with specified key id we'll get that value back
+
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "unknown_domain", "service1", "svc-x509", false), "svc-x509");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "unknown_domain", "service1", "ssh-x509", true), "ssh-x509");
 
         // add a new domain
 
@@ -15351,11 +15356,13 @@ public class ZTSImplTest {
 
         // get the x509 key id
 
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", true), "x509-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", null, true), "x509-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", "keyid", true), "x509-keyid");
 
         // get the ssh key id
 
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", false), "ssh-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", null, true), "x509-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", "keyid", true), "x509-keyid");
 
         // now let's add service specific keys, our first service item
         // in the list is the one we want to modify
@@ -15366,30 +15373,36 @@ public class ZTSImplTest {
 
         // get the x509 key id - for the backup and unknown service we'll get the domain value
 
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", true), "svc-x509");
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "backup", true), "x509-keyid");
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "unknown", true), "x509-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", null, true), "svc-x509");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", "keyid", true), "svc-x509");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "backup", null, true), "x509-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "backup", "keyid", true), "x509-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "backup", null, true), "x509-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "backup", "keyid", true), "x509-keyid");
 
         // get the ssh key id - for the backup and unknown service we'll get the domain value
 
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", false), "svc-ssh");
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "backup", false), "ssh-keyid");
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "unknown", false), "ssh-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", null, false), "svc-ssh");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", "keyid", false), "svc-ssh");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "backup", null, false), "ssh-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "backup", "keyid", false), "ssh-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "unknown", null, false), "ssh-keyid");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "unknown", "keyid", false), "ssh-keyid");
 
         // now let's try checks with domain tags to ignore the setting
         // with no domain data we should get the service specific key id
 
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", true), "svc-x509");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(null, "coretech", "api", null, true), "svc-x509");
 
         // with valid domain data but no tags, we should get the service specific key id
 
         DomainData domainData = new DomainData().setTags(null);
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", true), "svc-x509");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", null, true), "svc-x509");
 
         // with tags set but no values in the tag, we should get the service specific key id
 
         domainData.setTags(new HashMap<>());
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", true), "svc-x509");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", null, true), "svc-x509");
 
         // with tags set and the value set to true, we should get the service specific key id
 
@@ -15398,17 +15411,17 @@ public class ZTSImplTest {
         tagValueList.setList(Collections.singletonList("true"));
         tags.put("zts.RoleCertUseDomainSignerKeyId", tagValueList);
         domainData.setTags(tags);
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", true), "svc-x509");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", null, true), "svc-x509");
 
         // now with the domain signer key set, we must get that value back
 
         domainData.setX509CertSignerKeyId("dom-x509");
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", true), "dom-x509");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", null, true), "dom-x509");
 
         // with tags set and the value set to false, we should get the service specific key id
 
         tagValueList.setList(Collections.singletonList("false"));
-        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", true), "svc-x509");
+        assertEquals(ztsImpl.getPrincipalDomainSignerKeyId(domainData, "coretech", "api", null, true), "svc-x509");
     }
 
     @Test
@@ -15661,5 +15674,237 @@ public class ZTSImplTest {
         assertNull(ztsImpl.serviceCredsEncryptionKey);
 
         System.clearProperty(ZTSConsts.ZTS_PROP_SVC_CREDS_KEY_NAME);
+    }
+
+    @Test
+    public void testGetServiceX509KeySignerIdWithServiceIdentity() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setX509CertSignerKeyId("domain-x509-key-id");
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setX509CertSignerKeyId("service-x509-key-id");
+
+        // Test case 1: serviceIdentity has X509CertSignerKeyId - should return service's keyId
+        String result = ztsImpl.getServiceX509KeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "service-x509-key-id");
+    }
+
+    @Test
+    public void testGetServiceX509KeySignerIdWithNullServiceIdentity() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setX509CertSignerKeyId("domain-x509-key-id");
+
+        // Test case 2: serviceIdentity is null - should return domain's keyId
+        String result = ztsImpl.getServiceX509KeySignerId(domainData, null, "request-key-id");
+        assertEquals(result, "domain-x509-key-id");
+    }
+
+    @Test
+    public void testGetServiceX509KeySignerIdWithEmptyServiceKeyId() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setX509CertSignerKeyId("domain-x509-key-id");
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setX509CertSignerKeyId("");
+
+        // Test case 3: serviceIdentity has empty X509CertSignerKeyId - should return domain's keyId
+        String result = ztsImpl.getServiceX509KeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "domain-x509-key-id");
+    }
+
+    @Test
+    public void testGetServiceX509KeySignerIdWithAllEmpty() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setX509CertSignerKeyId(null);
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setX509CertSignerKeyId(null);
+
+        // Test case 4: both serviceIdentity and domainData have null keyIds - should return requestSignerKeyId
+        String result = ztsImpl.getServiceX509KeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "request-key-id");
+    }
+
+    @Test
+    public void testGetServiceX509KeySignerIdWithEmptyDomainKeyId() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setX509CertSignerKeyId("");
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setX509CertSignerKeyId(null);
+
+        // Test case 5: domainData has empty keyId and serviceIdentity has null - should return requestSignerKeyId
+        String result = ztsImpl.getServiceX509KeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "request-key-id");
+    }
+
+    @Test
+    public void testGetServiceX509KeySignerIdPreferServiceOverDomain() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setX509CertSignerKeyId("domain-x509-key-id");
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setX509CertSignerKeyId("service-x509-key-id");
+
+        // Test case 6: both have keyIds - should prefer serviceIdentity's keyId
+        String result = ztsImpl.getServiceX509KeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "service-x509-key-id");
+    }
+
+    @Test
+    public void testGetServiceSshKeySignerIdWithServiceIdentity() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setSshCertSignerKeyId("domain-ssh-key-id");
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setSshCertSignerKeyId("service-ssh-key-id");
+
+        // Test case 1: serviceIdentity has SshCertSignerKeyId - should return service's keyId
+        String result = ztsImpl.getServiceSshKeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "service-ssh-key-id");
+    }
+
+    @Test
+    public void testGetServiceSshKeySignerIdWithNullServiceIdentity() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setSshCertSignerKeyId("domain-ssh-key-id");
+
+        // Test case 2: serviceIdentity is null - should return domain's keyId
+        String result = ztsImpl.getServiceSshKeySignerId(domainData, null, "request-key-id");
+        assertEquals(result, "domain-ssh-key-id");
+    }
+
+    @Test
+    public void testGetServiceSshKeySignerIdWithEmptyServiceKeyId() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setSshCertSignerKeyId("domain-ssh-key-id");
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setSshCertSignerKeyId("");
+
+        // Test case 3: serviceIdentity has empty SshCertSignerKeyId - should return domain's keyId
+        String result = ztsImpl.getServiceSshKeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "domain-ssh-key-id");
+    }
+
+    @Test
+    public void testGetServiceSshKeySignerIdWithAllEmpty() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setSshCertSignerKeyId(null);
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setSshCertSignerKeyId(null);
+
+        // Test case 4: both serviceIdentity and domainData have null keyIds - should return requestSignerKeyId
+        String result = ztsImpl.getServiceSshKeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "request-key-id");
+    }
+
+    @Test
+    public void testGetServiceSshKeySignerIdWithEmptyDomainKeyId() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setSshCertSignerKeyId("");
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setSshCertSignerKeyId(null);
+
+        // Test case 5: domainData has empty keyId and serviceIdentity has null - should return requestSignerKeyId
+        String result = ztsImpl.getServiceSshKeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "request-key-id");
+    }
+
+    @Test
+    public void testGetServiceSshKeySignerIdPreferServiceOverDomain() {
+        ChangeLogStore structStore = new MockZMSFileChangeLogStore("/tmp/zts_server_unit_tests/zts_root",
+                privateKey, "0");
+        DataStore store = new DataStore(structStore, null, ztsMetric);
+        ZTSImpl ztsImpl = new ZTSImpl(mockCloudStore, store);
+
+        DomainData domainData = new DomainData();
+        domainData.setName("testdomain");
+        domainData.setSshCertSignerKeyId("domain-ssh-key-id");
+
+        com.yahoo.athenz.zms.ServiceIdentity serviceIdentity = new com.yahoo.athenz.zms.ServiceIdentity();
+        serviceIdentity.setName("testdomain.service1");
+        serviceIdentity.setSshCertSignerKeyId("service-ssh-key-id");
+
+        // Test case 6: both have keyIds - should prefer serviceIdentity's keyId
+        String result = ztsImpl.getServiceSshKeySignerId(domainData, serviceIdentity, "request-key-id");
+        assertEquals(result, "service-ssh-key-id");
     }
 }


### PR DESCRIPTION
# Description

The ZTS server has the capability to enforce a specific x509/ssh keyid to be used when issuing certificates for a specific service and/or domain. However, this requires the system administrator to set this value. If the service admin wants to run some tests they have no capability to request with a specific id. They have to ask the system admin to enable the option for a service, run some tests and then disable it if this was only for testing. Now, we're exposing the key id parameters for instance register and refresh and role certificate requests. With this requirement, the caller must specify the correct value.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

