### PR TITLE
Removing ETag for getTransportPolicySnapshot api

### DIFF
--- a/clients/go/msd/client.go
+++ b/clients/go/msd/client.go
@@ -1212,32 +1212,26 @@ func (client MSDClient) GetTransportPolicySnapshots(domainName DomainName, servi
 	}
 }
 
-func (client MSDClient) GetTransportPolicySnapshot(domainName DomainName, serviceName EntityName, snapshotName EntityName, matchingTag string) (*TransportPolicySnapshot, string, error) {
+func (client MSDClient) GetTransportPolicySnapshot(domainName DomainName, serviceName EntityName, snapshotName EntityName) (*TransportPolicySnapshot, error) {
 	var data *TransportPolicySnapshot
-	headers := map[string]string{
-		"If-None-Match": matchingTag,
-	}
 	url := client.URL + "/domain/" + fmt.Sprint(domainName) + "/service/" + fmt.Sprint(serviceName) + "/snapshot/" + fmt.Sprint(snapshotName)
-	resp, err := client.httpGet(url, headers)
+	resp, err := client.httpGet(url, nil)
 	if err != nil {
-		return nil, "", err
+		return data, err
 	}
 	defer resp.Body.Close()
 	switch resp.StatusCode {
-	case 200, 304:
-		if 304 != resp.StatusCode {
-			err = json.NewDecoder(resp.Body).Decode(&data)
-			if err != nil {
-				return nil, "", err
-			}
+	case 200:
+		err = json.NewDecoder(resp.Body).Decode(&data)
+		if err != nil {
+			return data, err
 		}
-		tag := resp.Header.Get(rdl.FoldHttpHeaderName("ETag"))
-		return data, tag, nil
+		return data, nil
 	default:
 		var errobj rdl.ResourceError
 		contentBytes, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return nil, "", err
+			return data, err
 		}
 		json.Unmarshal(contentBytes, &errobj)
 		if errobj.Code == 0 {
@@ -1246,7 +1240,7 @@ func (client MSDClient) GetTransportPolicySnapshot(domainName DomainName, servic
 		if errobj.Message == "" {
 			errobj.Message = string(contentBytes)
 		}
-		return nil, "", errobj
+		return data, errobj
 	}
 }
 

--- a/clients/go/msd/msd_schema.go
+++ b/clients/go/msd/msd_schema.go
@@ -1129,8 +1129,6 @@ func init() {
 	mGetTransportPolicySnapshot.Input("domainName", "DomainName", true, "", "", false, nil, "name of the domain")
 	mGetTransportPolicySnapshot.Input("serviceName", "EntityName", true, "", "", false, nil, "name of the service")
 	mGetTransportPolicySnapshot.Input("snapshotName", "EntityName", true, "", "", false, nil, "name of the snapshot")
-	mGetTransportPolicySnapshot.Input("matchingTag", "String", false, "", "If-None-Match", false, nil, "Retrieved from the previous request, this timestamp specifies to the server to return the snapshot if modified since this time")
-	mGetTransportPolicySnapshot.Output("tag", "String", "ETag", false, "The current snapshot modification timestamp is returned in this header")
 	mGetTransportPolicySnapshot.Auth("msd.GetNetworkPolicy", "{domainName}:service.{serviceName}", false, "")
 	mGetTransportPolicySnapshot.Exception("BAD_REQUEST", "ResourceError", "")
 	mGetTransportPolicySnapshot.Exception("FORBIDDEN", "ResourceError", "")

--- a/core/msd/src/main/java/com/yahoo/athenz/msd/MSDSchema.java
+++ b/core/msd/src/main/java/com/yahoo/athenz/msd/MSDSchema.java
@@ -1148,8 +1148,6 @@ public class MSDSchema {
             .pathParam("domainName", "DomainName", "name of the domain")
             .pathParam("serviceName", "EntityName", "name of the service")
             .pathParam("snapshotName", "EntityName", "name of the snapshot")
-            .headerParam("If-None-Match", "matchingTag", "String", null, "Retrieved from the previous request, this timestamp specifies to the server to return the snapshot if modified since this time")
-            .output("ETag", "tag", "String", "The current snapshot modification timestamp is returned in this header")
             .auth("msd.GetNetworkPolicy", "{domainName}:service.{serviceName}")
             .expected("OK")
             .exception("BAD_REQUEST", "ResourceError", "")

--- a/core/msd/src/main/rdl/Snapshot.rdli
+++ b/core/msd/src/main/rdl/Snapshot.rdli
@@ -61,10 +61,8 @@ resource TransportPolicySnapshot GET "/domain/{domainName}/service/{serviceName}
     DomainName domainName; // name of the domain
     EntityName serviceName; // name of the service
     EntityName snapshotName; // name of the snapshot
-    String matchingTag (header="If-None-Match"); // Retrieved from the previous request, this timestamp specifies to the server to return the snapshot if modified since this time
-    String tag (header="ETag", out); // The current snapshot modification timestamp is returned in this header
     authorize ("msd.GetNetworkPolicy", "{domainName}:service.{serviceName}");
-    expected OK, NOT_MODIFIED;
+    expected OK;
     exceptions {
         ResourceError BAD_REQUEST;
         ResourceError NOT_FOUND;


### PR DESCRIPTION
# Description
Removing ETag support for getTransportPolicySnapshot() api since the snapshot doesn't change after it is created.

The earlier api didn't make it into the release, so it is safe to make this change now. 

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

