### PR TITLE
[skip ci] Add explanatory comment for email format check in `ExtractServicePrincipal`

### DIFF
--- a/libs/go/athenzutils/principal.go
+++ b/libs/go/athenzutils/principal.go
@@ -38,14 +38,18 @@ func ExtractServicePrincipal(x509Cert x509.Certificate) (string, error) {
 			return "", fmt.Errorf("certificate does not have a single email SAN value")
 		}
 
-		// Note: Starting from Go 1.25.2, the x509 parser performs stricter checks,
-		// ensuring the email address always has a valid format (contains '@').
-		var found bool
-		principal, _, found = strings.Cut(emails[0], "@")
-		if !found {
-			// This path should be unreachable with Go 1.22+
+		// athenz always verifies that we include a valid
+		// email in the certificate
+
+		idx := strings.Index(emails[0], "@")
+		if idx == -1 {
+			// Note: Starting from Go 1.25.2, the x509 parser performs stricter checks
+			// to ensure the email address always has a valid format (contains '@').
+			// Therefore, this path should be unreachable.
 			return "", fmt.Errorf("certificate email is invalid: %s", emails[0])
 		}
+
+		principal = emails[0][0:idx]
 	}
 
 	return principal, nil


### PR DESCRIPTION
# Description
This PR adds a contextual comment to the email format validation (`@` check) within `ExtractServicePrincipal`. 

Starting from Go 1.25.2, the `x509` parser enforces stricter checks, ensuring that any parsed email address naturally contains an `@`, with the following review: https://go-review.googlesource.com/c/go/+/709854

w/ related newly added code:

```go
parsed, ok := parseRFC2821Mailbox(email)
if !ok || (ok && !domainNameValid(parsed.domain, false)) {
  return errors.New("x509: SAN rfc822Name is malformed")
}
```


As a result, the following error path has essentially become unreachable in newer Go versions:

```go
return "", fmt.Errorf("certificate email is invalid: %s", emails[0])
```

It could be considered as "dead code," but keeping the explicit check is still meaningful for robustness and as a defense-in-depth measure. However, adding the comments provides valuable context for future maintainers, clarifying exactly why this code path exists but is highly unlikely to be triggered.

Related PR: https://github.com/AthenZ/athenz/pull/3095

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**


