### PR TITLE
ZTS token exchange: propagate SPIFFE claim

### DIFF
--- a/docs/zts_token_exchange_requirements.md
+++ b/docs/zts_token_exchange_requirements.md
@@ -73,6 +73,15 @@ Requirements:
 - Validates that the subject identity has access to at least one of the requested roles
   The generated token will only include roles that the subject identity has access to.
 
+## ID Token Exchange
+
+The ID token exchange feature allows a service to exchange an existing ID token for a new
+ID token that includes Athenz role/group information for a requested audience.
+
+Notes:
+
+- If the `subject_token` includes a SPIFFE ID in the `spiffe` claim, ZTS copies it into the issued ID token `spiffe` claim.
+
 ## Access Token Exchange (Impersonation)
 Specification: https://datatracker.ietf.org/doc/html/rfc8693
 
@@ -91,6 +100,7 @@ Requirements:
 - The token request must have a valid `audience` parameter specified
 - The token request must have the `scope` parameter set to the list of roles being requested in the
   format: `{domainName}:role.{roleName} {domainName}:role.{roleName} ...`
+- If the `subject_token` includes a SPIFFE ID in the `spiffe` claim, ZTS copies it into the issued access token `spiffe` claim.
 
 1. Role Names Validation
 
@@ -131,6 +141,7 @@ Requirements:
   parameter set to `urn:ietf:params:oauth:token-type:id_token`, `urn:ietf:params:oauth:token-type:id-access-token` or
   `urn:ietf:params:oauth:token-type:jwt`
 - The subject_token must have a valid `may_act` claim that includes a `sub` claim that matches the actor_token's subject
+- If the `subject_token` includes a SPIFFE ID in the `spiffe` claim, ZTS copies it into the issued access token `spiffe` claim.
 
 1. Role Names Validation
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2620,6 +2620,27 @@ public class ZTSImpl implements ZTSHandler {
         }
     }
 
+    String extractSpiffeIdFromToken(final OAuth2Token token) {
+        if (token == null) {
+            return null;
+        }
+
+        final Object spiffeClaim = token.getClaim(IdToken.CLAIM_SPIFFE);
+        if (spiffeClaim != null) {
+            final String spiffeId = spiffeClaim.toString();
+            if (!StringUtil.isEmpty(spiffeId) && spiffeId.startsWith(ZTSConsts.ZTS_CERT_SPIFFE_URI)) {
+                return spiffeId;
+            }
+        }
+
+        final String subject = token.getSubject();
+        if (!StringUtil.isEmpty(subject) && subject.startsWith(ZTSConsts.ZTS_CERT_SPIFFE_URI)) {
+            return subject;
+        }
+
+        return null;
+    }
+
     AccessTokenResponse processAccessTokenImpersonationRequest(ResourceContext ctx, Principal principal,
             AccessTokenRequest accessTokenRequest, final String principalDomain, final String caller) {
 
@@ -2709,6 +2730,11 @@ public class ZTSImpl implements ZTSHandler {
         accessToken.setSubject(subjectPrincipal);
         accessToken.setIssuer(issuerResolver.getAccessTokenIssuer(ctx.request(), accessTokenRequest.isUseOpenIDIssuer()));
         accessToken.setScope(new ArrayList<>(roles));
+
+        final String spiffeId = extractSpiffeIdFromToken(subjectToken);
+        if (spiffeId != null) {
+            accessToken.setCustomClaim(IdToken.CLAIM_SPIFFE, spiffeId);
+        }
 
         // if we have a certificate used for mTLS authentication then
         // we're going to bind the certificate to the access token
@@ -2861,6 +2887,11 @@ public class ZTSImpl implements ZTSHandler {
         accessToken.setSubject(subjectPrincipal);
         accessToken.setIssuer(issuerResolver.getAccessTokenIssuer(ctx.request(), accessTokenRequest.isUseOpenIDIssuer()));
         accessToken.setScope(new ArrayList<>(roles));
+
+        final String spiffeId = extractSpiffeIdFromToken(subjectToken);
+        if (spiffeId != null) {
+            accessToken.setCustomClaim(IdToken.CLAIM_SPIFFE, spiffeId);
+        }
 
         // include the act claim in our response. we're going to use
         // the act claim from the original token and then add our new
@@ -3019,6 +3050,11 @@ public class ZTSImpl implements ZTSHandler {
         idToken.setGroups(idTokenGroups);
         idToken.setIssueTime(iat);
         idToken.setAuthTime(iat);
+
+        final String spiffeId = extractSpiffeIdFromToken(subjectToken);
+        if (spiffeId != null) {
+            idToken.setSpiffe(spiffeId);
+        }
 
         // for user principals we're going to use the default 1 hour while for
         // service principals 12 hours as the max timeout, unless the client

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -3945,6 +3945,13 @@ public class ZTSImplAccessTokenTest {
     private String createAccessToken(PrivateKey privateKey, final String keyId, final String subject,
                 final String audience, List<String> roles, final String mayActSubject, final String actSubject,
                 long expiryTime) {
+        return createAccessToken(privateKey, keyId, subject, audience, roles, mayActSubject, actSubject,
+                expiryTime, null);
+    }
+
+    private String createAccessToken(PrivateKey privateKey, final String keyId, final String subject,
+                final String audience, List<String> roles, final String mayActSubject, final String actSubject,
+                long expiryTime, final String spiffe) {
         try {
             AccessToken accessToken = new AccessToken();
             accessToken.setVersion(1);
@@ -3964,6 +3971,9 @@ public class ZTSImplAccessTokenTest {
             }
             if (actSubject != null) {
                 accessToken.setActEntry("sub", actSubject);
+            }
+            if (spiffe != null) {
+                accessToken.setCustomClaim("spiffe", spiffe);
             }
 
             ServerPrivateKey serverPrivateKey = new ServerPrivateKey(privateKey, keyId);
@@ -4238,6 +4248,97 @@ public class ZTSImplAccessTokenTest {
             assertNotNull(actMap);
             assertEquals(actMap.get("sub"), "user_domain.proxy-user1");
 
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+
+        cloudStore.close();
+    }
+
+    @Test
+    public void testProcessAccessTokenExchangeDelegationRequestSuccessWithSpiffeClaim() throws JOSEException {
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        // Create source domain
+        SignedDomain sourceDomain = createSignedDomain("sourcedomain", "weather", "storage", true);
+        store.processSignedDomain(sourceDomain, false);
+
+        // Create target domain
+        SignedDomain targetDomain = createSignedDomain("targetdomain", "weather", "storage", true);
+        store.processSignedDomain(targetDomain, false);
+
+        // Add token target exchange policy
+        addTokenTargetExchangePolicy("targetdomain", "sourcedomain", "user_domain.proxy-user1", "writers");
+
+        // Load EC private key for creating tokens
+        final File ecPrivateKey = new File("./src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        KeyStore keyStore = getServerPublicKeyProvider(privateKey);
+
+        // Create subject token (AccessToken) with roles in source domain
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        List<String> subjectRoles = List.of("writers");
+        final String spiffeId = "spiffe://athenz.io/ns/default/sa/sourcedomain.weather";
+        String subjectTokenStr = createAccessToken(privateKey, "0", "user_domain.user",
+                "sourcedomain", subjectRoles, "user_domain.proxy-user1", null, expiryTime, spiffeId);
+
+        // Create actor token (OAuth2Token)
+        String actorTokenStr = createActorToken(privateKey, "0", "user_domain.proxy-user1",
+                "targetdomain", expiryTime);
+
+        // Create principal for proxy-user1 who will request the token exchange
+        Principal principal = SimplePrincipal.create("user_domain", "proxy-user1",
+                "v=U1;d=user_domain;n=proxy-user1;s=signature", 0, null);
+        assertNotNull(principal);
+        ResourceContext context = createResourceContext(principal);
+        TokenConfigOptions tokenConfigOptions = createTokenConfigOptions(ztsImpl);
+        tokenConfigOptions.setOauth2Issuers(Set.of("https://athenz.io:4443/zts/v1"));
+        tokenConfigOptions.setPublicKeyProvider(keyStore);
+        ztsImpl.tokenConfigOptions = tokenConfigOptions;
+
+        final String requestBody = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
+                        + "&requested_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&subject_token=" + subjectTokenStr
+                        + "&subject_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&actor_token=" + actorTokenStr
+                        + "&actor_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&audience=targetdomain"
+                        + "&scope=targetdomain:role.writers";
+
+        AccessTokenResponse response = ztsImpl.postAccessTokenRequest(context, requestBody);
+
+        assertNotNull(response);
+        assertNotNull(response.getAccess_token());
+        assertEquals(response.getToken_type(), "Bearer");
+        assertTrue(response.getExpires_in() > 0);
+        assertEquals(response.getScope(), "targetdomain:role.writers");
+
+        // Verify the access token
+        String accessTokenStr = response.getAccess_token();
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(accessTokenStr);
+            assertTrue(signedJWT.verify(verifier));
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+
+            assertNotNull(claimSet);
+            assertNotNull(claimSet.getJWTID());
+            assertEquals(claimSet.getSubject(), "user_domain.user");
+            assertEquals(claimSet.getAudience().get(0), "targetdomain");
+            assertEquals(claimSet.getIssuer(), ztsImpl.ztsOAuthIssuer);
+            assertEquals(claimSet.getStringClaim("spiffe"), spiffeId);
+
+            List<String> scopes = claimSet.getStringListClaim("scp");
+            assertNotNull(scopes);
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
         } catch (Exception ex) {
             fail(ex.getMessage());
         }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplIDTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplIDTokenTest.java
@@ -390,6 +390,11 @@ public class ZTSImplIDTokenTest {
 
     private String createIdToken(PrivateKey privateKey, String keyId, String subject,
             String audience, long expiryTime, String issuer) {
+        return createIdToken(privateKey, keyId, subject, audience, expiryTime, issuer, null);
+    }
+
+    private String createIdToken(PrivateKey privateKey, String keyId, String subject,
+            String audience, long expiryTime, String issuer, String spiffe) {
         try {
             JWSSigner signer = JwtsHelper.getJWSSigner(privateKey);
             long now = System.currentTimeMillis() / 1000;
@@ -401,6 +406,9 @@ public class ZTSImplIDTokenTest {
                     .audience(audience)
                     .claim("ver", 1)
                     .claim("auth_time", now);
+            if (spiffe != null) {
+                builder.claim("spiffe", spiffe);
+            }
             JWTClaimsSet claimsSet = builder.build();
             SignedJWT signedJWT = new SignedJWT(
                     new JWSHeader.Builder(JWSAlgorithm.ES256)
@@ -601,6 +609,65 @@ public class ZTSImplIDTokenTest {
             assertNotNull(claimSet.getIssueTime());
             assertNotNull(claimSet.getClaim("auth_time"));
             assertTrue(claimSet.getExpirationTime().getTime() > System.currentTimeMillis());
+
+            List<String> groups = claimSet.getStringListClaim("groups");
+            assertNotNull(groups);
+            assertTrue(groups.contains("coretech:role.writers"));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+
+        ztsImpl.cloudStore.close();
+    }
+
+    @Test
+    public void testIdTokenExchangeSuccessWithSpiffeClaim() throws JOSEException {
+
+        ZTSImpl ztsImpl = createZtsImpl();
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        addIdTokenExchangePolicy("coretech", "user_domain.proxy-user1", "writers");
+
+        PrivateKey ecPrivateKey = loadECPrivateKey();
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        final String spiffeId = "spiffe://athenz.io/ns/default/sa/coretech.weather";
+        String subjectToken = createIdToken(ecPrivateKey, "0", "user_domain.user",
+                "user_domain.proxy-user1", expiryTime, null, spiffeId);
+
+        Principal principal = SimplePrincipal.create("user_domain", "proxy-user1",
+                "v=U1;d=user_domain;n=proxy-user1;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        String tokenRequest = buildIdTokenExchangeRequest(subjectToken, "coretech.storage",
+                "coretech:role.writers");
+
+        AccessTokenResponse response = ztsImpl.postAccessTokenRequest(context, tokenRequest);
+
+        assertNotNull(response);
+        assertNotNull(response.getId_token());
+        assertEquals(response.getToken_type(), "Bearer");
+        assertEquals(response.getIssued_token_type(), ZTSConsts.OAUTH_TOKEN_TYPE_ID);
+        assertTrue(response.getExpires_in() > 0);
+        assertNull(response.getAccess_token());
+
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(response.getId_token());
+            assertTrue(signedJWT.verify(verifier));
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+
+            assertNotNull(claimSet);
+            assertEquals(claimSet.getSubject(), "user_domain.user");
+            assertEquals(claimSet.getAudience().get(0), "coretech.storage");
+            assertNotNull(claimSet.getClaim("nonce"));
+            assertNotNull(claimSet.getIssueTime());
+            assertNotNull(claimSet.getClaim("auth_time"));
+            assertTrue(claimSet.getExpirationTime().getTime() > System.currentTimeMillis());
+            assertEquals(claimSet.getStringClaim("spiffe"), spiffeId);
 
             List<String> groups = claimSet.getStringListClaim("groups");
             assertNotNull(groups);


### PR DESCRIPTION
# Description
  - ZTS now propagates SPIFFE ID from the subject_token into Token Exchange outputs:
      - ID Token Exchange: copies spiffe into issued ID token (IdToken.setSpiffe) (servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java).
      - Access Token Exchange (impersonation/delegation): copies spiffe into issued access token as a custom claim (servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java).
  - Added tests covering SPIFFE propagation:
      - servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplIDTokenTest.java
      - servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
  - Updated docs: docs/zts_token_exchange_requirements.md.
  - Verified with: mvn -Dmaven.repo.local=/tmp/m2 -pl servers/zts -am -Dtest=ZTSImplIDTokenTest,ZTSImplAccessTokenTest -Dsurefire.failIfNoSpecifiedTests=false test.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

