### PR TITLE
[skip ci] Docfix: Clarify partial scope behavior for `ID-JAG` token exchange in `zts_token_exchange_requirements.md`

### DIFF
--- a/docs/zts_token_exchange_requirements.md
+++ b/docs/zts_token_exchange_requirements.md
@@ -20,7 +20,8 @@ Requirements:
   format: `{domainName}:role.{roleName} {domainName}:role.{roleName} ...`
 - The token request must have a valid `audience` parameter specified
 - The requesting principal (service or user) must be authorized to perform the JAG token exchange
-  for each role in the requested scope.
+  for the evaluated subset of requested roles that the subject identity can access, with ZTS issuing
+  a token containing only those roles and denying the request entirely if no roles are accessible.
 
 1. Subject Token Validation
 


### PR DESCRIPTION
# Description
The `docs/zts_token_exchange_requirements.md` document currently contains the following statement:

`The requesting principal (service or user) must be authorized to perform the JAG token exchange for each role in the requested scope.`

This used to be true, but since the implementation of [PR: allow to return jag token with subset of scopes #3138](https://github.com/AthenZ/athenz/pull/3138), ZTS now allows returning a token with a partial scope if one or some of the scopes are valid. Also, ZTS now returns an error only when all of the requested scopes are invalid.

This PR fixes the outdated documentation to correctly match the current system behavior.

Related Issue: https://github.com/AthenZ/athenz/issues/3100

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

