### PR TITLE
Fix the FQDN regexp of StaticWorkloadName

### DIFF
--- a/clients/go/msd/msd_schema.go
+++ b/clients/go/msd/msd_schema.go
@@ -122,19 +122,19 @@ func init() {
 	sb.AddType(tTransportPolicySubjectServiceName.Build())
 
 	tStaticWorkloadComponent := rdl.NewStringTypeBuilder("StaticWorkloadComponent")
-	tStaticWorkloadComponent.Pattern("[a-zA-Z0-9][a-zA-Z0-9-:._]*")
+	tStaticWorkloadComponent.Pattern("[A-Za-z0-9][A-Za-z0-9:_\\.-]*")
 	sb.AddType(tStaticWorkloadComponent.Build())
 
 	tStaticWorkloadFQDN := rdl.NewStringTypeBuilder("StaticWorkloadFQDN")
-	tStaticWorkloadFQDN.Pattern("([a-zA-Z0-9][a-zA-Z0-9-:._]*\\.)*[a-zA-Z0-9][a-zA-Z0-9-:._]*")
+	tStaticWorkloadFQDN.Pattern("([A-Za-z0-9][A-Za-z0-9:_\\.-]*\\.)*[A-Za-z0-9][A-Za-z0-9:_\\.-]*")
 	sb.AddType(tStaticWorkloadFQDN.Build())
 
 	tStaticWorkloadName := rdl.NewStringTypeBuilder("StaticWorkloadName")
-	tStaticWorkloadName.Pattern("\\*\\.(([a-zA-Z0-9][a-zA-Z0-9-:._]*\\.)*[a-zA-Z0-9][a-zA-Z0-9-:._]*)|(([a-zA-Z0-9][a-zA-Z0-9-:._]*\\.)*[a-zA-Z0-9][a-zA-Z0-9-:._]*)(\\/[0-9]{1,3})?")
+	tStaticWorkloadName.Pattern("(\\*\\.([A-Za-z0-9][A-Za-z0-9:_\\.-]*\\.)*[A-Za-z0-9][A-Za-z0-9:_\\.-]*)|((([A-Za-z0-9][A-Za-z0-9:_\\.-]*\\.)*[A-Za-z0-9][A-Za-z0-9:_\\.-]*)(\\/[0-9]{1,3})?)")
 	sb.AddType(tStaticWorkloadName.Build())
 
 	tTransportPolicySubjectExternal := rdl.NewStringTypeBuilder("TransportPolicySubjectExternal")
-	tTransportPolicySubjectExternal.Pattern("(([a-zA-Z0-9][a-zA-Z0-9-:._]*\\.)*[a-zA-Z0-9][a-zA-Z0-9-:._]*)(\\/[0-9]{1,3})?")
+	tTransportPolicySubjectExternal.Pattern("(([A-Za-z0-9][A-Za-z0-9:_\\.-]*\\.)*[A-Za-z0-9][A-Za-z0-9:_\\.-]*)(\\/[0-9]{1,3})?")
 	sb.AddType(tTransportPolicySubjectExternal.Build())
 
 	tTransportPolicyEnforcementState := rdl.NewEnumTypeBuilder("Enum", "TransportPolicyEnforcementState")

--- a/core/msd/src/main/java/com/yahoo/athenz/msd/MSDSchema.java
+++ b/core/msd/src/main/java/com/yahoo/athenz/msd/MSDSchema.java
@@ -105,16 +105,16 @@ public class MSDSchema {
             .pattern("\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*");
 
         sb.stringType("StaticWorkloadComponent")
-            .pattern("[a-zA-Z0-9][a-zA-Z0-9-:._]*");
+            .pattern("[A-Za-z0-9][A-Za-z0-9:_\\.-]*");
 
         sb.stringType("StaticWorkloadFQDN")
-            .pattern("([a-zA-Z0-9][a-zA-Z0-9-:._]*\\.)*[a-zA-Z0-9][a-zA-Z0-9-:._]*");
+            .pattern("([A-Za-z0-9][A-Za-z0-9:_\\.-]*\\.)*[A-Za-z0-9][A-Za-z0-9:_\\.-]*");
 
         sb.stringType("StaticWorkloadName")
-            .pattern("\\*\\.(([a-zA-Z0-9][a-zA-Z0-9-:._]*\\.)*[a-zA-Z0-9][a-zA-Z0-9-:._]*)|(([a-zA-Z0-9][a-zA-Z0-9-:._]*\\.)*[a-zA-Z0-9][a-zA-Z0-9-:._]*)(\\/[0-9]{1,3})?");
+            .pattern("(\\*\\.([A-Za-z0-9][A-Za-z0-9:_\\.-]*\\.)*[A-Za-z0-9][A-Za-z0-9:_\\.-]*)|((([A-Za-z0-9][A-Za-z0-9:_\\.-]*\\.)*[A-Za-z0-9][A-Za-z0-9:_\\.-]*)(\\/[0-9]{1,3})?)");
 
         sb.stringType("TransportPolicySubjectExternal")
-            .pattern("(([a-zA-Z0-9][a-zA-Z0-9-:._]*\\.)*[a-zA-Z0-9][a-zA-Z0-9-:._]*)(\\/[0-9]{1,3})?");
+            .pattern("(([A-Za-z0-9][A-Za-z0-9:_\\.-]*\\.)*[A-Za-z0-9][A-Za-z0-9:_\\.-]*)(\\/[0-9]{1,3})?");
 
         sb.enumType("TransportPolicyEnforcementState")
             .comment("Types of transport policy enforcement states")

--- a/core/msd/src/main/rdl/Names.tdl
+++ b/core/msd/src/main/rdl/Names.tdl
@@ -51,8 +51,8 @@ type TransportPolicySubjectDomainName String (pattern="\\*|{DomainName}");
 // ServiceName in TransportPolicySubject should allow * to indicate ANY
 type TransportPolicySubjectServiceName String (pattern="\\*|{EntityName}");
 
-type StaticWorkloadComponent String (pattern="[a-zA-Z0-9][a-zA-Z0-9-:._]*");
+type StaticWorkloadComponent String (pattern="[A-Za-z0-9][A-Za-z0-9:_\\.-]*");
 type StaticWorkloadFQDN String (pattern="({StaticWorkloadComponent}\\.)*{StaticWorkloadComponent}");
-type StaticWorkloadName String (pattern="\\*\\.({StaticWorkloadFQDN})|({StaticWorkloadFQDN})(\\/[0-9]{1,3})?");
+type StaticWorkloadName String (pattern="(\\*\\.({StaticWorkloadComponent}\\.)*{StaticWorkloadComponent})|(({StaticWorkloadFQDN})(\\/[0-9]{1,3})?)");
 
 type TransportPolicySubjectExternal String (pattern="({StaticWorkloadFQDN})(\\/[0-9]{1,3})?");

--- a/core/msd/src/test/java/com/yahoo/athenz/msd/StaticWorkloadTest.java
+++ b/core/msd/src/test/java/com/yahoo/athenz/msd/StaticWorkloadTest.java
@@ -132,6 +132,8 @@ public class StaticWorkloadTest {
                 {"ABC::AA012_113_3332_11344", true},
                 {"myhostname.subdomain.domain.com", true},
                 {"*.myhostname.subdomain.domain.com", true},
+                {"id.subdomain.domain.com", true},
+                {"id-uat.subdomain.domain.com", true},
                 {"*.*.subdomain.domain.com", false},
                 {"*.myhostname.*.domain.com", false},
                 {"*.myhostname.subdomain.domain.com/24", false},


### PR DESCRIPTION
**Problem**

There is an issue with the regular expression used in MSD for validating domain/FQDN values:

`([a-zA-Z0-9_][a-zA-Z0-9_-]*\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*`


This regex behaves inconsistently due to ambiguous backtracking caused by the repeating group.
Specifically, both the repeating group and the final label can match the same parts of the input, which leads to excessive backtracking and causes Java’s regex engine to fail validation in some cases.

As a result:

`id-uat.subdomain.domain.com ✅ passes validation`

`id.subdomain.domain.com ❌ fails validation`

Both values are valid FQDNs, but the shorter label (id) exposes the ambiguity in the pattern.

**Impact**

The issue affects both API and UI, which return the same validation error:

```
com.yahoo.athenz.msd.ResourceException: ResourceException (400): {
  code: 400,
  message: "Invalid BulkWorkloadRequest error:
  String pattern mismatch (expected
  "([a-zA-Z0-9_][a-zA-Z0-9_-]*\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*")
  for type EntityName in data[0][0]"
}
```

**Proposed Change**

Replace the problematic regex with the one already used in the MSD controller, which correctly handles FQDNs and wildcard domains without ambiguous backtracking:

`^([a-zA-Z0-9*]([-a-zA-Z0-9_*]*[a-zA-Z0-9*])*\.?)*$`


**This pattern:**

- Avoids overlapping matches between repeated groups

- Correctly validates FQDNs and wildcard domains

- Produces consistent validation behavior across API and UI