### PR TITLE
remove filter validation for simple name for resource access list

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -10129,10 +10129,6 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             action = action.toLowerCase();
         }
 
-        if (!StringUtil.isEmpty(filter)) {
-            validate(filter, TYPE_SIMPLE_NAME, caller);
-        }
-
         return dbService.getResourceAccessList(principal, action, filter);
     }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -17782,15 +17782,6 @@ public class ZMSImplTest {
         } catch (Exception ex) {
             assertTrue(true);
         }
-
-        // invalid filter value
-        try {
-            zmsImpl.getResourceAccessList(rsrcCtx1, "principal", "DELETE", "invalid () fitler");
-            fail();
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 400);
-            assertTrue(ex.getMessage().contains("Invalid SimpleName error"));
-        }
     }
 
     @Test


### PR DESCRIPTION
# Description

the filter attribute definition was changed in pr #3097 to be just a string but the server code was not removed that validates the value is a simple name.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

