### PR TITLE
Allow wrapper-controlled init to fix jwk_uri backward compatibility (Issue #3054)

### DIFF
--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/AuthZpeClient.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/AuthZpeClient.java
@@ -155,7 +155,7 @@ public class AuthZpeClient {
     }
     
     static {
-
+        
         // load public keys
 
         setPublicKeyStoreFactoryClass(System.getProperty(ZpeConsts.ZPE_PROP_PUBLIC_KEY_CLASS, ZPE_PKEY_CLASS));
@@ -175,7 +175,12 @@ public class AuthZpeClient {
         // load the x509 issuers
         
         setX509CAIssuers(System.getProperty(ZpeConsts.ZPE_PROP_X509_CA_ISSUERS));
+    }
 
+    public static void init() {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Init: load the ZPE");
+        }
         // initialize the access token signing key resolver
 
         initializeAccessTokenSignKeyResolver();
@@ -183,12 +188,6 @@ public class AuthZpeClient {
         // save the last zts api call time, and the allowed interval between api calls
 
         setMillisBetweenZtsCalls(Long.parseLong(System.getProperty(ZPE_PROP_MILLIS_BETWEEN_ZTS_CALLS, Long.toString(30 * 1000 * 60))));
-    }
-
-    public static void init() {
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("Init: load the ZPE");
-        }
     }
 
     public static void close() {
@@ -203,6 +202,7 @@ public class AuthZpeClient {
         if (serverUrl == null || serverUrl.isEmpty()) {
             throw new IllegalArgumentException("Missing required property: " + ZpeConsts.ZPE_PROP_JWK_URI);
         }
+        String proxyUrl = System.getProperty(ZpeConsts.ZPE_PROP_JWK_PROXY_URI);
 
         final String keyPath = System.getProperty(ZpeConsts.ZPE_PROP_JWK_PRIVATE_KEY_PATH);
         final String certPath = System.getProperty(ZpeConsts.ZPE_PROP_JWK_X509_CERT_PATH);
@@ -217,7 +217,7 @@ public class AuthZpeClient {
                 LOG.error("Unable to initialize key refresher: {}", ex.getMessage());
             }
         }
-        setAccessTokenSignKeyResolver(serverUrl, sslContext);
+        setAccessTokenSignKeyResolver(serverUrl, sslContext, proxyUrl);
     }
 
     /**

--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/AuthZpeClient.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/AuthZpeClient.java
@@ -67,6 +67,7 @@ public class AuthZpeClient {
 
     private static int allowedOffset = 300;
     private static JwtsSigningKeyResolver accessSignKeyResolver = null;
+    private static boolean tokenSignKeyResolverInitialized = false;
 
     private static ZpeClient zpeClt = null;
     private static PublicKeyStore publicKeyStore = null;
@@ -175,19 +176,25 @@ public class AuthZpeClient {
         // load the x509 issuers
         
         setX509CAIssuers(System.getProperty(ZpeConsts.ZPE_PROP_X509_CA_ISSUERS));
+
+        // initialize the access token signing key resolver
+
+        initializeAccessTokenSignKeyResolver(false);
+
+        // save the last zts api call time, and the allowed interval between api calls
+        if (tokenSignKeyResolverInitialized) {
+            setMillisBetweenZtsCalls(Long.parseLong(System.getProperty(ZPE_PROP_MILLIS_BETWEEN_ZTS_CALLS, Long.toString(30 * 1000 * 60))));
+        }
     }
 
     public static void init() {
         if (LOG.isDebugEnabled()) {
             LOG.debug("Init: load the ZPE");
         }
-        // initialize the access token signing key resolver
-
-        initializeAccessTokenSignKeyResolver();
-
-        // save the last zts api call time, and the allowed interval between api calls
-
-        setMillisBetweenZtsCalls(Long.parseLong(System.getProperty(ZPE_PROP_MILLIS_BETWEEN_ZTS_CALLS, Long.toString(30 * 1000 * 60))));
+        if (!tokenSignKeyResolverInitialized) {
+            initializeAccessTokenSignKeyResolver(true);
+            setMillisBetweenZtsCalls(Long.parseLong(System.getProperty(ZPE_PROP_MILLIS_BETWEEN_ZTS_CALLS, Long.toString(30 * 1000 * 60))));
+        }
     }
 
     public static void close() {
@@ -197,10 +204,13 @@ public class AuthZpeClient {
         zpeClt.close();
     }
 
-    public static void initializeAccessTokenSignKeyResolver() {
+    public static void initializeAccessTokenSignKeyResolver(boolean throwOnMissingUrl) {
         String serverUrl = System.getProperty(ZpeConsts.ZPE_PROP_JWK_URI);
         if (serverUrl == null || serverUrl.isEmpty()) {
-            throw new IllegalArgumentException("Missing required property: " + ZpeConsts.ZPE_PROP_JWK_URI);
+            if (throwOnMissingUrl) {
+                throw new IllegalArgumentException("Missing required property: " + ZpeConsts.ZPE_PROP_JWK_URI);
+            }
+            return;
         }
         String proxyUrl = System.getProperty(ZpeConsts.ZPE_PROP_JWK_PROXY_URI);
 
@@ -218,6 +228,7 @@ public class AuthZpeClient {
             }
         }
         setAccessTokenSignKeyResolver(serverUrl, sslContext, proxyUrl);
+        tokenSignKeyResolverInitialized = true;
     }
 
     /**

--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/AuthZpeClient.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/AuthZpeClient.java
@@ -181,10 +181,6 @@ public class AuthZpeClient {
 
         initializeAccessTokenSignKeyResolver(false);
 
-        // save the last zts api call time, and the allowed interval between api calls
-        if (tokenSignKeyResolverInitialized) {
-            setMillisBetweenZtsCalls(Long.parseLong(System.getProperty(ZPE_PROP_MILLIS_BETWEEN_ZTS_CALLS, Long.toString(30 * 1000 * 60))));
-        }
     }
 
     public static void init() {
@@ -193,7 +189,6 @@ public class AuthZpeClient {
         }
         if (!tokenSignKeyResolverInitialized) {
             initializeAccessTokenSignKeyResolver(true);
-            setMillisBetweenZtsCalls(Long.parseLong(System.getProperty(ZPE_PROP_MILLIS_BETWEEN_ZTS_CALLS, Long.toString(30 * 1000 * 60))));
         }
     }
 
@@ -229,6 +224,7 @@ public class AuthZpeClient {
         }
         setAccessTokenSignKeyResolver(serverUrl, sslContext, proxyUrl);
         tokenSignKeyResolverInitialized = true;
+        setMillisBetweenZtsCalls(Long.parseLong(System.getProperty(ZPE_PROP_MILLIS_BETWEEN_ZTS_CALLS, Long.toString(30 * 1000 * 60))));
     }
 
     /**

--- a/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeConsts.java
+++ b/clients/java/zpe/src/main/java/com/yahoo/athenz/zpe/ZpeConsts.java
@@ -53,6 +53,7 @@ public final class ZpeConsts {
     public static final String ZPE_PROP_ATHENZ_CONF                  = "athenz.athenz_conf";
     public static final String ZPE_PROP_JWK_ATHENZ_CONF              = "athenz.jwk_athenz_conf";
     public static final String ZPE_PROP_JWK_URI                      = "athenz.zpe.jwk_uri";
+    public static final String ZPE_PROP_JWK_PROXY_URI                = "athenz.zpe.jwk_proxy_uri";
     public static final String ZPE_PROP_JWK_PRIVATE_KEY_PATH         = "athenz.zpe.jwk_private_key_path";
     public static final String ZPE_PROP_JWK_X509_CERT_PATH           = "athenz.zpe.jwk_x509_cert_path";
 

--- a/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestAuthZpe.java
+++ b/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestAuthZpe.java
@@ -1537,7 +1537,7 @@ public class TestAuthZpe {
     public void testInitializeAccessTokenSignKeyResolver() throws IOException {
         final String originalJwkValue = System.clearProperty(ZpeConsts.ZPE_PROP_JWK_URI);
         try {
-            AuthZpeClient.initializeAccessTokenSignKeyResolver();
+            AuthZpeClient.initializeAccessTokenSignKeyResolver(true);
             fail();
         } catch (Exception ex) {
             assertTrue(ex.getMessage().contains("Missing required property"));
@@ -1545,7 +1545,7 @@ public class TestAuthZpe {
 
         System.setProperty(ZpeConsts.ZPE_PROP_JWK_URI, "");
         try {
-            AuthZpeClient.initializeAccessTokenSignKeyResolver();
+            AuthZpeClient.initializeAccessTokenSignKeyResolver(true);
             fail();
         } catch (Exception ex) {
             assertTrue(ex.getMessage().contains("Missing required property"));
@@ -1557,7 +1557,7 @@ public class TestAuthZpe {
         System.setProperty(ZpeConsts.ZPE_PROP_JWK_URI, "file://" + jwkUri);
         System.setProperty(ZpeConsts.ZPE_PROP_JWK_PRIVATE_KEY_PATH, "src/test/resources/jwk/athenz_private.pem");
         System.setProperty(ZpeConsts.ZPE_PROP_JWK_X509_CERT_PATH, "src/test/resources/jwk/athenz_x509.pem");
-        AuthZpeClient.initializeAccessTokenSignKeyResolver();
+        AuthZpeClient.initializeAccessTokenSignKeyResolver(true);
 
         // try with valid paths
 
@@ -1565,7 +1565,7 @@ public class TestAuthZpe {
         String certPath = new File("src/test/resources/ec_public_x509.cert").getCanonicalPath();
         System.setProperty(ZpeConsts.ZPE_PROP_JWK_PRIVATE_KEY_PATH, keyPath);
         System.setProperty(ZpeConsts.ZPE_PROP_JWK_X509_CERT_PATH, certPath);
-        AuthZpeClient.initializeAccessTokenSignKeyResolver();
+        AuthZpeClient.initializeAccessTokenSignKeyResolver(true);
 
         // reset the original state
 

--- a/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestAuthZpe.java
+++ b/clients/java/zpe/src/test/java/com/yahoo/athenz/zpe/TestAuthZpe.java
@@ -29,6 +29,7 @@ import org.testng.Assert;
 import org.testng.annotations.*;
 
 import javax.security.auth.x500.X500Principal;
+import java.lang.reflect.Field;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -1543,6 +1544,9 @@ public class TestAuthZpe {
             assertTrue(ex.getMessage().contains("Missing required property"));
         }
 
+        // optional initialization mode must not throw when uri is missing
+        AuthZpeClient.initializeAccessTokenSignKeyResolver(false);
+
         System.setProperty(ZpeConsts.ZPE_PROP_JWK_URI, "");
         try {
             AuthZpeClient.initializeAccessTokenSignKeyResolver(true);
@@ -1550,6 +1554,9 @@ public class TestAuthZpe {
         } catch (Exception ex) {
             assertTrue(ex.getMessage().contains("Missing required property"));
         }
+
+        // optional initialization mode must not throw when uri is empty
+        AuthZpeClient.initializeAccessTokenSignKeyResolver(false);
 
         // try with unknown file paths - we'll be successful without any errors
 
@@ -1569,8 +1576,84 @@ public class TestAuthZpe {
 
         // reset the original state
 
-        System.setProperty(ZpeConsts.ZPE_PROP_JWK_URI, originalJwkValue);
+        if (originalJwkValue == null) {
+            System.clearProperty(ZpeConsts.ZPE_PROP_JWK_URI);
+        } else {
+            System.setProperty(ZpeConsts.ZPE_PROP_JWK_URI, originalJwkValue);
+        }
         System.clearProperty(ZpeConsts.ZPE_PROP_JWK_PRIVATE_KEY_PATH);
         System.clearProperty(ZpeConsts.ZPE_PROP_JWK_X509_CERT_PATH);
+    }
+
+    private boolean getTokenSignKeyResolverInitialized() throws Exception {
+        Field field = AuthZpeClient.class.getDeclaredField("tokenSignKeyResolverInitialized");
+        field.setAccessible(true);
+        return field.getBoolean(null);
+    }
+
+    private void setTokenSignKeyResolverInitialized(boolean value) throws Exception {
+        Field field = AuthZpeClient.class.getDeclaredField("tokenSignKeyResolverInitialized");
+        field.setAccessible(true);
+        field.setBoolean(null, value);
+    }
+
+    @Test
+    public void testInitRequiresJwkUriWhenResolverNotInitialized() throws Exception {
+        final String originalJwkValue = System.clearProperty(ZpeConsts.ZPE_PROP_JWK_URI);
+        final boolean originalInitialized = getTokenSignKeyResolverInitialized();
+        try {
+            setTokenSignKeyResolverInitialized(false);
+            try {
+                AuthZpeClient.init();
+                fail();
+            } catch (IllegalArgumentException ex) {
+                assertTrue(ex.getMessage().contains("Missing required property"));
+            }
+        } finally {
+            if (originalJwkValue == null) {
+                System.clearProperty(ZpeConsts.ZPE_PROP_JWK_URI);
+            } else {
+                System.setProperty(ZpeConsts.ZPE_PROP_JWK_URI, originalJwkValue);
+            }
+            setTokenSignKeyResolverInitialized(originalInitialized);
+        }
+    }
+
+    @Test
+    public void testInitSkipsResolverWhenAlreadyInitialized() throws Exception {
+        final String originalJwkValue = System.clearProperty(ZpeConsts.ZPE_PROP_JWK_URI);
+        final boolean originalInitialized = getTokenSignKeyResolverInitialized();
+        try {
+            setTokenSignKeyResolverInitialized(true);
+            AuthZpeClient.init();
+        } finally {
+            if (originalJwkValue == null) {
+                System.clearProperty(ZpeConsts.ZPE_PROP_JWK_URI);
+            } else {
+                System.setProperty(ZpeConsts.ZPE_PROP_JWK_URI, originalJwkValue);
+            }
+            setTokenSignKeyResolverInitialized(originalInitialized);
+        }
+    }
+
+    @Test
+    public void testInitInitializesResolverWhenUriPresent() throws Exception {
+        final String originalJwkValue = System.getProperty(ZpeConsts.ZPE_PROP_JWK_URI);
+        final boolean originalInitialized = getTokenSignKeyResolverInitialized();
+        try {
+            final String jwkUri = new File("src/test/resources/jwk/athenz_jwks.json").getCanonicalPath();
+            System.setProperty(ZpeConsts.ZPE_PROP_JWK_URI, "file://" + jwkUri);
+            setTokenSignKeyResolverInitialized(false);
+
+            AuthZpeClient.init();
+            assertTrue(getTokenSignKeyResolverInitialized());
+        } finally {
+            if (originalJwkValue == null) {
+                System.clearProperty(ZpeConsts.ZPE_PROP_JWK_URI);
+            } else {
+                System.setProperty(ZpeConsts.ZPE_PROP_JWK_URI, originalJwkValue);
+            }
+            setTokenSignKeyResolverInitialized(originalInitialized);
+        }
     }
 }


### PR DESCRIPTION
# Description
## Context
* In v1.12.x, jwk_uri became mandatory and the check runs in a static initializer, which prevents wrappers from setting system properties before AuthZpeClient loads. (Issue #3054)

## Changes
* Move access-token resolver setup out of the static initializer into AuthZpeClient.init() so callers can set properties before initialization.
* Keep the existing jwk_uri requirement for access-token validation, but make its initialization explicit and controllable.
* Add support for an optional athenz.zpe.jwk_proxy_uri and pass it into setAccessTokenSignKeyResolver to enable proxied JWK fetches.

## Outcome
* Restores upgrade path for Role Token users by avoiding premature jwk_uri validation during class load, while preserving access-token behavior when init() is called.


# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

