### PR TITLE
allow to return jag token with subset of scopes

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2666,9 +2666,9 @@ public class ZTSImpl implements ZTSHandler {
         Set<String> subjectRoles = new HashSet<>();
         dataStore.getAccessibleRoles(data, domainName, subjectIdentity, requestedRoles, false, subjectRoles, false);
 
-        // we return failure if we don't have access to all the roles requested
+        // we return failure if we don't have access to any roles
 
-        if (subjectRoles.size() != requestedRoles.length) {
+        if (subjectRoles.isEmpty()) {
             throw forbiddenError(tokenErrorMessage(caller, subjectIdentity, domainName, requestedRoles),
                     caller, domainName, principalDomain);
         }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -3028,23 +3028,22 @@ public class ZTSImplAccessTokenTest {
         ResourceContext context = createResourceContext(principal);
         TokenConfigOptions tokenConfigOptions = createTokenConfigOptions(ztsImpl);
 
-        try {
-            // Request both roles but subject only has access to one
-            AccessTokenRequest accessTokenRequest = new AccessTokenRequest(
-                    "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
-                    + "&requested_token_type=urn:ietf:params:oauth:token-type:id-jag"
-                    + "&subject_token=" + subjectToken + "&audience=https://athenz.io"
-                    + "&subject_token_type=urn:ietf:params:oauth:token-type:id_token"
-                    + "&scope=coretech:role.writers coretech:role.readers",
-                    tokenConfigOptions);
+        // Request both roles but subject only has access to one
+        AccessTokenRequest accessTokenRequest = new AccessTokenRequest(
+                "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
+                + "&requested_token_type=urn:ietf:params:oauth:token-type:id-jag"
+                + "&subject_token=" + subjectToken + "&audience=https://athenz.io"
+                + "&subject_token_type=urn:ietf:params:oauth:token-type:id_token"
+                + "&scope=coretech:role.writers coretech:role.readers",
+                tokenConfigOptions);
 
-            ztsImpl.processJAGTokenIssueRequest(context, principal,
-                    accessTokenRequest, "user_domain", "postAccessTokenRequest");
-            fail("Expected ResourceException for partial access");
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), ResourceException.FORBIDDEN);
-        }
-        
+        AccessTokenResponse response = ztsImpl.processJAGTokenIssueRequest(context, principal,
+                accessTokenRequest, "user_domain", "postAccessTokenRequest");
+        assertNotNull(response);
+
+        // verify the response contains a single scope in the response
+
+        assertEquals(response.getScope(), "coretech:role.writers");
         cloudStore.close();
     }
 


### PR DESCRIPTION
# Description

since the mcp client might ask for multiple roles, there is no need to reject the jag issue token if the user only has a subset of role access. instead we'll just return the subset. #3100 

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

