### PR TITLE
fix the order of cert and key in function call

### DIFF
--- a/libs/go/sia/util/util.go
+++ b/libs/go/sia/util/util.go
@@ -1430,7 +1430,7 @@ func TouchDoneFile(fileDir, fileName string) error {
 }
 
 func GetRoleCertificate(athenzDomain, athenzService, instanceId, athenzProvider, roleName, ztsUrl string, expiryTime int64, sanDNSDomains []string, spiffeTrustDomain string, csrSubjectFields CsrSubjectFields, svcTLSCert *SiaCertData, rolePrincipalEmail bool) (*SiaCertData, error) {
-	client, err := ZtsmTLSClient(ztsUrl, []byte(svcTLSCert.X509CertificatePem), []byte(svcTLSCert.PrivateKeyPem), nil)
+	client, err := ZtsmTLSClient(ztsUrl, []byte(svcTLSCert.PrivateKeyPem), []byte(svcTLSCert.X509CertificatePem), nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description
Geminis words: This pull request resolves a critical issue where the certificate and private key were inadvertently swapped when passed to the ZtsmTLSClient function. This fix ensures that the TLS client is correctly initialized, which is essential for the proper functioning of role certificate retrieval.


# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

