### PR TITLE
Add server-aws-common to ZMS/ZTS assembly tarballs

### DIFF
--- a/assembly/zms/pom.xml
+++ b/assembly/zms/pom.xml
@@ -38,6 +38,11 @@
       <version>${project.parent.version}</version>
     </dependency>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>athenz-server-aws-common</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
       <version>${logback.server.version}</version>

--- a/assembly/zts/pom.xml
+++ b/assembly/zts/pom.xml
@@ -39,6 +39,11 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>athenz-server-aws-common</artifactId>
+      <version>${project.parent.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>athenz-instance-provider</artifactId>
       <version>${project.parent.version}</version>
     </dependency>


### PR DESCRIPTION
## Summary

Adds `athenz-server-aws-common` as a dependency in both `assembly/zms/pom.xml` and `assembly/zts/pom.xml`. This ensures the AWS factory classes (`AWSObjectStoreFactory`, `AWSCertRecordStoreFactory`) and their transitive dependencies (AWS SDK v2) are included in the assembly tarballs.

Without this, users deploying from the assembly tarballs as described in the [ZMS setup docs](https://athenz.github.io/athenz/setup_zms/) get `ClassNotFoundException` at runtime when using the AWS factory classes.

Fixes #3214

## Trade-off

This adds the AWS SDK v2 JARs to both tarballs unconditionally, increasing their size. For non-AWS deployments these JARs are unnecessary. If that's a concern, an alternative approach would be a Maven profile (e.g., `-Paws`) that conditionally includes the dependency. Happy to implement that instead if preferred.