### PR TITLE
convert filter argument in resource access list to string from SimpleName

### DIFF
--- a/clients/go/zms/client.go
+++ b/clients/go/zms/client.go
@@ -3723,7 +3723,7 @@ func (client ZMSClient) GetAccessExt(action ActionName, resource string, domain 
 	}
 }
 
-func (client ZMSClient) GetResourceAccessList(principal ResourceName, action ActionName, filter SimpleName) (*ResourceAccessList, error) {
+func (client ZMSClient) GetResourceAccessList(principal ResourceName, action ActionName, filter string) (*ResourceAccessList, error) {
 	var data *ResourceAccessList
 	url := client.URL + "/resource" + encodeParams(encodeStringParam("principal", string(principal), ""), encodeStringParam("action", string(action), ""), encodeStringParam("filter", string(filter), ""))
 	resp, err := client.httpGet(url, nil)

--- a/clients/go/zms/zms_schema.go
+++ b/clients/go/zms/zms_schema.go
@@ -2697,7 +2697,7 @@ func init() {
 	mGetResourceAccessList.Comment("Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified")
 	mGetResourceAccessList.Input("principal", "ResourceName", false, "principal", "", true, nil, "specifies principal to query the resource list for")
 	mGetResourceAccessList.Input("action", "ActionName", false, "action", "", true, nil, "action as specified in the policy assertion")
-	mGetResourceAccessList.Input("filter", "SimpleName", false, "filter", "", true, nil, "resource filter for specific subset of resources")
+	mGetResourceAccessList.Input("filter", "String", false, "filter", "", true, nil, "resource filter for specific subset of resources")
 	mGetResourceAccessList.Auth("", "", true, "")
 	mGetResourceAccessList.Exception("BAD_REQUEST", "ResourceError", "")
 	mGetResourceAccessList.Exception("FORBIDDEN", "ResourceError", "")

--- a/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
+++ b/core/zms/src/main/java/com/yahoo/athenz/zms/ZMSSchema.java
@@ -3028,7 +3028,7 @@ public class ZMSSchema {
             .comment("Return list of resources that the given principal has access to. Even though the principal is marked as optional, it must be specified")
             .queryParam("principal", "principal", "ResourceName", null, "specifies principal to query the resource list for")
             .queryParam("action", "action", "ActionName", null, "action as specified in the policy assertion")
-            .queryParam("filter", "filter", "SimpleName", null, "resource filter for specific subset of resources")
+            .queryParam("filter", "filter", "String", null, "resource filter for specific subset of resources")
             .auth("", "", true)
             .expected("OK")
             .exception("BAD_REQUEST", "ResourceError", "")

--- a/core/zms/src/main/rdl/Access.rdli
+++ b/core/zms/src/main/rdl/Access.rdli
@@ -66,7 +66,7 @@ type ResourceAccessList Struct {
 resource ResourceAccessList GET "/resource?principal={principal}&action={action}&filter={filter}" {
     ResourceName principal (optional); //specifies principal to query the resource list for
     ActionName action (optional); //action as specified in the policy assertion
-    SimpleName filter (optional); //resource filter for specific subset of resources
+    String filter (optional); //resource filter for specific subset of resources
     authenticate;
     expected OK;
     exceptions {

--- a/libs/go/zmscli/access.go
+++ b/libs/go/zmscli/access.go
@@ -87,7 +87,7 @@ func (cli Zms) ShowAccessExt(dn string, action string, resource string, altIdent
 }
 
 func (cli Zms) ShowResourceAccess(principal, action, filter string) (*string, error) {
-	rsrcAccessList, err := cli.Zms.GetResourceAccessList(zms.ResourceName(principal), zms.ActionName(action), zms.SimpleName(filter))
+	rsrcAccessList, err := cli.Zms.GetResourceAccessList(zms.ResourceName(principal), zms.ActionName(action), filter)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description

the filter argument was defined as SimpleName which is too restrictive. If we want to filter on gcp project id that has value, for example, "abc:prod.project", the validation fails since that's not a simple name. it was converted to String for better support.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

