### PR TITLE
libs/go/sia/util: fix dropped error

### DIFF
--- a/libs/go/sia/util/util.go
+++ b/libs/go/sia/util/util.go
@@ -1464,6 +1464,9 @@ func GetRoleCertificate(athenzDomain, athenzService, instanceId, athenzProvider,
 		return nil, err
 	}
 	tlsCertificate, err := tls.X509KeyPair([]byte(roleCertificate.X509Certificate), []byte(svcTLSCert.PrivateKeyPem))
+	if err != nil {
+		return nil, err
+	}
 	x509Certificate, err := ParseCertificate(roleCertificate.X509Certificate)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes a dropped `err` in `libs/go/sia/util`. Unit tests pass both before and after the change.