### PR TITLE
Refactor: Optimize validation order in `validateRoleStructure()`

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -4584,11 +4584,6 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         if (!StringUtil.isEmpty(role.getTrust())) {
 
-            AthenzDomain athenzDomain = getAthenzDomain(role.getTrust(), true);
-            if (athenzDomain == null) {
-                throw ZMSUtils.requestError("Delegated role assigned to non existing domain", caller);
-            }
-
             if (!ZMSUtils.isCollectionEmpty(role.getRoleMembers())) {
                 throw ZMSUtils.requestError("validateRoleMembers: Role cannot have both roleMembers and delegated domain set", caller);
             }
@@ -4599,6 +4594,10 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
             if (domainName.equals(role.getTrust())) {
                 throw ZMSUtils.requestError("validateRoleMembers: Role cannot be delegated to itself", caller);
+            }
+
+            if (getAthenzDomain(role.getTrust(), true) == null) {
+                throw ZMSUtils.requestError("Delegated role assigned to non existing domain", caller);
             }
         }
     }


### PR DESCRIPTION
# Background
While diving into the source code, I noticed a small optimization opportunity in `validateRoleStructure()`.

## What's done

- **Deferred DB I/O**: Moved `getAthenzDomain()` (that takes DB lookup) to the end of the block. We should fail fast on structural errors (like self-delegation) before making any external calls
- **Cleanup**: Removed the unnecessary variable definition `athenzDomain` since it was being used only once

It's a minor change since these validation errors are extremely rare to happen, but it keeps the logic cleaner and more optimal just in case.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

