### PR TITLE
Use httptest and http packages to run test servers

### DIFF
--- a/libs/go/sia/aws/meta/meta_test.go
+++ b/libs/go/sia/aws/meta/meta_test.go
@@ -17,7 +17,6 @@
 package meta
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"net/http"


### PR DESCRIPTION
# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

The current code 

1. Requires manual configuration of a port/IP address to listen on, which can be a problem for some environments (e.g. behind a proxy setup)
2. Uses the httptreemux project which is deprecated, when std packages could do this same work

This PR uses the net/http/httptest framework and http std packages only and removes the custom server code. If this PR is approved, there are something like another 10 places where this approach could be used - if you like this change, I'll make those changes in a larger, separate PR.
 
# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**
- [x] **Re-ran tests.**

## Attach Screenshots (Optional) 

