### PR TITLE
S3 ChangeLog store with filtered domain support

### DIFF
--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStore.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStore.java
@@ -53,10 +53,10 @@ public class S3ChangeLogStore implements ChangeLogStore {
     long lastModTime;
     S3Client awsS3Client = null;
 
-    private String s3BucketName;
-    private String awsRegion;
-    private ObjectMapper jsonMapper;
-    private boolean jwsDomainSupport;
+    protected String s3BucketName;
+    protected String awsRegion;
+    protected ObjectMapper jsonMapper;
+    protected boolean jwsDomainSupport;
 
     private static final String NUMBER_OF_THREADS = "athenz.zts.bucket.threads";
     private static final String DEFAULT_TIMEOUT_SECONDS = "athenz.zts.bucket.threads.timeout";
@@ -255,6 +255,19 @@ public class S3ChangeLogStore implements ChangeLogStore {
      * @param modTime only include domains newer than this timestamp
      */
     void listObjects(S3Client s3, Collection<String> domains, long modTime) {
+        listObjects(s3, domains, modTime, null);
+    }
+
+    /**
+     * list the objects in the zts bucket. If the mod time is specified as 0
+     * then we want to list all objects otherwise, we only list objects
+     * that are newer than the specified timestamp
+     * @param s3 AWS S3 client object
+     * @param domains collection to be updated to include domain names
+     * @param modTime only include domains newer than this timestamp
+     * @param domainFilter the domain filter to use
+     */
+    void listObjects(S3Client s3, Collection<String> domains, long modTime, Set<String> domainFilter) {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("listObjects: Retrieving domains from {} with mod time > {}",
@@ -293,6 +306,11 @@ public class S3ChangeLogStore implements ChangeLogStore {
                 if (objectName.charAt(0) == '.') {
                     continue;
                 }
+
+                if (domainFilter != null && !domainFilter.contains(objectName)) {
+                    continue;
+                }
+
                 domains.add(objectName);
             }
 

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3FilteredChangeLogStore.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3FilteredChangeLogStore.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.athenz.server.aws.common.store.impl;
+
+import software.amazon.awssdk.services.s3.S3Client;
+
+import java.util.Collection;
+import java.util.Set;
+
+public class S3FilteredChangeLogStore extends S3ChangeLogStore {
+
+    private final Set<String> supportedDomains;
+
+    public S3FilteredChangeLogStore(final Set<String> supportedDomains) {
+        this.supportedDomains = supportedDomains;
+        super.init();
+        super.initAwsRegion();
+    }
+
+    /**
+     * list the objects which should match the supported domains. If the
+     * mod time is specified as 0 then we want to list all objects which
+     * match the supported domains otherwise, we only list objects
+     * that are newer than the specified timestamp
+     * @param s3 AWS S3 client object
+     * @param domains collection to be updated to include domain names
+     * @param modTime only include domains newer than this timestamp
+     */
+    @Override
+    void listObjects(S3Client s3, Collection<String> domains, long modTime) {
+        super.listObjects(s3, domains, modTime, supportedDomains);
+    }
+}

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3FilteredChangeLogStoreFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3FilteredChangeLogStoreFactory.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package io.athenz.server.aws.common.store.impl;
+
+import com.yahoo.athenz.common.server.store.ChangeLogStore;
+import com.yahoo.athenz.common.server.store.ChangeLogStoreFactory;
+
+import java.security.PrivateKey;
+import java.util.HashSet;
+import java.util.Set;
+
+/*
+ * Factory class for creating a filtered change log store implementation
+ * that only lists objects which match the supported domains. This is useful
+ * when the ZTS is only deployed to issue user certificates and not to store
+ * any data in the datastore. This is useful to reduce the load on the ZTS and
+ * the datastore. With the user certificate support, the datastore is only used
+ * to store the details about the provider service in the configured domain so
+ * there is no need to monitor and load data for all domains. This, of course,
+ * depends on the deployment configuration and the use case. With this factory,
+ * the ZTS instance can be deployed to only issue user certificates and not to
+ * issue any oauth2 access tokens nor service x.509 identity certificates.
+ */
+public class S3FilteredChangeLogStoreFactory implements ChangeLogStoreFactory {
+
+    private static final String ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER = "athenz.zts.s3_change_log_store_filter";
+
+    @Override
+    public ChangeLogStore create(String ztsHomeDir, PrivateKey privateKey, String privateKeyId) {
+
+        // to use the filtered change log store, we must have the configuration property
+        // that includes the list of domains to filter
+
+        String filter = System.getProperty(ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER);
+        if (filter == null) {
+            throw new IllegalArgumentException("athenz.zts.s3_change_log_store_filter property is required for the change log store");
+        }
+
+        // generate a list of domains to filter. the value is a comma separated list
+        // of domains to filter.
+
+        Set<String> domains = new HashSet<>();
+        for (String domain : filter.split(",")) {
+            domains.add(domain.trim());
+        }
+
+        if (domains.isEmpty()) {
+            throw new IllegalArgumentException("athenz.zts.s3_change_log_store_filter property must include at least one domain to filter");
+        }
+
+        return new S3FilteredChangeLogStore(domains);
+    }
+}

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3FilteredChangeLogStoreFactoryTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3FilteredChangeLogStoreFactoryTest.java
@@ -1,0 +1,82 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.athenz.server.aws.common.store.impl;
+
+import com.yahoo.athenz.common.server.store.ChangeLogStore;
+import org.testng.annotations.Test;
+
+import static com.yahoo.athenz.common.ServerCommonConsts.ZTS_PROP_AWS_BUCKET_NAME;
+import static com.yahoo.athenz.common.ServerCommonConsts.ZTS_PROP_AWS_REGION_NAME;
+import static org.testng.Assert.*;
+
+public class S3FilteredChangeLogStoreFactoryTest {
+
+    private static final String ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER = "athenz.zts.s3_change_log_store_filter";
+
+    @Test
+    public void testCreateStoreNullFilter() {
+        System.clearProperty(ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER);
+        S3FilteredChangeLogStoreFactory factory = new S3FilteredChangeLogStoreFactory();
+        try {
+            factory.create(null, null, null);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("athenz.zts.s3_change_log_store_filter"));
+        }
+    }
+
+    @Test
+    public void testCreateStoreValidFilter() {
+        System.setProperty(ZTS_PROP_AWS_BUCKET_NAME, "s3-unit-test-bucket-name");
+        System.setProperty(ZTS_PROP_AWS_REGION_NAME, "us-west-1");
+        System.setProperty(ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER, "iaas");
+
+        S3FilteredChangeLogStoreFactory factory = new S3FilteredChangeLogStoreFactory();
+        ChangeLogStore store = factory.create(null, null, null);
+        assertNotNull(store);
+        assertTrue(store instanceof S3FilteredChangeLogStore);
+
+        System.clearProperty(ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER);
+    }
+
+    @Test
+    public void testCreateStoreMultipleDomains() {
+        System.setProperty(ZTS_PROP_AWS_BUCKET_NAME, "s3-unit-test-bucket-name");
+        System.setProperty(ZTS_PROP_AWS_REGION_NAME, "us-west-1");
+        System.setProperty(ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER, "iaas,cd.docker,platforms");
+
+        S3FilteredChangeLogStoreFactory factory = new S3FilteredChangeLogStoreFactory();
+        ChangeLogStore store = factory.create(null, null, null);
+        assertNotNull(store);
+        assertTrue(store instanceof S3FilteredChangeLogStore);
+
+        System.clearProperty(ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER);
+    }
+
+    @Test
+    public void testCreateStoreWithWhitespace() {
+        System.setProperty(ZTS_PROP_AWS_BUCKET_NAME, "s3-unit-test-bucket-name");
+        System.setProperty(ZTS_PROP_AWS_REGION_NAME, "us-west-1");
+        System.setProperty(ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER, " iaas , cd.docker , platforms ");
+
+        S3FilteredChangeLogStoreFactory factory = new S3FilteredChangeLogStoreFactory();
+        ChangeLogStore store = factory.create(null, null, null);
+        assertNotNull(store);
+        assertTrue(store instanceof S3FilteredChangeLogStore);
+
+        System.clearProperty(ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER);
+    }
+}

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3FilteredChangeLogStoreTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3FilteredChangeLogStoreTest.java
@@ -1,0 +1,232 @@
+/*
+ *  Copyright The Athenz Authors
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package io.athenz.server.aws.common.store.impl;
+
+import static com.yahoo.athenz.common.ServerCommonConsts.ZTS_PROP_AWS_BUCKET_NAME;
+import static com.yahoo.athenz.common.ServerCommonConsts.ZTS_PROP_AWS_REGION_NAME;
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+import java.util.*;
+
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.*;
+
+public class S3FilteredChangeLogStoreTest {
+
+    @BeforeMethod
+    public void setup() {
+        System.setProperty(ZTS_PROP_AWS_BUCKET_NAME, "s3-unit-test-bucket-name");
+        System.setProperty(ZTS_PROP_AWS_REGION_NAME, "test-region");
+    }
+
+    @Test
+    public void testListObjectsFilteredNoModTime() {
+
+        Set<String> supportedDomains = new HashSet<>(Arrays.asList("iaas", "cd.docker"));
+        MockS3FilteredChangeLogStore store = new MockS3FilteredChangeLogStore(supportedDomains);
+
+        ListObjectsV2Response mockResponse = mock(ListObjectsV2Response.class);
+        ArrayList<S3Object> objectList = new ArrayList<>();
+        objectList.add(S3Object.builder().key("iaas").build());
+        objectList.add(S3Object.builder().key("iaas.athenz").build());
+        objectList.add(S3Object.builder().key("cd.docker").build());
+        objectList.add(S3Object.builder().key("platforms").build());
+
+        when(mockResponse.contents()).thenReturn(objectList);
+        when(mockResponse.isTruncated()).thenReturn(false);
+        when(store.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(mockResponse);
+
+        ArrayList<String> domains = new ArrayList<>();
+        store.listObjects(store.awsS3Client, domains, 0);
+
+        assertEquals(domains.size(), 2);
+        assertTrue(domains.contains("iaas"));
+        assertTrue(domains.contains("cd.docker"));
+        assertFalse(domains.contains("iaas.athenz"));
+        assertFalse(domains.contains("platforms"));
+    }
+
+    @Test
+    public void testListObjectsFilteredWithModTime() {
+
+        Set<String> supportedDomains = new HashSet<>(Arrays.asList("iaas", "iaas.athenz", "cd.docker"));
+        MockS3FilteredChangeLogStore store = new MockS3FilteredChangeLogStore(supportedDomains);
+
+        ListObjectsV2Response mockResponse = mock(ListObjectsV2Response.class);
+        ArrayList<S3Object> objectList = new ArrayList<>();
+        objectList.add(S3Object.builder().key("iaas").lastModified((new Date(100)).toInstant()).build());
+        objectList.add(S3Object.builder().key("iaas.athenz").lastModified((new Date(200)).toInstant()).build());
+        objectList.add(S3Object.builder().key("cd.docker").lastModified((new Date(200)).toInstant()).build());
+        objectList.add(S3Object.builder().key("platforms").lastModified((new Date(200)).toInstant()).build());
+
+        when(mockResponse.contents()).thenReturn(objectList);
+        when(mockResponse.isTruncated()).thenReturn(false);
+        when(store.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(mockResponse);
+
+        ArrayList<String> domains = new ArrayList<>();
+        store.listObjects(store.awsS3Client, domains, (new Date(150)).getTime());
+
+        // iaas filtered out by modTime (100 <= 150), platforms filtered out by domain filter
+        assertEquals(domains.size(), 2);
+        assertTrue(domains.contains("iaas.athenz"));
+        assertTrue(domains.contains("cd.docker"));
+    }
+
+    @Test
+    public void testListObjectsFilteredMultiplePages() {
+
+        Set<String> supportedDomains = new HashSet<>(Arrays.asList("iaas", "platforms"));
+        MockS3FilteredChangeLogStore store = new MockS3FilteredChangeLogStore(supportedDomains);
+
+        ListObjectsV2Response mockResponse = mock(ListObjectsV2Response.class);
+
+        ArrayList<S3Object> objectList1 = new ArrayList<>();
+        objectList1.add(S3Object.builder().key("iaas").build());
+        objectList1.add(S3Object.builder().key("iaas.athenz").build());
+
+        ArrayList<S3Object> objectList2 = new ArrayList<>();
+        objectList2.add(S3Object.builder().key("cd.docker").build());
+        objectList2.add(S3Object.builder().key("platforms").build());
+
+        when(mockResponse.contents())
+                .thenReturn(objectList1)
+                .thenReturn(objectList2);
+        when(mockResponse.isTruncated())
+                .thenReturn(true)
+                .thenReturn(false);
+        when(store.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(mockResponse);
+
+        ArrayList<String> domains = new ArrayList<>();
+        store.listObjects(store.awsS3Client, domains, 0);
+
+        assertEquals(domains.size(), 2);
+        assertTrue(domains.contains("iaas"));
+        assertTrue(domains.contains("platforms"));
+    }
+
+    @Test
+    public void testListObjectsEmptyFilter() {
+
+        Set<String> supportedDomains = new HashSet<>();
+        MockS3FilteredChangeLogStore store = new MockS3FilteredChangeLogStore(supportedDomains);
+
+        ListObjectsV2Response mockResponse = mock(ListObjectsV2Response.class);
+        ArrayList<S3Object> objectList = new ArrayList<>();
+        objectList.add(S3Object.builder().key("iaas").build());
+        objectList.add(S3Object.builder().key("cd.docker").build());
+
+        when(mockResponse.contents()).thenReturn(objectList);
+        when(mockResponse.isTruncated()).thenReturn(false);
+        when(store.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(mockResponse);
+
+        ArrayList<String> domains = new ArrayList<>();
+        store.listObjects(store.awsS3Client, domains, 0);
+
+        assertEquals(domains.size(), 0);
+    }
+
+    @Test
+    public void testListObjectsFilteredSkipsHiddenDomains() {
+
+        Set<String> supportedDomains = new HashSet<>(Arrays.asList("iaas", ".hidden"));
+        MockS3FilteredChangeLogStore store = new MockS3FilteredChangeLogStore(supportedDomains);
+
+        ListObjectsV2Response mockResponse = mock(ListObjectsV2Response.class);
+        ArrayList<S3Object> objectList = new ArrayList<>();
+        objectList.add(S3Object.builder().key("iaas").build());
+        objectList.add(S3Object.builder().key(".hidden").build());
+        objectList.add(S3Object.builder().key("cd.docker").build());
+
+        when(mockResponse.contents()).thenReturn(objectList);
+        when(mockResponse.isTruncated()).thenReturn(false);
+        when(store.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(mockResponse);
+
+        ArrayList<String> domains = new ArrayList<>();
+        store.listObjects(store.awsS3Client, domains, 0);
+
+        assertEquals(domains.size(), 1);
+        assertTrue(domains.contains("iaas"));
+        assertFalse(domains.contains(".hidden"));
+    }
+
+    @Test
+    public void testGetServerDomainListFiltered() {
+
+        Set<String> supportedDomains = new HashSet<>(Collections.singletonList("iaas"));
+        MockS3FilteredChangeLogStore store = new MockS3FilteredChangeLogStore(supportedDomains);
+
+        ListObjectsV2Response mockResponse = mock(ListObjectsV2Response.class);
+        ArrayList<S3Object> objectList = new ArrayList<>();
+        objectList.add(S3Object.builder().key("iaas").build());
+        objectList.add(S3Object.builder().key("iaas.athenz").build());
+        objectList.add(S3Object.builder().key("cd.docker").build());
+
+        when(mockResponse.contents()).thenReturn(objectList);
+        when(mockResponse.isTruncated()).thenReturn(false);
+        when(store.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(mockResponse);
+
+        Set<String> domains = store.getServerDomainList();
+
+        assertEquals(domains.size(), 1);
+        assertTrue(domains.contains("iaas"));
+    }
+
+    @Test
+    public void testGetLocalDomainListFiltered() {
+
+        Set<String> supportedDomains = new HashSet<>(Arrays.asList("iaas", "cd.docker"));
+        MockS3FilteredChangeLogStore store = new MockS3FilteredChangeLogStore(supportedDomains);
+
+        ListObjectsV2Response mockResponse = mock(ListObjectsV2Response.class);
+        ArrayList<S3Object> objectList = new ArrayList<>();
+        objectList.add(S3Object.builder().key("iaas").build());
+        objectList.add(S3Object.builder().key("iaas.athenz").build());
+        objectList.add(S3Object.builder().key("cd.docker").build());
+        objectList.add(S3Object.builder().key("platforms").build());
+
+        when(mockResponse.contents()).thenReturn(objectList);
+        when(mockResponse.isTruncated()).thenReturn(false);
+        when(store.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(mockResponse);
+
+        List<String> domains = store.getLocalDomainList();
+
+        assertEquals(domains.size(), 2);
+        assertTrue(domains.contains("iaas"));
+        assertTrue(domains.contains("cd.docker"));
+    }
+
+    static class MockS3FilteredChangeLogStore extends S3FilteredChangeLogStore {
+
+        S3Client awsS3Client;
+
+        public MockS3FilteredChangeLogStore(Set<String> supportedDomains) {
+            super(supportedDomains);
+            awsS3Client = mock(S3Client.class);
+        }
+
+        @Override
+        S3Client getS3Client() {
+            if (awsS3Client == null) {
+                awsS3Client = mock(S3Client.class);
+            }
+            return awsS3Client;
+        }
+    }
+}


### PR DESCRIPTION
# Description

can be used with #3238 to have an ZTS instance allocated for user certs only

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

