### PR TITLE
feat: add Spacelift OIDC inbound provider for service identity authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
 **/.idea
+**/.venv
 **/.classpath
 **/.project
 **/.settings

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceSpaceliftProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceSpaceliftProvider.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.yahoo.athenz.auth.Authorizer;
+import com.yahoo.athenz.auth.KeyStore;
+import com.yahoo.athenz.auth.Principal;
+import com.yahoo.athenz.auth.impl.SimplePrincipal;
+import com.yahoo.athenz.auth.token.jwts.JwtsHelper;
+import com.yahoo.athenz.auth.token.jwts.JwtsSigningKeyResolver;
+import com.yahoo.athenz.common.server.util.config.dynamic.DynamicConfigLong;
+import com.yahoo.athenz.instance.provider.InstanceConfirmation;
+import com.yahoo.athenz.instance.provider.InstanceProvider;
+import com.yahoo.athenz.instance.provider.ProviderResourceException;
+import org.eclipse.jetty.util.StringUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLContext;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import static com.yahoo.athenz.common.server.util.config.ConfigManagerSingleton.CONFIG_MANAGER;
+
+/**
+ * Instance provider for Spacelift, based on its OIDC setup:
+ * <ul>
+ *     <li><a href="https://docs.spacelift.io/integrations/cloud-providers/oidc">Overview</a></li>
+ * </ul>
+ */
+public class InstanceSpaceliftProvider implements InstanceProvider {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(InstanceSpaceliftProvider.class);
+
+    private static final String URI_INSTANCE_ID_PREFIX = "athenz://instanceid/";
+    private static final String URI_SPIFFE_PREFIX = "spiffe://";
+
+    static final String SPACELIFT_PROP_PROVIDER_DNS_SUFFIX = "athenz.zts.spacelift.provider_dns_suffix";
+    static final String SPACELIFT_PROP_BOOT_TIME_OFFSET    = "athenz.zts.spacelift.boot_time_offset";
+    static final String SPACELIFT_PROP_CERT_EXPIRY_TIME    = "athenz.zts.spacelift.cert_expiry_time";
+    static final String SPACELIFT_PROP_AUDIENCE            = "athenz.zts.spacelift.audience";
+    static final String SPACELIFT_PROP_ISSUER              = "athenz.zts.spacelift.issuer";
+    static final String SPACELIFT_PROP_JWKS_URI            = "athenz.zts.spacelift.jwks_uri";
+
+    public static final String CLAIM_SPACE_ID    = "spaceId";
+    public static final String CLAIM_CALLER_TYPE = "callerType";
+    public static final String CLAIM_CALLER_ID   = "callerId";
+    public static final String CLAIM_RUN_TYPE    = "runType";
+    public static final String CLAIM_RUN_ID      = "runId";
+
+    Set<String> dnsSuffixes = null;
+    String spaceliftIssuer = null;
+    String provider = null;
+    String audience = null;
+    ConfigurableJWTProcessor<SecurityContext> jwtProcessor = null;
+    Authorizer authorizer = null;
+    DynamicConfigLong bootTimeOffsetSeconds;
+    long certExpiryTime;
+
+    @Override
+    public Scheme getProviderScheme() {
+        return Scheme.CLASS;
+    }
+
+    @Override
+    public void initialize(String provider, String providerEndpoint, SSLContext sslContext, KeyStore keyStore) {
+
+        // save our provider name
+
+        this.provider = provider;
+
+        // lookup the zts audience. if not specified we'll default to athenz.io
+
+        audience = System.getProperty(SPACELIFT_PROP_AUDIENCE, "athenz.io");
+
+        // determine the dns suffix. if this is not specified we'll just default to spacelift.athenz.io
+
+        final String dnsSuffix = System.getProperty(SPACELIFT_PROP_PROVIDER_DNS_SUFFIX, "spacelift.athenz.io");
+        dnsSuffixes = Set.of(dnsSuffix.split(","));
+
+        // how long the instance must be booted in the past before we
+        // stop validating the instance requests
+
+        long timeout = TimeUnit.SECONDS.convert(5, TimeUnit.MINUTES);
+        bootTimeOffsetSeconds = new DynamicConfigLong(CONFIG_MANAGER, SPACELIFT_PROP_BOOT_TIME_OFFSET, timeout);
+
+        // get default/max expiry time for any generated tokens - 6 hours
+
+        certExpiryTime = Long.parseLong(System.getProperty(SPACELIFT_PROP_CERT_EXPIRY_TIME, "360"));
+
+        // initialize our jwt processor. the issuer is required since
+        // spacelift uses per-account issuer urls
+
+        spaceliftIssuer = System.getProperty(SPACELIFT_PROP_ISSUER);
+        if (StringUtil.isEmpty(spaceliftIssuer)) {
+            throw new IllegalArgumentException("InstanceSpaceliftProvider: Issuer not specified");
+        }
+
+        jwtProcessor = JwtsHelper.getJWTProcessor(new JwtsSigningKeyResolver(extractSpaceliftIssuerJwksUri(spaceliftIssuer), null));
+    }
+
+    String extractSpaceliftIssuerJwksUri(final String issuer) {
+
+        // if we have the value configured then that's what we're going to use
+
+        final String jwksUri = System.getProperty(SPACELIFT_PROP_JWKS_URI);
+        if (!StringUtil.isEmpty(jwksUri)) {
+            return jwksUri;
+        }
+
+        // otherwise we'll assume the issuer follows the standard and
+        // includes the jwks uri in its openid configuration
+
+        final String openIdConfigUri = issuer + "/.well-known/openid-configuration";
+        JwtsHelper helper = new JwtsHelper();
+        return helper.extractJwksUri(openIdConfigUri, null);
+    }
+
+    private ProviderResourceException forbiddenError(String message) {
+        LOGGER.error(message);
+        return new ProviderResourceException(ProviderResourceException.FORBIDDEN, message);
+    }
+
+    @Override
+    public void setAuthorizer(Authorizer authorizer) {
+        this.authorizer = authorizer;
+    }
+
+    @Override
+    public InstanceConfirmation confirmInstance(InstanceConfirmation confirmation) throws ProviderResourceException {
+
+        // before running any checks make sure we have a valid authorizer
+
+        if (authorizer == null) {
+            throw forbiddenError("Authorizer not available");
+        }
+
+        final String instanceDomain = confirmation.getDomain();
+        final String instanceService = confirmation.getService();
+        final Map<String, String> instanceAttributes = confirmation.getAttributes();
+
+        // our request must not have any sanIPs or hostnames
+
+        if (!StringUtil.isEmpty(InstanceUtils.getInstanceProperty(instanceAttributes,
+                InstanceProvider.ZTS_INSTANCE_SAN_IP))) {
+            throw forbiddenError("Request must not have any sanIP addresses");
+        }
+
+        if (!StringUtil.isEmpty(InstanceUtils.getInstanceProperty(instanceAttributes,
+                InstanceProvider.ZTS_INSTANCE_HOSTNAME))) {
+            throw forbiddenError("Request must not have any hostname values");
+        }
+
+        // validate san URI
+
+        if (!validateSanUri(InstanceUtils.getInstanceProperty(instanceAttributes,
+                InstanceProvider.ZTS_INSTANCE_SAN_URI))) {
+            throw forbiddenError("Unable to validate certificate request URI values");
+        }
+
+        // we need to validate the token which is our attestation
+        // data for the service requesting a certificate
+
+        final String attestationData = confirmation.getAttestationData();
+        if (StringUtil.isEmpty(attestationData)) {
+            throw forbiddenError("Service credentials not provided");
+        }
+
+        StringBuilder errMsg = new StringBuilder(256);
+        final String reqInstanceId = InstanceUtils.getInstanceProperty(instanceAttributes,
+                InstanceProvider.ZTS_INSTANCE_ID);
+        if (!validateOIDCToken(attestationData, instanceDomain, instanceService, reqInstanceId, errMsg)) {
+            throw forbiddenError("Unable to validate Certificate Request: " + errMsg);
+        }
+
+        // validate the certificate san DNS names
+
+        StringBuilder instanceId = new StringBuilder(256);
+        if (!InstanceUtils.validateCertRequestSanDnsNames(instanceAttributes, instanceDomain,
+                instanceService, dnsSuffixes, null, null, false, instanceId, null)) {
+            throw forbiddenError("Unable to validate certificate request sanDNS entries");
+        }
+
+        // set our cert attributes in the return object.
+        // for Spacelift we do not allow refresh of those certificates, and
+        // the issued certificate can only be used by clients and not servers
+
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put(InstanceProvider.ZTS_CERT_REFRESH, "false");
+        attributes.put(InstanceProvider.ZTS_CERT_USAGE, ZTS_CERT_USAGE_CLIENT);
+        attributes.put(InstanceProvider.ZTS_CERT_EXPIRY_TIME, Long.toString(certExpiryTime));
+
+        confirmation.setAttributes(attributes);
+        return confirmation;
+    }
+
+    @Override
+    public InstanceConfirmation refreshInstance(InstanceConfirmation confirmation) throws ProviderResourceException {
+
+        // we do not allow refresh of Spacelift certificates
+
+        throw forbiddenError("Spacelift X.509 Certificates cannot be refreshed");
+    }
+
+    /**
+     * verifies that sanUri only contains the spiffe and instance id uris
+     * @param sanUri the SAN URI value
+     * @return true if it only contains spiffe and instance id uris, otherwise false
+     */
+    boolean validateSanUri(final String sanUri) {
+
+        if (StringUtil.isEmpty(sanUri)) {
+            LOGGER.debug("Request contains no sanURI to verify");
+            return true;
+        }
+
+        for (String uri: sanUri.split(",")) {
+            if (uri.startsWith(URI_SPIFFE_PREFIX) || uri.startsWith(URI_INSTANCE_ID_PREFIX)) {
+                continue;
+            }
+            LOGGER.error("Request contains unsupported uri value: {}", uri);
+            return false;
+        }
+
+        return true;
+    }
+
+    boolean validateOIDCToken(final String jwToken, final String domainName, final String serviceName,
+            final String instanceId, StringBuilder errMsg) {
+
+        if (jwtProcessor == null) {
+            errMsg.append("JWT Processor not initialized");
+            return false;
+        }
+
+        JWTClaimsSet claimsSet;
+        try {
+            claimsSet = jwtProcessor.process(jwToken, null);
+        } catch (Exception ex) {
+            errMsg.append("Unable to parse and validate token: ").append(ex.getMessage());
+            return false;
+        }
+
+        // verify the issuer is set to Spacelift
+
+        if (!spaceliftIssuer.equals(claimsSet.getIssuer())) {
+            errMsg.append("token issuer is not Spacelift: ").append(claimsSet.getIssuer());
+            return false;
+        }
+
+        // verify that token audience is set for our service
+
+        if (!audience.equals(JwtsHelper.getAudience(claimsSet))) {
+            errMsg.append("token audience is not ZTS Server audience: ").append(JwtsHelper.getAudience(claimsSet));
+            return false;
+        }
+
+        // need to verify that the issue time is within our configured bootstrap time
+
+        Date issueDate = claimsSet.getIssueTime();
+        if (issueDate == null || issueDate.getTime() < System.currentTimeMillis() -
+                TimeUnit.SECONDS.toMillis(bootTimeOffsetSeconds.get())) {
+            errMsg.append("job start time is not recent enough, issued at: ").append(issueDate);
+            return false;
+        }
+
+        // verify that the instance id matches the claims in the token
+
+        if (!validateInstanceId(instanceId, claimsSet, errMsg)) {
+            return false;
+        }
+
+        // verify the domain and service names in the token based on our configuration
+
+        return validateTenantDomainToken(claimsSet, domainName, serviceName, errMsg);
+    }
+
+    boolean validateInstanceId(final String instanceId, final JWTClaimsSet claimsSet, StringBuilder errMsg) {
+
+        // the format for our instance id is <spaceId>:<callerId>:<runId>
+
+        final String spaceId = JwtsHelper.getStringClaim(claimsSet, CLAIM_SPACE_ID);
+        if (StringUtil.isEmpty(spaceId)) {
+            errMsg.append("token does not contain required ").append(CLAIM_SPACE_ID).append(" claim");
+            return false;
+        }
+        final String callerId = JwtsHelper.getStringClaim(claimsSet, CLAIM_CALLER_ID);
+        if (StringUtil.isEmpty(callerId)) {
+            errMsg.append("token does not contain required ").append(CLAIM_CALLER_ID).append(" claim");
+            return false;
+        }
+        final String runId = JwtsHelper.getStringClaim(claimsSet, CLAIM_RUN_ID);
+        if (StringUtil.isEmpty(runId)) {
+            errMsg.append("token does not contain required ").append(CLAIM_RUN_ID).append(" claim");
+            return false;
+        }
+
+        final String tokenInstanceId = spaceId + ":" + callerId + ":" + runId;
+        if (!tokenInstanceId.equals(instanceId)) {
+            errMsg.append("invalid instance id: ").append(tokenInstanceId).append("/").append(instanceId);
+            return false;
+        }
+        return true;
+    }
+
+    boolean validateTenantDomainToken(final JWTClaimsSet claimsSet, final String domainName, final String serviceName,
+            StringBuilder errMsg) {
+
+        // we need to generate our resource value based on the subject
+
+        final String subject = claimsSet.getSubject();
+        if (StringUtil.isEmpty(subject)) {
+            errMsg.append("token does not contain required subject claim");
+            return false;
+        }
+
+        // generate our principal object and carry out authorization check
+
+        final String resource = domainName + ":" + subject;
+        Principal principal = SimplePrincipal.create(domainName, serviceName, (String) null);
+
+        // Spacelift has no event/action type; instead, the user must configure policies based
+        // on the subject claim which includes space, stack/module, run_type, and scope.
+        // e.g., 'space:<SPACE>:stack:<STACK>:run_type:TRACKED:scope:write'
+        // vs 'space:<SPACE>:stack:<STACK>:run_type:*:scope:*' for broader access.
+
+        final String action = "spacelift.run";
+        if (!authorizer.access(action, resource, principal, null)) {
+            errMsg.append("authorization check failed for action ").append(action).append(", resource: ").append(resource);
+            return false;
+        }
+        return true;
+    }
+}

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceSpaceliftProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/InstanceSpaceliftProvider.java
@@ -61,11 +61,11 @@ public class InstanceSpaceliftProvider implements InstanceProvider {
     static final String SPACELIFT_PROP_ISSUER              = "athenz.zts.spacelift.issuer";
     static final String SPACELIFT_PROP_JWKS_URI            = "athenz.zts.spacelift.jwks_uri";
 
-    public static final String CLAIM_SPACE_ID    = "spaceId";
-    public static final String CLAIM_CALLER_TYPE = "callerType";
-    public static final String CLAIM_CALLER_ID   = "callerId";
-    public static final String CLAIM_RUN_TYPE    = "runType";
-    public static final String CLAIM_RUN_ID      = "runId";
+    private static final String CLAIM_SPACE_ID    = "spaceId";
+    private static final String CLAIM_CALLER_TYPE = "callerType";
+    private static final String CLAIM_CALLER_ID   = "callerId";
+    private static final String CLAIM_RUN_TYPE    = "runType";
+    private static final String CLAIM_RUN_ID      = "runId";
 
     Set<String> dnsSuffixes = null;
     String spaceliftIssuer = null;

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceSpaceliftProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/InstanceSpaceliftProviderTest.java
@@ -1,0 +1,625 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.instance.provider.impl;
+
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.yahoo.athenz.auth.Authorizer;
+import com.yahoo.athenz.auth.Principal;
+import com.yahoo.athenz.auth.impl.SimplePrincipal;
+import com.yahoo.athenz.auth.util.Crypto;
+import com.yahoo.athenz.instance.provider.InstanceConfirmation;
+import com.yahoo.athenz.instance.provider.InstanceProvider;
+import com.yahoo.athenz.instance.provider.ProviderResourceException;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.startsWith;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+public class InstanceSpaceliftProviderTest {
+
+    private final File ecPrivateKey = new File("./src/test/resources/unit_test_ec_private.key");
+
+    private final ClassLoader classLoader = this.getClass().getClassLoader();
+
+    private final Map<String, ?> testClaims = Map.of(
+            "iss", "https://demo.app.spacelift.io",
+            "aud", "https://athenz.io",
+            "sub", "space:my-space:stack:my-stack:run_type:TRACKED:scope:write",
+            "spaceId", "my-space",
+            "callerType", "stack",
+            "callerId", "my-stack",
+            "runType", "TRACKED",
+            "runId", "run-uuid-123",
+            "scope", "write"
+    );
+
+    static void createOpenIdConfigFile(File configFile, File jwksUri) throws IOException {
+
+        String fileContents;
+        if (jwksUri == null) {
+            fileContents = "{}";
+        } else {
+            fileContents = "{\n" +
+                    "    \"jwks_uri\": \"file://" + jwksUri.getCanonicalPath() + "\"\n" +
+                    "}";
+        }
+        Files.createDirectories(configFile.toPath().getParent());
+        Files.write(configFile.toPath(), fileContents.getBytes());
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        System.clearProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_AUDIENCE);
+        System.clearProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI);
+        System.clearProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER);
+    }
+
+    @Test
+    public void testInitializeWithConfig() {
+        String jwksUri = "https://test.jwks";
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+        assertEquals(provider.getProviderScheme(), InstanceProvider.Scheme.CLASS);
+    }
+
+    @Test
+    public void testInitializeWithOpenIdConfig() throws IOException {
+
+        File issuerFile = new File("./src/test/resources/config-openid/");
+        File configFile = new File("./src/test/resources/config-openid/.well-known/openid-configuration");
+        File jwksUriFile = new File("./src/test/resources/jwt-jwks.json");
+        createOpenIdConfigFile(configFile, jwksUriFile);
+
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "file://" + issuerFile.getCanonicalPath());
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+        assertNotNull(provider);
+        Files.delete(configFile.toPath());
+    }
+
+    @Test
+    public void testInitializeWithOpenIdConfigWithoutUri() throws IOException {
+
+        File issuerFile = new File("./src/test/resources/config-openid/");
+        File configFile = new File("./src/test/resources/config-openid/.well-known/openid-configuration");
+        createOpenIdConfigFile(configFile, null);
+
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "file://" + issuerFile.getCanonicalPath());
+
+        // without a jwks_uri in the openid config and no explicit jwks_uri property,
+        // the provider should fail to initialize since there is no fallback
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        try {
+            provider.initialize("sys.auth.spacelift",
+                    "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+            fail();
+        } catch (Exception ex) {
+            assertTrue(ex.getMessage().contains("Jwks uri must be specified"));
+        }
+        Files.delete(configFile.toPath());
+    }
+
+    @Test
+    public void testInitializeMissingIssuer() {
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        try {
+            provider.initialize("sys.auth.spacelift",
+                    "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+            fail();
+        } catch (IllegalArgumentException ex) {
+            assertTrue(ex.getMessage().contains("Issuer not specified"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstance() throws ProviderResourceException {
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Principal trackedPrincipal = SimplePrincipal.create("sports", "api", (String) null);
+        Principal proposedPrincipal = SimplePrincipal.create("sports", "pr", (String) null);
+        String trackedResource = "sports:space:my-space:stack:my-stack:run_type:TRACKED";
+        String proposedResource = "sports:space:my-space:stack:my-stack:run_type:PROPOSED";
+        String action = "spacelift.run";
+        Mockito.when(authorizer.access(eq(action), startsWith(trackedResource), eq(trackedPrincipal), isNull()))
+                .thenReturn(true);
+        Mockito.when(authorizer.access(eq(action), startsWith(proposedResource), eq(proposedPrincipal), isNull()))
+                .thenReturn(true);
+        provider.setAuthorizer(authorizer);
+
+        // test for a tracked run requesting the main service
+
+        Map<String, String> instanceAttributes = new HashMap<>();
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_ID, "my-space:my-stack:run-uuid-123");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "spiffe://ns/default/sports/api,athenz://instanceid/sys.auth.spacelift/my-space:my-stack:run-uuid-123");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_DNS, "api.sports.spacelift.athenz.io");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain("sports");
+        confirmation.setService("api");
+
+        Map<String, Object> claims = new HashMap<>(testClaims);
+        confirmation.setAttestationData(generateIdToken(Duration.ZERO, claims));
+        confirmation.setAttributes(instanceAttributes);
+
+        InstanceConfirmation confirmResponse = provider.confirmInstance(confirmation);
+        assertNotNull(confirmResponse);
+        assertEquals(confirmResponse.getAttributes().get(InstanceProvider.ZTS_CERT_REFRESH), "false");
+        assertEquals(confirmResponse.getAttributes().get(InstanceProvider.ZTS_CERT_USAGE), "client");
+        assertEquals(confirmResponse.getAttributes().get(InstanceProvider.ZTS_CERT_EXPIRY_TIME), "360");
+
+        // test for a proposed run requesting the main service (should fail)
+
+        claims.put("sub", "space:my-space:stack:my-stack:run_type:PROPOSED:scope:read");
+        claims.put("runType", "PROPOSED");
+        claims.put("scope", "read");
+        confirmation.setAttestationData(generateIdToken(Duration.ZERO, claims));
+        confirmation.setAttributes(instanceAttributes);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("authorization check failed for action"));
+        }
+
+        // test for a proposed run requesting the pr service
+
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "spiffe://ns/default/sports/pr,athenz://instanceid/sys.auth.spacelift/my-space:my-stack:run-uuid-123");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_DNS, "pr.sports.spacelift.athenz.io");
+        confirmation.setService("pr");
+        confirmation.setAttestationData(generateIdToken(Duration.ZERO, claims));
+        confirmation.setAttributes(instanceAttributes);
+
+        confirmResponse = provider.confirmInstance(confirmation);
+        assertNotNull(confirmResponse);
+    }
+
+    @Test
+    public void testConfirmInstanceFailures() {
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks_empty.json")).toString();
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Principal principal = SimplePrincipal.create("sports", "api", (String) null);
+        Mockito.when(authorizer.access(eq("spacelift.run"), startsWith("sports:space:my-space:stack:my-stack:run_type:TRACKED"), eq(principal), isNull()))
+                .thenReturn(true);
+        provider.setAuthorizer(authorizer);
+
+        Map<String, String> instanceAttributes = new HashMap<>();
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_ID, "my-space:my-stack:run-uuid-123");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "spiffe://ns/default/sports/api,athenz://instanceid/sys.auth.spacelift/my-space:my-stack:run-uuid-123");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_DNS, "host1.athenz.io");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain("sports");
+        confirmation.setService("api");
+        confirmation.setAttestationData(generateIdToken(Duration.ZERO, testClaims));
+        confirmation.setAttributes(instanceAttributes);
+
+        // without the public key we should get a token validation failure
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("no matching key(s) found"));
+        }
+
+        provider.close();
+    }
+
+    @Test
+    public void testConfirmInstanceFailuresInvalidSanDNS() {
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        Principal principal = SimplePrincipal.create("sports", "api", (String) null);
+        Mockito.when(authorizer.access(eq("spacelift.run"), startsWith("sports:space:my-space:stack:my-stack:run_type:TRACKED"), eq(principal), isNull()))
+                .thenReturn(true);
+        provider.setAuthorizer(authorizer);
+
+        Map<String, String> instanceAttributes = new HashMap<>();
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_ID, "my-space:my-stack:run-uuid-123");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "spiffe://ns/default/sports/api,athenz://instanceid/sys.auth.spacelift/my-space:my-stack:run-uuid-123");
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_DNS, "host1.athenz.io");
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain("sports");
+        confirmation.setService("api");
+        confirmation.setAttestationData(generateIdToken(Duration.ZERO, testClaims));
+        confirmation.setAttributes(instanceAttributes);
+
+        // we should get a failure due to invalid san dns entry
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Unable to validate certificate request sanDNS entries"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceWithoutAuthorizer() {
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, "https://config.athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+        provider.setAuthorizer(null);
+        try {
+            provider.confirmInstance(null);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Authorizer not available"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceWithSanIP() {
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, "https://config.athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        provider.setAuthorizer(authorizer);
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        Map<String, String> instanceAttributes = new HashMap<>();
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_IP, "10.1.1.1");
+        confirmation.setAttributes(instanceAttributes);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Request must not have any sanIP addresses"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceWithHostname() {
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, "https://config.athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        provider.setAuthorizer(authorizer);
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        Map<String, String> instanceAttributes = new HashMap<>();
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_HOSTNAME, "host1.athenz.io");
+        confirmation.setAttributes(instanceAttributes);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Request must not have any hostname values"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceWithSanURI() {
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, "https://config.athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        provider.setAuthorizer(authorizer);
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        Map<String, String> instanceAttributes = new HashMap<>();
+        instanceAttributes.put(InstanceProvider.ZTS_INSTANCE_SAN_URI, "spiffe://ns/athenz.production/instanceid,https://athenz.io");
+        confirmation.setAttributes(instanceAttributes);
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Unable to validate certificate request URI values"));
+        }
+    }
+
+    @Test
+    public void testConfirmInstanceWithoutAttestationData() {
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, "https://config.athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        Authorizer authorizer = Mockito.mock(Authorizer.class);
+        provider.setAuthorizer(authorizer);
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Service credentials not provided"));
+        }
+    }
+
+    @Test
+    public void testRefreshNotSupported() {
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, "https://config.athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+        try {
+            provider.refreshInstance(null);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Spacelift X.509 Certificates cannot be refreshed"));
+        }
+    }
+
+    @Test
+    public void testValidateSanUri() {
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        assertTrue(provider.validateSanUri(null));
+        assertTrue(provider.validateSanUri(""));
+        assertTrue(provider.validateSanUri("spiffe://ns/athenz.production/instanceid"));
+        assertTrue(provider.validateSanUri("athenz://instanceid/athenz.production/instanceid"));
+        assertTrue(provider.validateSanUri("athenz://instanceid/athenz.production/instanceid,spiffe://ns/athenz.production/instanceid"));
+        assertFalse(provider.validateSanUri("athenz://instanceid/athenz.production/instanceid,spiffe://ns/athenz.production/instanceid,https://athenz.io"));
+        assertFalse(provider.validateSanUri("athenz://hostname/host1,athenz://instanceid/athenz.production/instanceid"));
+        assertFalse(provider.validateSanUri("athenz://hostname/host1"));
+    }
+
+    @Test
+    public void testValidateOIDCTokenWithoutJWTProcessor() {
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+
+        StringBuilder errMsg = new StringBuilder(256);
+        assertFalse(provider.validateOIDCToken("some-jwt", "sports", "api", "my-space:my-stack:run-uuid-123", errMsg));
+        assertTrue(errMsg.toString().contains("JWT Processor not initialized"));
+
+        provider.close();
+    }
+
+    @Test
+    public void testValidateOIDCTokenIssuerMismatch() {
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        // our issuer will not match
+
+        Map<String, Object> claims = new HashMap<>(testClaims);
+        claims.put("iss", "https://some-other-issuer.com");
+        String idToken = generateIdToken(Duration.ZERO, claims);
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "my-space:my-stack:run-uuid-123", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("token issuer is not Spacelift"));
+    }
+
+    @Test
+    public void testValidateOIDCTokenAudienceMismatch() {
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_AUDIENCE, "https://test.athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        // our audience will not match
+
+        Map<String, Object> claims = new HashMap<>(testClaims);
+        claims.put("aud", "https://some-other-audience.com");
+        String idToken = generateIdToken(Duration.ZERO, claims);
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "my-space:my-stack:run-uuid-123", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("token audience is not ZTS Server audience"));
+    }
+
+    @Test
+    public void testValidateOIDCTokenStartNotRecentEnough() {
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        // our issue time is not recent enough
+
+        String idToken = generateIdToken(Duration.ofSeconds(400).negated(), testClaims);
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "my-space:my-stack:run-uuid-123", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("job start time is not recent enough"));
+    }
+
+    @Test
+    public void testValidateOIDCTokenInstanceIdMismatch() {
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        // instance ID from confirmation attributes does not match claims
+
+        String idToken = generateIdToken(Duration.ZERO, testClaims);
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "my-space:my-stack:wrong-run-id", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("invalid instance id: my-space:my-stack:run-uuid-123/my-space:my-stack:wrong-run-id"));
+
+        // missing spaceId
+
+        Map<String, ?> claims = new HashMap<>(testClaims);
+        claims.remove("spaceId");
+        idToken = generateIdToken(Duration.ZERO, claims);
+        errMsg.setLength(0);
+        result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:1001", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("token does not contain required spaceId claim"));
+
+        // missing callerId
+
+        claims = new HashMap<>(testClaims);
+        claims.remove("callerId");
+        idToken = generateIdToken(Duration.ZERO, claims);
+        errMsg.setLength(0);
+        result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:1001", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("token does not contain required callerId claim"));
+
+        // missing runId
+
+        claims = new HashMap<>(testClaims);
+        claims.remove("runId");
+        idToken = generateIdToken(Duration.ZERO, claims);
+        errMsg.setLength(0);
+        result = provider.validateOIDCToken(idToken, "sports", "api", "athenz:sia:1001", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("token does not contain required runId claim"));
+    }
+
+    @Test
+    public void testValidateOIDCTokenMissingSubject() {
+
+        final String jwksUri = Objects.requireNonNull(classLoader.getResource("jwt_jwks.json")).toString();
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_JWKS_URI, jwksUri);
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_AUDIENCE, "https://athenz.io");
+        System.setProperty(InstanceSpaceliftProvider.SPACELIFT_PROP_ISSUER, "https://demo.app.spacelift.io");
+
+        InstanceSpaceliftProvider provider = new InstanceSpaceliftProvider();
+        provider.initialize("sys.auth.spacelift",
+                "class://com.yahoo.athenz.instance.provider.impl.InstanceSpaceliftProvider", null, null);
+
+        // create an id token without the subject claim
+
+        Map<String, ?> claims = new HashMap<>(testClaims);
+        claims.remove("sub");
+        String idToken = generateIdToken(Duration.ZERO, claims);
+
+        StringBuilder errMsg = new StringBuilder(256);
+        boolean result = provider.validateOIDCToken(idToken, "sports", "api", "my-space:my-stack:run-uuid-123", errMsg);
+        assertFalse(result);
+        assertTrue(errMsg.toString().contains("token does not contain required subject claim"));
+    }
+
+    private String generateIdToken(Duration issuedAtOffset, Map<String, ?> claims) {
+
+        try {
+            PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+
+            JWSSigner signer = new ECDSASigner((ECPrivateKey) privateKey);
+            JWTClaimsSet.Builder claimsSetBuilder = new JWTClaimsSet.Builder()
+                    .expirationTime(Date.from(Instant.now().plus(issuedAtOffset).plusSeconds(3600)))
+                    .issueTime(Date.from(Instant.now().plus(issuedAtOffset)));
+            claims.forEach(claimsSetBuilder::claim);
+
+            SignedJWT signedJWT = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.ES256).keyID("eckey1").build(),
+                    claimsSetBuilder.build());
+            signedJWT.sign(signer);
+            return signedJWT.serialize();
+        } catch (Exception ex) {
+            return null;
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,7 @@
     <module>provider/gcp/sia-run</module>
     <module>provider/github/sia-actions</module>
     <module>provider/harness/sia-harness</module>
+    <module>provider/spacelift/sia-spacelift</module>
     <module>utils/zms-cli</module>
     <module>utils/athenz-conf</module>
     <module>utils/zms-domainattrs</module>

--- a/provider/spacelift/sia-spacelift/Makefile
+++ b/provider/spacelift/sia-spacelift/Makefile
@@ -1,17 +1,24 @@
 SCRIPT:=sia.py
+VENV:=.venv
+PYTHON:=$(VENV)/bin/python3
+PIP:=$(VENV)/bin/pip
 
 all: lint test
 
-lint:
-	@echo "Checking syntax..."
-	python3 -m py_compile $(SCRIPT)
+$(VENV):
+	python3 -m venv $(VENV)
+	$(PIP) install --quiet pytest cryptography PyJWT requests
 
-test:
+lint: $(VENV)
+	@echo "Checking syntax..."
+	$(PYTHON) -m py_compile $(SCRIPT)
+
+test: $(VENV)
 	@echo "Running tests..."
-	python3 -m pytest -v sia_test.py
+	$(PYTHON) -m pytest -v sia_test.py
 
 clean:
-	rm -rf __pycache__ .pytest_cache *.pyc
+	rm -rf __pycache__ .pytest_cache *.pyc $(VENV)
 
 ubuntu:
 	sed -i.bak s/SIA_PACKAGE_VERSION/$(PACKAGE_VERSION)/g debian/sia/DEBIAN/control

--- a/provider/spacelift/sia-spacelift/Makefile
+++ b/provider/spacelift/sia-spacelift/Makefile
@@ -1,0 +1,22 @@
+SCRIPT:=sia.py
+
+all: lint test
+
+lint:
+	@echo "Checking syntax..."
+	python3 -m py_compile $(SCRIPT)
+
+test:
+	@echo "Running tests..."
+	python3 -m pytest -v sia_test.py
+
+clean:
+	rm -rf __pycache__ .pytest_cache *.pyc
+
+ubuntu:
+	sed -i.bak s/SIA_PACKAGE_VERSION/$(PACKAGE_VERSION)/g debian/sia/DEBIAN/control
+	mkdir -p debian/sia/usr/local/bin/
+	cp -fp $(SCRIPT) debian/sia/usr/local/bin/sia
+	chmod +x debian/sia/usr/local/bin/sia
+	mkdir -p debian/pkg
+	cd debian && dpkg-deb --build sia pkg

--- a/provider/spacelift/sia-spacelift/README.md
+++ b/provider/spacelift/sia-spacelift/README.md
@@ -1,0 +1,44 @@
+# SIA for Spacelift
+
+The SIA utility authenticates Spacelift runs with Athenz and obtains a service
+identity X.509 certificate.
+
+The OIDC token is automatically read from the `SPACELIFT_OIDC_TOKEN` environment
+variable or from the `/mnt/workspace/spacelift.oidc` file.
+
+## Dependencies
+
+The script requires Python 3.10+ and the following packages:
+
+- `cryptography>=43.0`
+- `PyJWT>=2.9`
+- `requests>=2.32`
+
+When [uv](https://docs.astral.sh/uv/) is available, dependencies are resolved
+automatically. Otherwise, install them with `pip install cryptography PyJWT requests`.
+
+## Usage
+
+```
+./sia.py --zts <zts-server-url> --domain <athenz-domain> --service <athenz-service> \
+         --dns-domain <dns-domain> --key-file <key-file> --cert-file <cert-file>
+```
+
+The utility will generate a unique RSA private key and obtain a service identity
+X.509 certificate from Athenz and store the key and certificate in the specified files.
+
+As part of its output, the agent shows the action and resource values that the domain
+administrator must use to configure the Athenz services to allow the Spacelift run
+to authorize:
+
+```
+2024/02/15 17:05:43 Action:                          spacelift.run
+2024/02/15 17:05:43 Resource for specific run type:   sports:space:my-space:stack:my-stack:run_type:TRACKED:*
+2024/02/15 17:05:43 Resource for all run types:        sports:space:my-space:stack:my-stack:*
+```
+
+## Testing
+
+```
+python3 -m pytest -v sia_test.py
+```

--- a/provider/spacelift/sia-spacelift/debian/sia/DEBIAN/control
+++ b/provider/spacelift/sia-spacelift/debian/sia/DEBIAN/control
@@ -1,0 +1,5 @@
+Package: sia-spacelift
+Version: SIA_PACKAGE_VERSION
+Maintainer: cncf-athenz-maintainers@lists.cncf.io
+Architecture: amd64
+Description: Spacelift Athenz Service Identity Agent

--- a/provider/spacelift/sia-spacelift/pom.xml
+++ b/provider/spacelift/sia-spacelift/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>com.yahoo.athenz</groupId>
     <artifactId>athenz</artifactId>
-    <version>1.12.37-SNAPSHOT</version>
+    <version>1.12.39-SNAPSHOT</version>
     <relativePath>../../../pom.xml</relativePath>
   </parent>
 

--- a/provider/spacelift/sia-spacelift/pom.xml
+++ b/provider/spacelift/sia-spacelift/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright The Athenz Authors
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.yahoo.athenz</groupId>
+    <artifactId>athenz</artifactId>
+    <version>1.12.37-SNAPSHOT</version>
+    <relativePath>../../../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>sia-spacelift</artifactId>
+  <packaging>jar</packaging>
+  <name>sia-spacelift</name>
+  <description>Service Identity Agent for Spacelift</description>
+
+  <properties>
+    <maven.install.skip>true</maven.install.skip>
+    <checkstyle.skip>true</checkstyle.skip>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>${maven-exec-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>compile</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>make</executable>
+          <arguments>
+            <argument>clean</argument>
+            <argument>all</argument>
+          </arguments>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>${maven-jar-plugin.version}</version>
+        <executions>
+          <execution>
+            <id>default-jar</id>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/provider/spacelift/sia-spacelift/sia.py
+++ b/provider/spacelift/sia-spacelift/sia.py
@@ -1,0 +1,329 @@
+#!/bin/sh
+''':'
+if command -v uv >/dev/null 2>&1; then
+  exec uv run --script "$0" "$@"
+else
+  exec python3 "$0" "$@"
+fi
+':'''
+# /// script
+# dependencies = [
+#   "cryptography>=43.0",
+#   "PyJWT>=2.9",
+#   "requests>=2.32",
+# ]
+# ///
+from __future__ import annotations
+#
+# Copyright The Athenz Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Service Identity Agent for Spacelift.
+
+Obtains an Athenz X.509 service identity certificate using a Spacelift OIDC token.
+The token is read from the SPACELIFT_OIDC_TOKEN environment variable or from
+/mnt/workspace/spacelift.oidc.
+"""
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import jwt
+import requests
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import NameOID
+
+VERSION = "development"
+
+SPACELIFT_TOKEN_ENV_VAR = "SPACELIFT_OIDC_TOKEN"
+SPACELIFT_TOKEN_FILE = "/mnt/workspace/spacelift.oidc"
+
+JWT_ALGORITHMS = [
+    "RS256", "RS384", "RS512",
+    "PS256", "PS384", "PS512",
+    "ES256", "ES384", "ES512",
+    "EdDSA",
+]
+
+log = logging.getLogger("sia-spacelift")
+
+
+def get_oidc_token(
+    env_var: str = SPACELIFT_TOKEN_ENV_VAR,
+    token_file: str = SPACELIFT_TOKEN_FILE,
+) -> tuple[str, dict[str, Any]]:
+    """Read Spacelift OIDC token from environment or file and parse its claims.
+
+    Returns:
+        Tuple of (raw_token, claims_dict).
+
+    Raises:
+        RuntimeError: If the token cannot be obtained or parsed.
+    """
+    token = os.environ.get(env_var, "").strip()
+
+    if not token:
+        token_path = Path(token_file)
+        if token_path.is_file():
+            token = token_path.read_text().strip()
+
+    if not token:
+        raise RuntimeError(
+            f"Unable to obtain Spacelift OIDC token: env var {env_var} not set "
+            f"and file {token_file} not readable"
+        )
+
+    try:
+        claims: dict[str, Any] = jwt.decode(
+            token,
+            options={"verify_signature": False},
+            algorithms=JWT_ALGORITHMS,
+        )
+    except jwt.exceptions.DecodeError as exc:
+        raise RuntimeError(f"Unable to parse Spacelift OIDC token: {exc}") from exc
+
+    return token, claims
+
+
+def get_instance_id(claims: dict[str, Any]) -> str:
+    """Construct instance ID from token claims.
+
+    Format: <spaceId>:<callerId>:<runId>
+
+    Raises:
+        RuntimeError: If required claims are missing.
+    """
+    missing = [
+        field for field in ("spaceId", "callerId", "runId")
+        if not claims.get(field)
+    ]
+    if missing:
+        raise RuntimeError(
+            f"Unable to extract {', '.join(missing)} from OIDC token claims"
+        )
+
+    return f"{claims['spaceId']}:{claims['callerId']}:{claims['runId']}"
+
+
+def generate_csr(
+    private_key: rsa.RSAPrivateKey,
+    domain: str,
+    service: str,
+    provider: str,
+    instance_id: str,
+    dns_domain: str,
+    spiffe_trust_domain: str = "",
+    subj_c: str = "US",
+    subj_o: str = "",
+    subj_ou: str = "Athenz",
+) -> str:
+    """Generate a PEM-encoded X.509 CSR with Athenz SAN entries.
+
+    Returns:
+        PEM-encoded CSR as a string.
+    """
+    # build subject name attributes
+    name_attrs = [x509.NameAttribute(NameOID.COMMON_NAME, f"{domain}.{service}")]
+    if subj_c:
+        name_attrs.append(x509.NameAttribute(NameOID.COUNTRY_NAME, subj_c))
+    if subj_o:
+        name_attrs.append(x509.NameAttribute(NameOID.ORGANIZATION_NAME, subj_o))
+    if subj_ou:
+        name_attrs.append(x509.NameAttribute(NameOID.ORGANIZATIONAL_UNIT_NAME, subj_ou))
+
+    # build SAN entries
+    san_entries: list[x509.GeneralName] = []
+
+    # SAN DNS: <service>.<domain>.<dns_domain>
+    san_entries.append(x509.DNSName(f"{service}.{domain}.{dns_domain}"))
+
+    # SPIFFE URI must be first URI entry
+    if spiffe_trust_domain:
+        spiffe_uri = f"spiffe://{spiffe_trust_domain}/ns/default/sa/{domain}.{service}"
+        san_entries.append(x509.UniformResourceIdentifier(spiffe_uri))
+
+    # instance ID URI
+    instance_uri = f"athenz://instanceid/{provider}/{instance_id}"
+    san_entries.append(x509.UniformResourceIdentifier(instance_uri))
+
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(x509.Name(name_attrs))
+        .add_extension(x509.SubjectAlternativeName(san_entries), critical=False)
+        .sign(private_key, hashes.SHA256())
+    )
+
+    return csr.public_bytes(serialization.Encoding.PEM).decode()
+
+
+def register_instance(
+    zts_url: str,
+    provider: str,
+    domain: str,
+    service: str,
+    attestation_data: str,
+    csr: str,
+    expiry_time: int,
+    ca_cert: str | None = None,
+) -> dict[str, Any]:
+    """Register instance with ZTS and obtain X.509 certificate.
+
+    Returns:
+        Response dict with x509Certificate and x509CertificateSigner.
+
+    Raises:
+        RuntimeError: If the registration request fails.
+    """
+    url = f"{zts_url.rstrip('/')}/instance"
+    payload = {
+        "provider": provider,
+        "domain": domain,
+        "service": service,
+        "attestationData": attestation_data,
+        "csr": csr,
+        "expiryTime": expiry_time,
+    }
+
+    verify: bool | str = ca_cert if ca_cert else True
+    response = requests.post(
+        url,
+        json=payload,
+        headers={"User-Agent": f"SIA-Spacelift {VERSION}"},
+        verify=verify,
+        timeout=30,
+    )
+
+    if response.status_code not in (200, 201):
+        raise RuntimeError(
+            f"Unable to register instance: {response.status_code} {response.text}"
+        )
+
+    return response.json()
+
+
+def parse_args(args: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Spacelift Service Identity Agent for Athenz",
+    )
+    parser.add_argument("--key-file", required=True, help="output private key file")
+    parser.add_argument("--cert-file", required=True, help="output certificate file")
+    parser.add_argument("--signer-cert-file", default="", help="output signer certificate file (optional)")
+    parser.add_argument("--domain", required=True, help="domain of service")
+    parser.add_argument("--service", required=True, help="name of service")
+    parser.add_argument("--zts", required=True, help="url of the ZTS Service")
+    parser.add_argument("--dns-domain", required=True, help="dns domain suffix for sanDNS entries")
+    parser.add_argument("--subj-c", default="US", help="Subject C/Country field (default: US)")
+    parser.add_argument("--subj-o", default="", help="Subject O/Organization field (optional)")
+    parser.add_argument("--subj-ou", default="Athenz", help="Subject OU/OrganizationalUnit field (default: Athenz)")
+    parser.add_argument("--provider", default="sys.auth.spacelift", help="Athenz Provider (default: sys.auth.spacelift)")
+    parser.add_argument("--cacert", default="", help="CA certificate file (optional)")
+    parser.add_argument("--spiffe-trust-domain", default="", help="SPIFFE trust domain (optional)")
+    parser.add_argument("--expiry-time", type=int, default=360, help="expiry time in minutes (default: 360)")
+    parser.add_argument("--version", action="store_true", help="Show version")
+    return parser.parse_args(args)
+
+
+def main(args: list[str] | None = None) -> None:
+    logging.basicConfig(format="%(asctime)s %(message)s", level=logging.INFO)
+
+    opts = parse_args(args)
+
+    if opts.version:
+        log.info("SIA Spacelift version: %s", VERSION)
+        sys.exit(0)
+
+    # get the OIDC token for the Spacelift run
+    token, claims = get_oidc_token()
+
+    # construct the instance id from the claims
+    instance_id = get_instance_id(claims)
+
+    subject = claims.get("sub", "")
+    if not subject:
+        log.fatal("unable to extract subject from OIDC token claims")
+        sys.exit(1)
+
+    # display the action and resource for athenz policy configuration
+    # subject format: space:<space_id>:(stack|module):<caller_id>:run_type:<run_type>:scope:<scope>
+    subject_parts = subject.split(":")
+    if len(subject_parts) < 4:
+        log.fatal("invalid subject format: %s", subject)
+        sys.exit(1)
+
+    specific_resource = ":".join(subject_parts[:6]) + ":*"
+    broad_resource = ":".join(subject_parts[:4]) + ":*"
+
+    log.info("Action:                          %s", "spacelift.run")
+    log.info("Resource for specific run type:  %s", f"{opts.domain}:{specific_resource}")
+    log.info("Resource for all run types:      %s", f"{opts.domain}:{broad_resource}")
+
+    # generate RSA private key
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    # generate CSR
+    csr = generate_csr(
+        private_key,
+        opts.domain,
+        opts.service,
+        opts.provider,
+        instance_id,
+        opts.dns_domain,
+        opts.spiffe_trust_domain,
+        opts.subj_c,
+        opts.subj_o,
+        opts.subj_ou,
+    )
+
+    # register with ZTS
+    identity = register_instance(
+        opts.zts,
+        opts.provider,
+        opts.domain,
+        opts.service,
+        token,
+        csr,
+        opts.expiry_time,
+        opts.cacert or None,
+    )
+
+    # write private key
+    key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    key_path = Path(opts.key_file)
+    key_path.write_bytes(key_pem)
+    key_path.chmod(0o400)
+
+    # write certificate
+    cert_path = Path(opts.cert_file)
+    cert_path.write_text(identity["x509Certificate"])
+    cert_path.chmod(0o444)
+
+    # write signer certificate if requested
+    if opts.signer_cert_file and identity.get("x509CertificateSigner"):
+        signer_path = Path(opts.signer_cert_file)
+        signer_path.write_text(identity["x509CertificateSigner"])
+        signer_path.chmod(0o444)
+
+
+if __name__ == "__main__":
+    main()

--- a/provider/spacelift/sia-spacelift/sia_test.py
+++ b/provider/spacelift/sia-spacelift/sia_test.py
@@ -1,0 +1,269 @@
+# Copyright The Athenz Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the Spacelift SIA agent."""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import patch
+
+import jwt as pyjwt
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509 import load_pem_x509_csr
+
+from sia import generate_csr, get_instance_id, get_oidc_token, parse_args, register_instance
+
+
+def _make_test_token(claims: dict | None = None) -> str:
+    """Create a JWT token (unsigned) for testing purposes."""
+    payload = {
+        "iss": "https://demo.app.spacelift.io",
+        "aud": "demo.app.spacelift.io",
+        "sub": "space:my-space:stack:my-stack:run_type:TRACKED:scope:write",
+        "spaceId": "my-space",
+        "callerType": "stack",
+        "callerId": "my-stack",
+        "runType": "TRACKED",
+        "runId": "run-uuid-123",
+        "scope": "write",
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 3600,
+    }
+    if claims:
+        payload.update(claims)
+    return pyjwt.encode(payload, "secret", algorithm="HS256")
+
+
+# --- get_oidc_token ---
+
+
+class TestGetOidcToken:
+    def test_from_env(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        token = _make_test_token()
+        monkeypatch.setenv("SPACELIFT_OIDC_TOKEN", token)
+
+        raw, claims = get_oidc_token(token_file=str(tmp_path / "nonexistent"))
+        assert raw == token
+        assert claims["spaceId"] == "my-space"
+        assert claims["callerId"] == "my-stack"
+        assert claims["runId"] == "run-uuid-123"
+
+    def test_from_file(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        token = _make_test_token()
+        token_file = tmp_path / "spacelift.oidc"
+        token_file.write_text(token)
+        monkeypatch.delenv("SPACELIFT_OIDC_TOKEN", raising=False)
+
+        raw, claims = get_oidc_token(
+            env_var="SPACELIFT_OIDC_TOKEN",
+            token_file=str(token_file),
+        )
+        assert raw == token
+        assert claims["sub"] == "space:my-space:stack:my-stack:run_type:TRACKED:scope:write"
+
+    def test_strips_whitespace(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        token = _make_test_token()
+        monkeypatch.setenv("SPACELIFT_OIDC_TOKEN", f"  {token}  \n")
+
+        raw, claims = get_oidc_token(token_file=str(tmp_path / "nonexistent"))
+        assert raw == token
+        assert claims["spaceId"] == "my-space"
+
+    def test_missing_token(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        monkeypatch.delenv("SPACELIFT_OIDC_TOKEN", raising=False)
+
+        with pytest.raises(RuntimeError, match="Unable to obtain Spacelift OIDC token"):
+            get_oidc_token(
+                env_var="SPACELIFT_OIDC_TOKEN",
+                token_file=str(tmp_path / "nonexistent"),
+            )
+
+    def test_invalid_token(self, monkeypatch: pytest.MonkeyPatch, tmp_path):
+        monkeypatch.setenv("SPACELIFT_OIDC_TOKEN", "not-a-jwt")
+
+        with pytest.raises(RuntimeError, match="Unable to parse Spacelift OIDC token"):
+            get_oidc_token(token_file=str(tmp_path / "nonexistent"))
+
+
+# --- get_instance_id ---
+
+
+class TestGetInstanceId:
+    def test_valid_claims(self):
+        claims = {"spaceId": "my-space", "callerId": "my-stack", "runId": "run-123"}
+        assert get_instance_id(claims) == "my-space:my-stack:run-123"
+
+    @pytest.mark.parametrize("missing_field", ["spaceId", "callerId", "runId"])
+    def test_missing_field(self, missing_field: str):
+        claims = {"spaceId": "s", "callerId": "c", "runId": "r"}
+        del claims[missing_field]
+
+        with pytest.raises(RuntimeError, match=missing_field):
+            get_instance_id(claims)
+
+    def test_empty_field(self):
+        claims = {"spaceId": "", "callerId": "my-stack", "runId": "run-123"}
+        with pytest.raises(RuntimeError, match="spaceId"):
+            get_instance_id(claims)
+
+
+# --- generate_csr ---
+
+
+class TestGenerateCsr:
+    @pytest.fixture()
+    def private_key(self):
+        return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    def test_basic_csr(self, private_key):
+        csr_pem = generate_csr(
+            private_key, "sports", "api", "sys.auth.spacelift",
+            "my-space:my-stack:run-123", "athenz.io",
+        )
+        assert "BEGIN CERTIFICATE REQUEST" in csr_pem
+
+        csr = load_pem_x509_csr(csr_pem.encode())
+        assert csr.subject.get_attributes_for_oid(
+            x509.oid.NameOID.COMMON_NAME
+        )[0].value == "sports.api"
+
+        san = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        dns_names = san.value.get_values_for_type(x509.DNSName)
+        assert "api.sports.athenz.io" in dns_names
+
+        uris = san.value.get_values_for_type(x509.UniformResourceIdentifier)
+        assert "athenz://instanceid/sys.auth.spacelift/my-space:my-stack:run-123" in uris
+
+    def test_csr_with_spiffe(self, private_key):
+        csr_pem = generate_csr(
+            private_key, "sports", "api", "sys.auth.spacelift",
+            "my-space:my-stack:run-123", "athenz.io",
+            spiffe_trust_domain="athenz",
+        )
+
+        csr = load_pem_x509_csr(csr_pem.encode())
+        san = csr.extensions.get_extension_for_class(x509.SubjectAlternativeName)
+        uris = san.value.get_values_for_type(x509.UniformResourceIdentifier)
+        assert "spiffe://athenz/ns/default/sa/sports.api" in uris
+        assert "athenz://instanceid/sys.auth.spacelift/my-space:my-stack:run-123" in uris
+
+    def test_csr_subject_fields(self, private_key):
+        csr_pem = generate_csr(
+            private_key, "sports", "api", "sys.auth.spacelift",
+            "id", "athenz.io",
+            subj_c="DE", subj_o="MyOrg", subj_ou="MyUnit",
+        )
+
+        csr = load_pem_x509_csr(csr_pem.encode())
+        subject = csr.subject
+        assert subject.get_attributes_for_oid(x509.oid.NameOID.COUNTRY_NAME)[0].value == "DE"
+        assert subject.get_attributes_for_oid(x509.oid.NameOID.ORGANIZATION_NAME)[0].value == "MyOrg"
+        assert subject.get_attributes_for_oid(x509.oid.NameOID.ORGANIZATIONAL_UNIT_NAME)[0].value == "MyUnit"
+
+
+# --- register_instance ---
+
+
+class TestRegisterInstance:
+    def test_successful_registration(self):
+        response_data = {
+            "x509Certificate": "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
+            "x509CertificateSigner": "-----BEGIN CERTIFICATE-----\nsigner\n-----END CERTIFICATE-----",
+        }
+
+        with patch("sia.requests.post") as mock_post:
+            mock_post.return_value.status_code = 201
+            mock_post.return_value.json.return_value = response_data
+
+            result = register_instance(
+                "https://zts.athenz.io/zts/v1",
+                "sys.auth.spacelift", "sports", "api",
+                "oidc-token", "csr-pem", 360,
+            )
+
+        assert result["x509Certificate"] == response_data["x509Certificate"]
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[0][0] == "https://zts.athenz.io/zts/v1/instance"
+        assert call_kwargs[1]["json"]["provider"] == "sys.auth.spacelift"
+        assert call_kwargs[1]["json"]["attestationData"] == "oidc-token"
+
+    def test_failed_registration(self):
+        with patch("sia.requests.post") as mock_post:
+            mock_post.return_value.status_code = 403
+            mock_post.return_value.text = "Forbidden"
+
+            with pytest.raises(RuntimeError, match="Unable to register instance: 403"):
+                register_instance(
+                    "https://zts.athenz.io/zts/v1",
+                    "sys.auth.spacelift", "sports", "api",
+                    "oidc-token", "csr-pem", 360,
+                )
+
+    def test_with_ca_cert(self):
+        with patch("sia.requests.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.return_value = {"x509Certificate": "cert"}
+
+            register_instance(
+                "https://zts.athenz.io/zts/v1",
+                "sys.auth.spacelift", "sports", "api",
+                "token", "csr", 360, ca_cert="/path/to/ca.pem",
+            )
+
+        assert mock_post.call_args[1]["verify"] == "/path/to/ca.pem"
+
+    def test_url_trailing_slash_stripped(self):
+        with patch("sia.requests.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.return_value = {"x509Certificate": "cert"}
+
+            register_instance(
+                "https://zts.athenz.io/zts/v1/",
+                "sys.auth.spacelift", "sports", "api",
+                "token", "csr", 360,
+            )
+
+        assert mock_post.call_args[0][0] == "https://zts.athenz.io/zts/v1/instance"
+
+
+# --- parse_args ---
+
+
+class TestParseArgs:
+    def test_required_args(self):
+        opts = parse_args([
+            "--key-file", "/tmp/key", "--cert-file", "/tmp/cert",
+            "--domain", "sports", "--service", "api",
+            "--zts", "https://zts.athenz.io", "--dns-domain", "athenz.io",
+        ])
+        assert opts.domain == "sports"
+        assert opts.provider == "sys.auth.spacelift"
+        assert opts.expiry_time == 360
+
+    def test_defaults(self):
+        opts = parse_args([
+            "--key-file", "k", "--cert-file", "c",
+            "--domain", "d", "--service", "s",
+            "--zts", "z", "--dns-domain", "dns",
+        ])
+        assert opts.subj_c == "US"
+        assert opts.subj_ou == "Athenz"
+        assert opts.provider == "sys.auth.spacelift"
+        assert opts.cacert == ""
+        assert opts.spiffe_trust_domain == ""


### PR DESCRIPTION
# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

This PR adds support for obtaining Athenz credentials via a sia.py tool in Spacelift runs, from a configurable InstanceSpaceliftProvider in the ZTS server.

Fixes https://github.com/AthenZ/athenz/issues/3248

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

N/A