### PR TITLE
Use DefaultCredentialsProvider for RDS IAM auth

### DIFF
--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AWSCertRecordStoreFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AWSCertRecordStoreFactory.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 import com.yahoo.athenz.auth.PrivateKeyStore;
 import com.yahoo.athenz.common.server.db.DataSourceFactory;
 import com.yahoo.athenz.common.server.db.PoolableDataSource;
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.RdsUtilities;
@@ -92,12 +92,12 @@ public class AWSCertRecordStoreFactory implements CertRecordStoreFactory {
 
         String authToken = null;
         try (RdsClient rdsClient = RdsClient.builder().region(Utils.getAwsRegion((Region.US_EAST_1)))
-                .credentialsProvider(ProfileCredentialsProvider.create()).build()) {
+                .credentialsProvider(DefaultCredentialsProvider.create()).build()) {
 
             RdsUtilities utilities = rdsClient.utilities();
 
             GenerateAuthenticationTokenRequest tokenRequest = GenerateAuthenticationTokenRequest.builder()
-                    .credentialsProvider(ProfileCredentialsProvider.create())
+                    .credentialsProvider(DefaultCredentialsProvider.create())
                     .username(rdsUser)
                     .port(port)
                     .hostname(hostname)

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/AWSObjectStoreFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/AWSObjectStoreFactory.java
@@ -25,7 +25,7 @@ import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import software.amazon.awssdk.auth.credentials.ProfileCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.RdsClient;
 import software.amazon.awssdk.services.rds.RdsUtilities;
@@ -143,12 +143,12 @@ public class AWSObjectStoreFactory implements ObjectStoreFactory {
 
         String authToken = null;
         try (RdsClient rdsClient = RdsClient.builder().region(getRegion())
-                    .credentialsProvider(ProfileCredentialsProvider.create()).build()) {
+                    .credentialsProvider(DefaultCredentialsProvider.create()).build()) {
 
             RdsUtilities utilities = rdsClient.utilities();
 
             GenerateAuthenticationTokenRequest tokenRequest = GenerateAuthenticationTokenRequest.builder()
-                    .credentialsProvider(ProfileCredentialsProvider.create())
+                    .credentialsProvider(DefaultCredentialsProvider.create())
                     .username(rdsUser)
                     .port(port)
                     .hostname(hostname)


### PR DESCRIPTION
## Summary

- Replace `ProfileCredentialsProvider` with `DefaultCredentialsProvider` in `AWSObjectStoreFactory` and `AWSCertRecordStoreFactory`
- `ProfileCredentialsProvider` only reads `~/.aws/credentials`, which fails on EC2 instances using IAM roles
- `DefaultCredentialsProvider` uses the standard AWS credential chain and works in all deployment scenarios

Fixes #3215