### PR TITLE
support pkce when fetching user certificates

### DIFF
--- a/docs/design/user-certificate-feature.md
+++ b/docs/design/user-certificate-feature.md
@@ -60,81 +60,88 @@ The User Certificate feature allows human users to obtain X.509 TLS client certi
 
 ```
      User              Browser          zts-usercert CLI       localhost:9213        IdP              ZTS Server
-      │                   │                    │                     │                 │                   │
-      │  run CLI          │                    │                     │                 │                   │
-      ├──────────────────►│                    │                     │                 │                   │
-      │                   │                    │                     │                 │                   │
-      │                   │   1. Read private key from file          │                 │                   │
-      │                   │   2. Generate CSR (CN=userName)          │                 │                   │
-      │                   │   3. Generate nonce (24 bytes)           │                 │                   │
-      │                   │   4. Start callback HTTP server          │                 │                   │
-      │                   │                    │◄────────────────────┤                 │                   │
-      │                   │                    │   (listening)       │                 │                   │
-      │                   │                    │                     │                 │                   │
-      │                   │   5. Open browser to IdP /authorize      │                 │                   │
-      │                   ├────────────────────┼─────────────────────┼────────────────►│                   │
-      │                   │                    │                     │  ?client_id=    │                   │
-      │                   │                    │                     │  &redirect_uri= │                   │
-      │                   │                    │                     │  localhost:9213 │                   │
-      │                   │                    │                     │  &response_type=│                   │
-      │                   │                    │                     │  code           │                   │
-      │                   │                    │                     │  &nonce=...     │                   │
-      │                   │                    │                     │  &state=...     │                   │
-      │  6. User          │                    │                     │                 │                   │
-      │  authenticates    │                    │                     │                 │                   │
-      │  with IdP         │                    │                     │                 │                   │
-      │  (login/MFA)      │                    │                     │                 │                   │
-      │                   │                    │                     │                 │                   │
-      │                   │   7. IdP redirects to callback           │                 │                   │
-      │                   │◄─────────────────────────────────────────┼─────────────────┤                   │
-      │                   │  302 → localhost:9213/oauth2/callback    │                 │                   │
-      │                   │        ?code=AUTH_CODE&state=NONCE       │                 │                   │
-      │                   │                    │                     │                 │                   │
-      │                   ├────────────────────┼────────────────────►│                 │                   │
-      │                   │                    │   GET /oauth2/      │                 │                   │
-      │                   │                    │   callback?code=... │                 │                   │
-      │                   │                    │                     │                 │                   │
-      │                   │                    │◄────────────────────┤                 │                   │
-      │                   │                    │  8. Extract raw     │                 │                   │
-      │                   │                    │  query string       │                 │                   │
-      │                   │                    │  (code=...&state=.) │                 │                   │
-      │                   │                    │                     │                 │                   │
-      │                   │   9. Redirect browser to /close page     │                 │                   │
-      │                   │◄───────────────────┼─────────────────────┤                 │                   │
-      │                   │  "Authentication    │  10. Shutdown      │                 │                   │
-      │                   │   successful"       │  callback server   │                 │                   │
-      │                   │                    │                     │                 │                   │
-      │                   │   11. POST /usercert to ZTS              │                 │                   │
-      │                   │                    ├─────────────────────┼─────────────────┼──────────────────►│
-      │                   │                    │                     │                 │   JSON body:      │
-      │                   │                    │                     │                 │   { name,         │
-      │                   │                    │                     │                 │     csr,          │
-      │                   │                    │                     │                 │     attestation   │
-      │                   │                    │                     │                 │     Data }        │
-      │                   │                    │                     │                 │                   │
-      │                   │                    │                     │                 │ 12. ZTS validates │
-      │                   │                    │                     │                 │ request, calls    │
-      │                   │                    │                     │                 │ provider          │
-      │                   │                    │                     │                 │                   │
-      │                   │                    │                     │                 │  13. Provider     │
-      │                   │                    │                     │                 │◄──────────────────│
-      │                   │                    │                     │                 │  exchanges code   │
-      │                   │                    │                     │                 │  for access token │
-      │                   │                    │                     │                 │  POST /token      │
-      │                   │                    │                     │                 │──────────────────►│
-      │                   │                    │                     │                 │                   │
-      │                   │                    │                     │                 │  14. Validate     │
-      │                   │                    │                     │                 │  JWT signature    │
-      │                   │                    │                     │                 │  + subject match  │
-      │                   │                    │                     │                 │  + audience match │
-      │                   │                    │                     │                 │                   │
-      │                   │                    │                     │                 │ 15. Sign CSR,     │
-      │                   │                    │                     │                 │ return X.509 cert │
-      │                   │                    │◄────────────────────┼─────────────────┼───────────────────│
-      │                   │                    │                     │                 │                   │
-      │                   │   16. Write cert   │                     │                 │                   │
-      │                   │   to file or stdout│                     │                 │                   │
-      │                   │                    │                     │                 │                   │
+      │                   │                    │                     │                    │                   │
+      │  run CLI          │                    │                     │                    │                   │
+      ├──────────────────►│                    │                     │                    │                   │
+      │                   │                    │                     │                    │                   │
+      │                   │   1. Read private key from file          │                    │                   │
+      │                   │   2. Generate CSR (CN=userName)          │                    │                   │
+      │                   │   3. Generate nonce + state (24 B each)  │                    │                   │
+      │                   │      Generate PKCE verifier (if enabled) │                    │                   │
+      │                   │   4. Start callback HTTP server          │                    │                   │
+      │                   │                    │◄────────────────────┤                    │                   │
+      │                   │                    │   (listening)       │                    │                   │
+      │                   │                    │                     │                    │                   │
+      │                   │   5. Open browser to IdP /authorize      │                    │                   │
+      │                   ├────────────────────┼─────────────────────┼───────────────────►│                   │
+      │                   │                    │                     │  ?client_id=       │                   │
+      │                   │                    │                     │  &redirect_uri=    │                   │
+      │                   │                    │                     │  localhost:9213    │                   │
+      │                   │                    │                     │  &response_type=   │                   │
+      │                   │                    │                     │  code              │                   │
+      │                   │                    │                     │  &scope=openid     │                   │
+      │                   │                    │                     │  &nonce=...        │                   │
+      │                   │                    │                     │  &state=...        │                   │
+      │                   │                    │                     │  &code_challenge=..│                   │
+      │                   │                    │                     │  &code_challenge_  │                   │
+      │                   │                    │                     │   method=S256      │                   │
+      │  6. User          │                    │                     │                    │                   │
+      │  authenticates    │                    │                     │                    │                   │
+      │  with IdP         │                    │                     │                    │                   │
+      │  (login/MFA)      │                    │                     │                    │                   │
+      │                   │                    │                     │                    │                   │
+      │                   │   7. IdP redirects to callback           │                    │                   │
+      │                   │◄─────────────────────────────────────────┼────────────────────┤                   │
+      │                   │  302 → localhost:9213/oauth2/callback    │                    │                   │
+      │                   │        ?code=AUTH_CODE&state=NONCE       │                    │                   │
+      │                   │                    │                     │                    │                   │
+      │                   ├────────────────────┼────────────────────►│                    │                   │
+      │                   │                    │   GET /oauth2/      │                    │                   │
+      │                   │                    │   callback?code=... │                    │                   │
+      │                   │                    │                     │                    │                   │
+      │                   │                    │◄────────────────────┤                    │                   │
+      │                   │                    │  8. Extract raw     │                    │                   │
+      │                   │                    │  query string       │                    │                   │
+      │                   │                    │  (code=...&state=.) │                    │                   │
+      │                   │                    │  Validate state     │                    │                   │
+      │                   │                    │                     │                    │                   │
+      │                   │   9. Redirect browser to /close page     │                    │                   │
+      │                   │◄───────────────────┼─────────────────────┤                    │                   │
+      │                   │  "Authentication   │  10. Shutdown       │                    │                   │
+      │                   │   successful"      │  callback server    │                    │                   │
+      │                   │                    │                     │                    │                   │
+      │                   │   11. POST /usercert to ZTS              │                    │                   │
+      │                   │                    ├─────────────────────┼────────────────────┼──────────────────►│
+      │                   │                    │                     │                    │   JSON body:      │
+      │                   │                    │                     │                    │   { name,         │
+      │                   │                    │                     │                    │     csr,          │
+      │                   │                    │                     │                    │     attestation   │
+      │                   │                    │                     │                    │     Data (code +  │
+      │                   │                    │                     │                    │     verifier) }   │
+      │                   │                    │                     │                    │                   │
+      │                   │                    │                     │                    │ 12. ZTS validates │
+      │                   │                    │                     │                    │ request, calls    │
+      │                   │                    │                     │                    │ provider          │
+      │                   │                    │                     │                    │                   │
+      │                   │                    │                     │                    │  13. Provider     │
+      │                   │                    │                     │                    │◄──────────────────│
+      │                   │                    │                     │                    │  exchanges code   │
+      │                   │                    │                     │                    │  for access token │
+      │                   │                    │                     │                    │  POST /token      │
+      │                   │                    │                     │                    │──────────────────►│
+      │                   │                    │                     │                    │                   │
+      │                   │                    │                     │                    │  14. Validate     │
+      │                   │                    │                     │                    │  JWT signature    │
+      │                   │                    │                     │                    │  + subject match  │
+      │                   │                    │                     │                    │  + audience match │
+      │                   │                    │                     │                    │                   │
+      │                   │                    │                     │                    │ 15. Sign CSR,     │
+      │                   │                    │                     │                    │ return X.509 cert │
+      │                   │                    │◄────────────────────┼────────────────────┼───────────────────│
+      │                   │                    │                     │                    │                   │
+      │                   │   16. Write cert   │                     │                    │                   │
+      │                   │   to file or stdout│                     │                    │                   │
+      │                   │                    │                     │                    │                   │
 ```
 
 ### 3.2 Server-Side Processing Flow (ZTS + Provider)
@@ -221,8 +228,12 @@ The User Certificate feature allows human users to obtain X.509 TLS client certi
           │  │ code=AUTH_CODE         │  │    │ /token  │
           │  │ client_id=...          │  │    │         │
           │  │ redirect_uri=...       │  │    └────┬────┘
-          │  │ client_secret=...      │  │         │
+          │  │ client_secret=... (*)  │  │         │
+          │  │ code_verifier=.. (**)  │  │         │
           │  └───────────┬────────────┘  │         │
+          │  (*) if configured           │         │
+          │  (**) if present; required   │         │
+          │       when no client_secret  │         │
           │              │◄──────────────┼─────────┘
           │              │ access_token  │
           │              ▼               │
@@ -233,7 +244,6 @@ The User Certificate feature allows human users to obtain X.509 TLS client certi
           │  │ • Verify subject      │   │
           │  │   matches userName    │   │
           │  │ • Verify audience     │   │
-          │  │   (if configured)     │   │
           │  └───────────┬───────────┘   │
           │              │               │
           │              ▼               │
@@ -285,11 +295,15 @@ The CLI is a thin wrapper that parses command-line flags and delegates to `userc
 - `--cert-file` — Output certificate file (default: stdout)
 - `--subj-c`, `--subj-o`, `--subj-ou` — CSR subject fields (OU defaults to "Athenz")
 - `--spiffe-trust-domain` — SPIFFE trust domain for URI SAN
+- `--scope` — OIDC scope parameter (default: "openid")
 - `--callback-port` — Local port for OAuth2 callback (default: 9213)
 - `--callback-timeout` — Timeout in seconds for IdP auth flow (default: 45s)
 - `--expiry-time` — Certificate expiry in minutes (0 = server default)
 - `--cacert` — CA certificate file for ZTS TLS verification
+- `--pkce` — Enable PKCE (RFC 7636) for the IdP auth flow (default: true)
 - `--proxy` — Enable HTTP proxy (default: true)
+- `--verbose` — Enable verbose logging
+- `--version` — Show version information and exit
 
 #### 4.1.2 Core Library (`libs/go/usercert/usercert.go`)
 
@@ -300,8 +314,8 @@ The CLI is a thin wrapper that parses command-line flags and delegates to `userc
    - `CN = userName` (without domain prefix)
    - Optional Subject fields: Country, Organization, OrganizationalUnit
    - Optional SPIFFE URI SAN: `spiffe://<trustDomain>/ns/default/sa/<userName>`
-3. **Run IdP OAuth2 flow** via `GetAuthCode()` (see Section 4.1.3).
-4. **Build `UserCertificateRequest`** with `name`, `csr`, `attestationData` (raw query string from callback), and optional `expiryTime`.
+3. **Run IdP OAuth2 flow** via `GetAuthCode()` (see Section 4.1.3). The OIDC `scope` parameter (default: "openid") is passed to the authorization request.
+4. **Build `UserCertificateRequest`** with `name`, `csr`, `attestationData`, and optional `expiryTime`. The attestation data is the raw query string from the callback; when PKCE is enabled, the code verifier is appended (e.g., `code=AUTH_CODE&state=STATE&code_verifier=VERIFIER`).
 5. **POST to ZTS** `/usercert` endpoint via the generated ZTS Go client.
 6. **Return** the X.509 certificate PEM string.
 
@@ -312,16 +326,19 @@ The CLI is a thin wrapper that parses command-line flags and delegates to `userc
 1. **Start a local HTTP server** on `localhost:<callbackPort>` with two routes:
    - `GET /oauth2/callback` — Receives the IdP redirect, captures `code` and `state` from the query string, redirects to `/close`.
    - `GET /close` — Renders a static HTML page ("Authentication successful. You may close this window.").
-2. **Generate a cryptographic nonce** (24 random bytes, base64url-encoded) used as both `nonce` and `state` parameters.
-3. **Open the system browser** to the IdP authorization URL:
+2. **Generate cryptographic nonce and state** — Two independent random values (24 bytes each, base64url-encoded) are generated for the `nonce` and `state` parameters respectively.
+3. **Generate PKCE code verifier and challenge** (when PKCE is enabled) — A code verifier (32 random bytes, base64url-encoded) is generated per RFC 7636. The code challenge is computed as `BASE64URL(SHA256(code_verifier))` using the S256 method.
+4. **Open the system browser** to the IdP authorization URL:
    ```
-   <idpEndpoint>?client_id=<clientId>&redirect_uri=http://localhost:<port>/oauth2/callback&response_type=code&nonce=<nonce>&state=<nonce>
+   <idpEndpoint>?client_id=<clientId>&redirect_uri=http://localhost:<port>/oauth2/callback&response_type=code&scope=<scope>&nonce=<nonce>&state=<state>&code_challenge=<challenge>&code_challenge_method=S256
    ```
-4. **Wait** for either:
+   The `code_challenge` and `code_challenge_method` parameters are only included when PKCE is enabled.
+5. **Wait** for either:
    - The callback to deliver the authorization code (success), or
    - A timeout (default 45 seconds).
-5. **Shut down** the local HTTP server gracefully.
-6. **Return** the raw query string (e.g., `code=AUTH_CODE&state=NONCE`).
+6. **Validate state** — The `state` parameter returned in the callback is compared against the original value. A mismatch aborts the flow with an error.
+7. **Shut down** the local HTTP server gracefully.
+8. **Return** the raw query string (e.g., `code=AUTH_CODE&state=STATE`) and the PKCE code verifier (empty string when PKCE is disabled).
 
 **Security properties of the local server:**
 - Binds to `localhost` only (not `0.0.0.0`).
@@ -397,11 +414,11 @@ On startup, the provider configures itself from system properties:
 | Property | Required | Default                                 | Description |
 |---|---|-----------------------------------------|---|
 | `athenz.zts.user_cert.idp_config_endpoint` | No | —                                       | OpenID Connect discovery endpoint (auto-discovers token + JWKS endpoints) |
-| `athenz.zts.user_cert.idp_token_endpoint` | Yes* | —                                       | IdP token endpoint (*auto-discovered if config endpoint is set) |
-| `athenz.zts.user_cert.idp_jwks_endpoint` | Yes* | —                                       | IdP JWKS endpoint (*auto-discovered if config endpoint is set) |
+| `athenz.zts.user_cert.idp_token_endpoint` | Yes* | —                                       | IdP token endpoint (*auto-discovered if config endpoint is set). Must be an HTTPS URL. |
+| `athenz.zts.user_cert.idp_jwks_endpoint` | Yes* | —                                       | IdP JWKS endpoint (*auto-discovered if config endpoint is set). Must be an HTTPS URL. |
 | `athenz.zts.user_cert.idp_client_id` | Yes | —                                       | OAuth2 client ID |
 | `athenz.zts.user_cert.idp_redirect_uri` | No | `http://localhost:9213/oauth2/callback` | OAuth2 redirect URI |
-| `athenz.zts.user_cert.idp_audience` | No | —                                       | Expected audience claim in access token |
+| `athenz.zts.user_cert.idp_audience` | Yes | —                                       | Expected audience claim in access token |
 | `athenz.zts.user_cert.connect_timeout` | No | 10000 ms                                | Connection timeout for IdP requests |
 | `athenz.zts.user_cert.read_timeout` | No | 15000 ms                                | Read timeout for IdP requests |
 | `athenz.zts.user_cert.user_name_claim` | No | —                                       | Custom claim name for user identity (fallback if `sub` doesn't match) |
@@ -409,13 +426,16 @@ On startup, the provider configures itself from system properties:
 | `athenz.zts.user_cert.idp_client_secret_keygroup` | No | —                                       | Key group for secret store lookup |
 | `athenz.zts.user_cert.idp_client_secret_keyname` | No | —                                       | Key name for secret store lookup |
 
+Both the token and JWKS endpoints are validated during initialization to ensure they use HTTPS. The provider will fail to start if either endpoint uses a non-HTTPS URL, whether configured explicitly or auto-discovered via the OpenID Connect configuration endpoint.
+
 The JWKS signing key resolver is initialized to fetch and cache the IdP's public signing keys.
 
 #### 4.3.2 `confirmInstance()` — Attestation Verification
 
-1. **Extract authorization code** from `attestationData`:
-   - If the data contains `code=`, parse as query string and extract the `code` parameter.
-   - Otherwise, treat the entire string as a raw authorization code.
+1. **Extract authorization code and code verifier** from `attestationData`:
+   - The attestation data is parsed as an `&`-delimited string of key=value pairs.
+   - The `code=` parameter is extracted and URL-decoded. If no `code=` parameter is present, the request is rejected.
+   - The `code_verifier=` parameter, if present, is extracted and URL-decoded (used for PKCE).
 
 2. **Exchange auth code for access token** — POST to IdP token endpoint:
    ```
@@ -423,11 +443,14 @@ The JWKS signing key resolver is initialized to fetch and cache the IdP's public
    Content-Type: application/x-www-form-urlencoded
 
    grant_type=authorization_code
-   &code=<authCode>
    &client_id=<clientId>
    &redirect_uri=<redirectUri>
    &client_secret=<clientSecret>   (if configured)
+   &code=<authCode>
+   &code_verifier=<codeVerifier>   (if present)
    ```
+   - When `client_secret` is not configured, PKCE is required: the `code_verifier` must be present in the attestation data or the request is rejected.
+   - When `client_secret` is configured, `code_verifier` is optional but included when present.
    - Parse response as `AccessTokenResponse`.
    - Extract `access_token` field.
 
@@ -441,8 +464,8 @@ The JWKS signing key resolver is initialized to fetch and cache the IdP's public
    - If `userNameClaim` is configured, check if that custom claim equals `userName` or the full principal name.
    - If none match, reject with "Subject token does not match."
 
-5. **Validate audience** (if configured):
-   - If `audience` is configured, the token's `aud` claim must match exactly.
+5. **Validate audience**:
+   - The token's `aud` claim must match the configured `audience` value exactly.
 
 #### 4.3.3 `refreshInstance()` — Explicitly Forbidden
 
@@ -466,7 +489,7 @@ The authentication chain provides defense in depth:
 
 1. **IdP authenticates the user** — The IdP performs the actual identity verification (password, MFA, etc.).
 2. **Auth code is single-use** — The IdP authorization code can only be exchanged once for a token.
-3. **Server-side code exchange** — The auth code is exchanged for a token on the ZTS server, not the client, when a client secret is configured.
+3. **Server-side code exchange** — The auth code is exchanged for a token on the ZTS server, not the client. The exchange is protected by either a client secret (when configured) or PKCE (required when no client secret is configured).
 4. **JWT signature verification** — The access token's signature is verified against the IdP's JWKS keys.
 5. **Subject binding** — The token's subject must match the requested user name.
 6. **Certificate constraints** — The issued certificate is client-only, short-lived, and cannot be refreshed.
@@ -481,6 +504,7 @@ The authentication chain provides defense in depth:
 - The callback server binds to `localhost` only, limiting interception to local processes.
 - The auth code is single-use — the legitimate code exchange by ZTS will invalidate it.
 - When `client_secret` is configured, the attacker also needs the server-side secret.
+- When PKCE is enabled (default), the auth code is bound to the code verifier via the S256 challenge. An attacker who intercepts the code cannot exchange it without the verifier, which never leaves the client-to-ZTS path.
 - The callback server shuts down immediately after receiving the code.
 
 #### 5.2.2 Phishing / Redirect URI Manipulation
@@ -506,8 +530,8 @@ The authentication chain provides defense in depth:
 **Threat:** An attacker intercepts communication between ZTS and the IdP.
 
 **Mitigations:**
-- Token endpoint communication uses HTTPS.
-- JWKS keys are fetched over HTTPS.
+- Token endpoint communication uses HTTPS — enforced at provider initialization (non-HTTPS URLs are rejected).
+- JWKS keys are fetched over HTTPS — also enforced at provider initialization.
 - Connection and read timeouts prevent indefinite hanging (10s connect, 15s read).
 
 #### 5.2.5 CSR Manipulation
@@ -617,29 +641,40 @@ The OAuth2 Authorization Code flow was chosen because:
 - It leverages the user's browser for IdP authentication, supporting MFA and SSO.
 - The authorization code is single-use and short-lived.
 
-### 7.2 Attestation Data = Raw Query String
+### 7.2 PKCE Support (RFC 7636)
 
-The attestation data sent to ZTS is the raw query string from the OAuth2 callback (e.g., `code=AUTH_CODE&state=NONCE`). The provider extracts the code from this string. This design:
-- Keeps the client simple — it forwards the callback data as-is.
-- Allows the provider to be extended to validate the `state` parameter if needed.
-- Supports both query-string format and raw code values.
+The implementation supports Proof Key for Code Exchange (PKCE) per RFC 7636 with the S256 challenge method. When PKCE is enabled on the client:
 
-### 7.3 No Certificate Refresh
+1. The CLI generates a random code verifier (32 bytes, base64url-encoded) and computes the S256 challenge.
+2. The code challenge is sent with the authorization request to the IdP.
+3. The code verifier is included in the attestation data sent to ZTS.
+4. The provider forwards the code verifier to the IdP token endpoint during the code exchange.
+
+PKCE is required on the server side when no client secret is configured, ensuring that the authorization code cannot be exchanged without proof of possession. This is the recommended configuration for public/native clients where a client secret cannot be securely stored.
+
+### 7.3 Attestation Data = Raw Query String
+
+The attestation data sent to ZTS is the raw query string from the OAuth2 callback (e.g., `code=AUTH_CODE&state=STATE`), with the PKCE code verifier appended when PKCE is enabled (e.g., `code=AUTH_CODE&state=STATE&code_verifier=VERIFIER`). The provider parses this as `&`-delimited key=value pairs to extract the `code` and optional `code_verifier`. This design:
+- Keeps the client simple — it forwards the callback data with minimal transformation.
+- Allows the provider to be extended to validate additional parameters if needed.
+- Supports PKCE by carrying the code verifier alongside the authorization code in a single string.
+
+### 7.4 No Certificate Refresh
 
 User certificates explicitly cannot be refreshed. Each new certificate requires a fresh IdP authentication. This ensures:
 - Revoked/disabled users cannot continue using existing certificates after their current one expires.
 - The user's active status is re-verified with each certificate issuance.
 - Short lifetimes (max 60 minutes default) limit exposure of compromised certificates.
 
-### 7.4 Client-Only Certificate Usage
+### 7.5 Client-Only Certificate Usage
 
 Certificates are issued with `client` usage only. This prevents a user certificate from being used as a server certificate, limiting its utility in case of compromise.
 
-### 7.5 SPIFFE URI Support
+### 7.6 SPIFFE URI Support
 
 The CSR can optionally include a SPIFFE URI SAN (`spiffe://<trustDomain>/ns/default/sa/<userName>`). This enables integration with SPIFFE-aware systems while being validated against the server's configured SPIFFE URI validators.
 
-### 7.6 Audit Support
+### 7.7 Audit Support
 
 Certificate issuance is logged via `instanceCertManager.logX509Cert()`. The log includes the remote address, service name, principal name, and certificate details. This provides an audit trail for all issued user certificates.
 
@@ -647,6 +682,6 @@ Certificate issuance is logged via `instanceCertManager.logX509Cert()`. The log 
 
 ## 8. Other Considerations
 
-1. **Client secret requirement** — The client secret is optional. When not configured, the code exchange relies solely on the redirect URI validation by the IdP. For production deployments, configuring a client secret is recommended.
+1. **Client secret and PKCE** — The client secret is optional. When not configured, PKCE (RFC 7636) is required: the client must include a `code_verifier` in the attestation data, and the provider will reject requests without one. When a client secret is configured, PKCE is optional but supported — the code verifier is forwarded to the IdP when present. The CLI enables PKCE by default (`--pkce=true`).
 
 2. **Rate limiting** — The ZTS API endpoint returns `TOO_MANY_REQUESTS` (429) as a possible error code, but the rate limiting implementation is outside this feature's scope. Deployers should consider rate limiting to prevent abuse.

--- a/libs/go/usercert/idp.go
+++ b/libs/go/usercert/idp.go
@@ -25,8 +25,8 @@ type authResult struct {
 
 func encode(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
 
-// newCodeVerifier generates a PKCE code verifier per RFC 7636 Section 4.1.
-// It produces a 43-character base64url-encoded string (32 random bytes).
+// newCodeVerifier generates a random base64url-encoded string of the given size in bytes.
+// It is used for PKCE code verifiers, nonces, and state values.
 func newCodeVerifier(size int) (string, error) {
 	b := make([]byte, size)
 	_, err := io.ReadFull(rand.Reader, b)

--- a/libs/go/usercert/idp.go
+++ b/libs/go/usercert/idp.go
@@ -6,6 +6,7 @@ package usercert
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"io"
@@ -24,16 +25,25 @@ type authResult struct {
 
 func encode(b []byte) string { return base64.RawURLEncoding.EncodeToString(b) }
 
-func newNonce() (string, error) {
-	n := make([]byte, 24)
-	_, err := io.ReadFull(rand.Reader, n)
+// newCodeVerifier generates a PKCE code verifier per RFC 7636 Section 4.1.
+// It produces a 43-character base64url-encoded string (32 random bytes).
+func newCodeVerifier(size int) (string, error) {
+	b := make([]byte, size)
+	_, err := io.ReadFull(rand.Reader, b)
 	if err != nil {
 		return "", fmt.Errorf("rand read: %w", err)
 	}
-	return encode(n), nil
+	return encode(b), nil
 }
 
-func getIdpAuthURL(endPoint, clientId, scope, nonce, callbackPort string) (string, error) {
+// computeCodeChallenge computes the S256 code challenge per RFC 7636 Section 4.2:
+// BASE64URL(SHA256(code_verifier))
+func computeCodeChallenge(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return encode(h[:])
+}
+
+func getIdpAuthURL(endPoint, clientId, scope, nonce, state, callbackPort, codeChallenge string) (string, error) {
 	u, err := url.Parse(endPoint)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse auth endpoint: %v", err)
@@ -47,12 +57,18 @@ func getIdpAuthURL(endPoint, clientId, scope, nonce, callbackPort string) (strin
 	query.Set("response_type", "code")
 	query.Set("scope", scope)
 	query.Set("nonce", nonce)
-	query.Set("state", nonce)
+	query.Set("state", state)
+	if codeChallenge != "" {
+		query.Set("code_challenge", codeChallenge)
+		query.Set("code_challenge_method", "S256")
+	}
 
 	u.RawQuery = query.Encode()
 
 	return u.String(), nil
 }
+
+var browserOpen = openBrowser
 
 func openBrowser(url string) error {
 	var cmd *exec.Cmd
@@ -67,8 +83,8 @@ func openBrowser(url string) error {
 	return cmd.Run()
 }
 
-func openIdpAuthURL(endPoint, clientId, scope, nonce, callbackPort string, verbose bool) error {
-	authURL, err := getIdpAuthURL(endPoint, clientId, scope, nonce, callbackPort)
+func openIdpAuthURL(endPoint, clientId, scope, nonce, state, callbackPort, codeChallenge string, verbose bool) error {
+	authURL, err := getIdpAuthURL(endPoint, clientId, scope, nonce, state, callbackPort, codeChallenge)
 	if err != nil {
 		return err
 	}
@@ -77,7 +93,7 @@ func openIdpAuthURL(endPoint, clientId, scope, nonce, callbackPort string, verbo
 		log.Printf("Opening IdP auth URL: %v", authURL)
 	}
 
-	err = openBrowser(authURL)
+	err = browserOpen(authURL)
 	if err != nil {
 		return fmt.Errorf("failed to open authorize URL: %v", err)
 	}
@@ -151,19 +167,37 @@ func getAuthCodeFromCallbackHandler(port string, timeoutSeconds int, verbose boo
 
 // GetAuthCode initiates the IdP authentication flow. It starts a local HTTP server
 // to receive the IdP callback, opens the IdP authorization URL in the browser,
-// and waits for the authentication code or a timeout. Returns the raw query string
-// containing the code and state, or an error if the process fails.
-func GetAuthCode(endPoint, clientId, scope, callbackPort string, timeoutSeconds int, verbose bool) (string, error) {
+// and waits for the authentication code or a timeout.
+// When pkce is true, PKCE (RFC 7636) support is enabled: a code verifier/challenge
+// pair is generated, the challenge is sent with the authorization request, and the
+// verifier is returned so the caller can include it in the token exchange.
+// Returns the raw query string containing the code and state, the PKCE code
+// verifier (empty when pkce is false), or an error if the process fails.
+func GetAuthCode(endPoint, clientId, scope, callbackPort string, timeoutSeconds int, pkce, verbose bool) (string, string, error) {
 	result := getAuthCodeFromCallbackHandler(callbackPort, timeoutSeconds, verbose)
 
-	nonce, err := newNonce()
+	nonce, err := newCodeVerifier(24)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 
-	err = openIdpAuthURL(endPoint, clientId, scope, nonce, callbackPort, verbose)
+	state, err := newCodeVerifier(24)
 	if err != nil {
-		return "", err
+		return "", "", err
+	}
+
+	var codeVerifier, codeChallenge string
+	if pkce {
+		codeVerifier, err = newCodeVerifier(32)
+		if err != nil {
+			return "", "", err
+		}
+		codeChallenge = computeCodeChallenge(codeVerifier)
+	}
+
+	err = openIdpAuthURL(endPoint, clientId, scope, nonce, state, callbackPort, codeChallenge, verbose)
+	if err != nil {
+		return "", "", err
 	}
 
 	authResult := <-result
@@ -171,8 +205,16 @@ func GetAuthCode(endPoint, clientId, scope, callbackPort string, timeoutSeconds 
 		log.Printf("Received auth result, error: %v", authResult.Error)
 	}
 	if authResult.Error != nil {
-		return "", fmt.Errorf("error receiving auth code: %v", authResult.Error)
+		return "", "", fmt.Errorf("error receiving auth code: %v", authResult.Error)
 	}
 
-	return authResult.Code, nil
+	query, err := url.ParseQuery(authResult.Code)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to parse auth code: %v", err)
+	}
+	if query.Get("state") != state {
+		return "", "", fmt.Errorf("state mismatch: expected %s, got %s", state, query.Get("state"))
+	}
+
+	return authResult.Code, codeVerifier, nil
 }

--- a/libs/go/usercert/idp_test.go
+++ b/libs/go/usercert/idp_test.go
@@ -4,6 +4,7 @@
 package usercert
 
 import (
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"net"
@@ -47,7 +48,7 @@ func TestEncodeRawURLSafe(t *testing.T) {
 // --- newNonce tests ---
 
 func TestNewNonce(t *testing.T) {
-	nonce, err := newNonce()
+	nonce, err := newCodeVerifier(24)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -63,7 +64,7 @@ func TestNewNonce(t *testing.T) {
 func TestNewNonceUniqueness(t *testing.T) {
 	seen := make(map[string]bool)
 	for i := 0; i < 100; i++ {
-		nonce, err := newNonce()
+		nonce, err := newCodeVerifier(24)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -75,7 +76,7 @@ func TestNewNonceUniqueness(t *testing.T) {
 }
 
 func TestNewNonceIsValidBase64URL(t *testing.T) {
-	nonce, err := newNonce()
+	nonce, err := newCodeVerifier(24)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestNewNonceIsValidBase64URL(t *testing.T) {
 // --- getIdpAuthURL tests ---
 
 func TestGetIdpAuthURL(t *testing.T) {
-	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "9213")
+	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "test-state", "9213", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -118,8 +119,8 @@ func TestGetIdpAuthURL(t *testing.T) {
 	if q.Get("nonce") != "test-nonce" {
 		t.Errorf("expected nonce=test-nonce, got %s", q.Get("nonce"))
 	}
-	if q.Get("state") != "test-nonce" {
-		t.Errorf("expected state=test-nonce, got %s", q.Get("state"))
+	if q.Get("state") != "test-state" {
+		t.Errorf("expected state=test-state, got %s", q.Get("state"))
 	}
 	if q.Get("scope") != "openid" {
 		t.Errorf("expected scope=openid, got %s", q.Get("scope"))
@@ -138,7 +139,7 @@ func TestGetIdpAuthURLDifferentPorts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run("port-"+tt.port, func(t *testing.T) {
-			authURL, err := getIdpAuthURL("https://idp.example.com/auth", "client", "openid", "nonce", tt.port)
+			authURL, err := getIdpAuthURL("https://idp.example.com/auth", "client", "openid", "nonce", "test-state", tt.port, "")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -151,14 +152,14 @@ func TestGetIdpAuthURLDifferentPorts(t *testing.T) {
 }
 
 func TestGetIdpAuthURLInvalidEndpoint(t *testing.T) {
-	_, err := getIdpAuthURL("://invalid", "client", "openid", "nonce", "9213")
+	_, err := getIdpAuthURL("://invalid", "client", "openid", "nonce", "test-state", "9213", "")
 	if err == nil {
 		t.Fatal("expected error for invalid endpoint")
 	}
 }
 
 func TestGetIdpAuthURLPreservesExistingQueryParams(t *testing.T) {
-	authURL, err := getIdpAuthURL("https://idp.example.com/auth?extra=value", "client", "openid", "nonce", "9213")
+	authURL, err := getIdpAuthURL("https://idp.example.com/auth?extra=value", "client", "openid", "nonce", "test-state", "9213", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -172,7 +173,7 @@ func TestGetIdpAuthURLPreservesExistingQueryParams(t *testing.T) {
 }
 
 func TestGetIdpAuthURLCustomScope(t *testing.T) {
-	authURL, err := getIdpAuthURL("https://idp.example.com/auth", "client", "openid profile email", "nonce", "9213")
+	authURL, err := getIdpAuthURL("https://idp.example.com/auth", "client", "openid profile email", "nonce", "test-state", "9213", "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -370,6 +371,425 @@ func TestGetAuthCodeFromCallbackHandlerSuccess(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("test timed out waiting for auth result")
+	}
+}
+
+// --- GetAuthCode tests ---
+
+func TestGetAuthCodeSuccess(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	listener.Close()
+
+	origBrowserOpen := browserOpen
+	defer func() { browserOpen = origBrowserOpen }()
+
+	browserOpen = func(authURL string) error {
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		state := u.Query().Get("state")
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=test-auth-code&state=%s", port, state))
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	code, codeVerifier, err := GetAuthCode("https://idp.example.com/oauth2/authorize", "my-client", "openid", port, 10, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	q, err := url.ParseQuery(code)
+	if err != nil {
+		t.Fatalf("failed to parse returned code: %v", err)
+	}
+	if q.Get("code") != "test-auth-code" {
+		t.Errorf("expected code=test-auth-code, got %s", q.Get("code"))
+	}
+	if codeVerifier != "" {
+		t.Errorf("expected empty code verifier when pkce is false, got %s", codeVerifier)
+	}
+}
+
+func TestGetAuthCodeStateMismatch(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	listener.Close()
+
+	origBrowserOpen := browserOpen
+	defer func() { browserOpen = origBrowserOpen }()
+
+	browserOpen = func(authURL string) error {
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=test-auth-code&state=wrong-state", port))
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	_, _, err = GetAuthCode("https://idp.example.com/oauth2/authorize", "my-client", "openid", port, 10, false, false)
+	if err == nil {
+		t.Fatal("expected error for state mismatch")
+	}
+	if !strings.Contains(err.Error(), "state mismatch") {
+		t.Errorf("expected state mismatch error, got: %v", err)
+	}
+}
+
+func TestGetAuthCodeMissingState(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	listener.Close()
+
+	origBrowserOpen := browserOpen
+	defer func() { browserOpen = origBrowserOpen }()
+
+	browserOpen = func(authURL string) error {
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=test-auth-code", port))
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	_, _, err = GetAuthCode("https://idp.example.com/oauth2/authorize", "my-client", "openid", port, 10, false, false)
+	if err == nil {
+		t.Fatal("expected error for missing state")
+	}
+	if !strings.Contains(err.Error(), "state mismatch") {
+		t.Errorf("expected state mismatch error, got: %v", err)
+	}
+}
+
+func TestGetAuthCodeBrowserOpenFailure(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	listener.Close()
+
+	origBrowserOpen := browserOpen
+	defer func() { browserOpen = origBrowserOpen }()
+
+	browserOpen = func(authURL string) error {
+		return fmt.Errorf("browser open failed")
+	}
+
+	_, _, err = GetAuthCode("https://idp.example.com/oauth2/authorize", "my-client", "openid", port, 10, false, false)
+	if err == nil {
+		t.Fatal("expected error when browser fails to open")
+	}
+	if !strings.Contains(err.Error(), "failed to open authorize URL") {
+		t.Errorf("expected browser failure error, got: %v", err)
+	}
+}
+
+func TestGetAuthCodeInvalidEndpoint(t *testing.T) {
+	origBrowserOpen := browserOpen
+	defer func() { browserOpen = origBrowserOpen }()
+
+	browserOpen = func(authURL string) error {
+		return nil
+	}
+
+	_, _, err := GetAuthCode("://invalid", "my-client", "openid", "19999", 5, false, false)
+	if err == nil {
+		t.Fatal("expected error for invalid endpoint")
+	}
+	if !strings.Contains(err.Error(), "failed to parse auth endpoint") {
+		t.Errorf("expected parse error, got: %v", err)
+	}
+}
+
+// --- PKCE tests ---
+
+func TestNewCodeVerifier(t *testing.T) {
+	v, err := newCodeVerifier(32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v == "" {
+		t.Fatal("expected non-empty code verifier")
+	}
+	// 32 bytes -> 43 base64url chars (no padding)
+	if len(v) != 43 {
+		t.Errorf("expected code verifier length 43, got %d", len(v))
+	}
+}
+
+func TestNewCodeVerifierUniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 100; i++ {
+		v, err := newCodeVerifier(32)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if seen[v] {
+			t.Fatalf("duplicate code verifier: %s", v)
+		}
+		seen[v] = true
+	}
+}
+
+func TestNewCodeVerifierIsValidBase64URL(t *testing.T) {
+	v, err := newCodeVerifier(32)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_, err = base64.RawURLEncoding.DecodeString(v)
+	if err != nil {
+		t.Errorf("code verifier is not valid base64url: %v", err)
+	}
+}
+
+func TestNewCodeVerifierURLSafe(t *testing.T) {
+	for i := 0; i < 50; i++ {
+		v, err := newCodeVerifier(32)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if strings.ContainsAny(v, "+/=") {
+			t.Errorf("code verifier contains non-URL-safe characters: %s", v)
+		}
+	}
+}
+
+func TestComputeCodeChallenge(t *testing.T) {
+	verifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	challenge := computeCodeChallenge(verifier)
+	// RFC 7636 Appendix B reference value
+	expected := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+	if challenge != expected {
+		t.Errorf("expected challenge %s, got %s", expected, challenge)
+	}
+}
+
+func TestComputeCodeChallengeIsBase64URL(t *testing.T) {
+	verifier, _ := newCodeVerifier(32)
+	challenge := computeCodeChallenge(verifier)
+	_, err := base64.RawURLEncoding.DecodeString(challenge)
+	if err != nil {
+		t.Errorf("code challenge is not valid base64url: %v", err)
+	}
+}
+
+func TestComputeCodeChallengeLength(t *testing.T) {
+	verifier, _ := newCodeVerifier(32)
+	challenge := computeCodeChallenge(verifier)
+	// SHA-256 = 32 bytes -> 43 base64url chars
+	if len(challenge) != 43 {
+		t.Errorf("expected code challenge length 43, got %d", len(challenge))
+	}
+}
+
+func TestComputeCodeChallengeDeterministic(t *testing.T) {
+	verifier := "test-verifier-value"
+	c1 := computeCodeChallenge(verifier)
+	c2 := computeCodeChallenge(verifier)
+	if c1 != c2 {
+		t.Errorf("same verifier produced different challenges: %s vs %s", c1, c2)
+	}
+}
+
+func TestComputeCodeChallengeMatchesSHA256(t *testing.T) {
+	verifier, _ := newCodeVerifier(32)
+	challenge := computeCodeChallenge(verifier)
+
+	h := sha256.Sum256([]byte(verifier))
+	expected := base64.RawURLEncoding.EncodeToString(h[:])
+	if challenge != expected {
+		t.Errorf("challenge does not match manual SHA-256 computation: got %s, want %s", challenge, expected)
+	}
+}
+
+func TestGetIdpAuthURLWithPKCE(t *testing.T) {
+	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "test-state", "9213", challenge)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	u, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("failed to parse auth URL: %v", err)
+	}
+
+	q := u.Query()
+	if q.Get("code_challenge") != challenge {
+		t.Errorf("expected code_challenge=%s, got %s", challenge, q.Get("code_challenge"))
+	}
+	if q.Get("code_challenge_method") != "S256" {
+		t.Errorf("expected code_challenge_method=S256, got %s", q.Get("code_challenge_method"))
+	}
+}
+
+func TestGetIdpAuthURLWithoutPKCE(t *testing.T) {
+	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "test-state", "9213", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	u, err := url.Parse(authURL)
+	if err != nil {
+		t.Fatalf("failed to parse auth URL: %v", err)
+	}
+
+	q := u.Query()
+	if q.Get("code_challenge") != "" {
+		t.Errorf("expected no code_challenge param, got %s", q.Get("code_challenge"))
+	}
+	if q.Get("code_challenge_method") != "" {
+		t.Errorf("expected no code_challenge_method param, got %s", q.Get("code_challenge_method"))
+	}
+}
+
+func TestGetAuthCodeWithPKCESuccess(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	listener.Close()
+
+	origBrowserOpen := browserOpen
+	defer func() { browserOpen = origBrowserOpen }()
+
+	var capturedURL string
+	browserOpen = func(authURL string) error {
+		capturedURL = authURL
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		state := u.Query().Get("state")
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=pkce-code&state=%s", port, state))
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	code, codeVerifier, err := GetAuthCode("https://idp.example.com/oauth2/authorize", "my-client", "openid", port, 10, true, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	q, err := url.ParseQuery(code)
+	if err != nil {
+		t.Fatalf("failed to parse returned code: %v", err)
+	}
+	if q.Get("code") != "pkce-code" {
+		t.Errorf("expected code=pkce-code, got %s", q.Get("code"))
+	}
+
+	if codeVerifier == "" {
+		t.Fatal("expected non-empty code verifier when pkce is true")
+	}
+	if len(codeVerifier) != 43 {
+		t.Errorf("expected code verifier length 43, got %d", len(codeVerifier))
+	}
+
+	// Verify the auth URL contained PKCE parameters
+	u, err := url.Parse(capturedURL)
+	if err != nil {
+		t.Fatalf("failed to parse captured auth URL: %v", err)
+	}
+	challenge := u.Query().Get("code_challenge")
+	if challenge == "" {
+		t.Fatal("expected code_challenge in auth URL")
+	}
+	if u.Query().Get("code_challenge_method") != "S256" {
+		t.Errorf("expected code_challenge_method=S256, got %s", u.Query().Get("code_challenge_method"))
+	}
+
+	// Verify challenge matches the verifier
+	expectedChallenge := computeCodeChallenge(codeVerifier)
+	if challenge != expectedChallenge {
+		t.Errorf("code_challenge does not match verifier: got %s, want %s", challenge, expectedChallenge)
+	}
+}
+
+func TestGetAuthCodeWithPKCEDisabled(t *testing.T) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("failed to get free port: %v", err)
+	}
+	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	listener.Close()
+
+	origBrowserOpen := browserOpen
+	defer func() { browserOpen = origBrowserOpen }()
+
+	var capturedURL string
+	browserOpen = func(authURL string) error {
+		capturedURL = authURL
+		u, err := url.Parse(authURL)
+		if err != nil {
+			return err
+		}
+		state := u.Query().Get("state")
+		go func() {
+			time.Sleep(200 * time.Millisecond)
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=no-pkce-code&state=%s", port, state))
+			if err == nil {
+				resp.Body.Close()
+			}
+		}()
+		return nil
+	}
+
+	code, codeVerifier, err := GetAuthCode("https://idp.example.com/oauth2/authorize", "my-client", "openid", port, 10, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	q, err := url.ParseQuery(code)
+	if err != nil {
+		t.Fatalf("failed to parse returned code: %v", err)
+	}
+	if q.Get("code") != "no-pkce-code" {
+		t.Errorf("expected code=no-pkce-code, got %s", q.Get("code"))
+	}
+
+	if codeVerifier != "" {
+		t.Errorf("expected empty code verifier when pkce is false, got %s", codeVerifier)
+	}
+
+	// Verify the auth URL did NOT contain PKCE parameters
+	u, err := url.Parse(capturedURL)
+	if err != nil {
+		t.Fatalf("failed to parse captured auth URL: %v", err)
+	}
+	if u.Query().Get("code_challenge") != "" {
+		t.Errorf("expected no code_challenge in auth URL, got %s", u.Query().Get("code_challenge"))
+	}
+	if u.Query().Get("code_challenge_method") != "" {
+		t.Errorf("expected no code_challenge_method in auth URL, got %s", u.Query().Get("code_challenge_method"))
 	}
 }
 

--- a/libs/go/usercert/usercert.go
+++ b/libs/go/usercert/usercert.go
@@ -56,6 +56,7 @@ type Options struct {
 	CallbackPort      string // local port for OAuth2 callback server
 	CallbackTimeout   int    // seconds to wait for IdP callback
 	ExpiryTime        int    // certificate expiry in minutes (0 = server default)
+	PKCE              bool   // enable PKCE for IdP auth flow
 	Proxy             bool   // use HTTP proxy from environment
 	Verbose           bool   // enable verbose logging
 }
@@ -95,8 +96,8 @@ func RequestCertificate(opts Options) (string, error) {
 	if scope == "" {
 		scope = "openid"
 	}
-	authCode, err := GetAuthCode(opts.IdpEndpoint, opts.IdpClientId, scope, opts.CallbackPort,
-		opts.CallbackTimeout, opts.Verbose)
+	authCode, codeVerifier, err := GetAuthCode(opts.IdpEndpoint, opts.IdpClientId, scope, opts.CallbackPort,
+		opts.CallbackTimeout, opts.PKCE, opts.Verbose)
 	if err != nil {
 		return "", fmt.Errorf("failed to obtain IdP auth code: %v", err)
 	}
@@ -117,10 +118,14 @@ func RequestCertificate(opts Options) (string, error) {
 	}
 	client := zts.NewClient(opts.ZtsURL, transport)
 
+	attestationData := authCode
+	if codeVerifier != "" {
+		attestationData = fmt.Sprintf("%s&code_verifier=%s", authCode, codeVerifier)
+	}
 	req := &zts.UserCertificateRequest{
 		Name:            opts.UserName,
 		Csr:             csrData,
-		AttestationData: authCode,
+		AttestationData: attestationData,
 	}
 	if opts.ExpiryTime > 0 {
 		expiry := int32(opts.ExpiryTime)
@@ -167,7 +172,7 @@ func Run(opts Options) {
 	}
 
 	if opts.CertFile != "" {
-		err = os.WriteFile(opts.CertFile, []byte(cert), 0644)
+		err = os.WriteFile(opts.CertFile, []byte(cert), 0600)
 		if err != nil {
 			log.Fatalf("Unable to save user certificate to %s: %v\n", opts.CertFile, err)
 		}

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/UserCertificateProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/UserCertificateProvider.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 
@@ -59,6 +60,8 @@ public class UserCertificateProvider implements InstanceProvider {
     static final String USER_CERT_PROP_CLIENT_SECRET_KEYNAME  = "athenz.zts.user_cert.idp_client_secret_keyname";
 
     static final String CODE_PREFIX = "code=";
+    static final String STATE_PREFIX = "state=";
+    static final String CODE_VERIFIER_PREFIX = "code_verifier=";
 
     static final String DEFAULT_REDIRECT_URI = "http://localhost:9213/oauth2/callback";
 
@@ -108,6 +111,11 @@ public class UserCertificateProvider implements InstanceProvider {
             }
         }
 
+        if (!tokenEndpoint.toLowerCase().startsWith("https://")) {
+            throw new ProviderResourceException(ProviderResourceException.INTERNAL_SERVER_ERROR,
+                    "IdP token endpoint must be an https url");
+        }
+
         if (StringUtil.isEmpty(jwksEndpoint)) {
             jwksEndpoint = System.getProperty(USER_CERT_PROP_JWKS_ENDPOINT);
             if (StringUtil.isEmpty(jwksEndpoint)) {
@@ -115,6 +123,12 @@ public class UserCertificateProvider implements InstanceProvider {
                         "IdP jwks endpoint not configured");
             }
         }
+
+        if (!jwksEndpoint.toLowerCase().startsWith("https://")) {
+            throw new ProviderResourceException(ProviderResourceException.INTERNAL_SERVER_ERROR,
+                    "IdP jwks endpoint must be an https url");
+        }
+
         signingKeyResolver = new JwtsSigningKeyResolver(jwksEndpoint, null);
 
         clientId = System.getProperty(USER_CERT_PROP_CLIENT_ID);
@@ -126,9 +140,13 @@ public class UserCertificateProvider implements InstanceProvider {
         clientSecret = getClientSecret();
         redirectUri = System.getProperty(USER_CERT_PROP_REDIRECT_URI, DEFAULT_REDIRECT_URI);
 
-        // extract audience. if specified, the value must match the audience in the token
+        // extract audience. the value must match the audience in the token, otherwise the token is invalid.
         
         audience = System.getProperty(USER_CERT_PROP_AUDIENCE);
+        if (StringUtil.isEmpty(audience)) {
+            throw new ProviderResourceException(ProviderResourceException.INTERNAL_SERVER_ERROR,
+                    "IdP audience not configured");
+        }
 
         // extract connection and read timeouts
         
@@ -173,18 +191,10 @@ public class UserCertificateProvider implements InstanceProvider {
             throw forbiddenError("User name not provided in confirmation");
         }
 
-        // the attestation data is the callback query string from the OAuth2 flow
-        // which contains code and state parameters - extract the code
-
-        final String authCode = extractAuthCode(attestationData);
-        if (StringUtil.isEmpty(authCode)) {
-            throw forbiddenError("Unable to extract authorization code from attestation data");
-        }
-
         // exchange the authorization code with the IdP token endpoint
 
         AccessToken accessTokenObject;
-        final String accessTokenString = exchangeAuthCodeForAccessToken(authCode);
+        final String accessTokenString = exchangeAuthCodeForAccessToken(attestationData);
         try {
             accessTokenObject = new AccessToken(accessTokenString, signingKeyResolver);
         } catch (Exception ex) {
@@ -200,7 +210,7 @@ public class UserCertificateProvider implements InstanceProvider {
 
         // verify that the audience in the token matches the configured audience
 
-        if (!StringUtil.isEmpty(audience) && !audience.equals(accessTokenObject.getAudience())) {
+        if (!audience.equals(accessTokenObject.getAudience())) {
             LOGGER.error("Audience mismatch: token-audience={} vs. configured-audience={}",
                     accessTokenObject.getAudience(), audience);
             throw forbiddenError("Token audience mismatch");
@@ -247,35 +257,61 @@ public class UserCertificateProvider implements InstanceProvider {
         return false;
     }
 
-    String extractAuthCode(final String attestationData) {
+    String generateAccessTokenRequestBody(final String attestationData) throws ProviderResourceException {
 
-        // the attestation data could be:
-        // 1. a query string from the OAuth2 callback (code=...&state=...)
-        // 2. just the raw authorization code
+        String code = null;
+        String state = null;
+        String codeVerifier = null;
 
-        if (attestationData.contains(CODE_PREFIX)) {
-            String[] params = attestationData.split("&");
-            for (String param : params) {
-                if (param.startsWith(CODE_PREFIX)) {
-                    return param.substring(CODE_PREFIX.length());
-                }
+        String requestBody = "grant_type=authorization_code"
+            + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
+            + "&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8);
+
+        String[] params = attestationData.split("&");
+        for (String param : params) {
+            if (param.startsWith(CODE_PREFIX)) {
+                code = URLDecoder.decode(param.substring(CODE_PREFIX.length()), StandardCharsets.UTF_8);
+            } else if (param.startsWith(STATE_PREFIX)) {
+                state = URLDecoder.decode(param.substring(STATE_PREFIX.length()), StandardCharsets.UTF_8);
+            } else if (param.startsWith(CODE_VERIFIER_PREFIX)) {
+                codeVerifier = URLDecoder.decode(param.substring(CODE_VERIFIER_PREFIX.length()), StandardCharsets.UTF_8);
             }
-            return null;
         }
 
-        return attestationData;
+        // make sure we have valid code specified in our attestation data
+
+        if (StringUtil.isEmpty(code)) {
+            throw forbiddenError("Code not provided in attestation data");
+        }
+
+        // if our secret is not configured then pkce is required and as such
+        // the code verifier must be specified in the attestation data
+
+        if (StringUtil.isEmpty(clientSecret)) {
+            if (StringUtil.isEmpty(codeVerifier)) {
+                throw forbiddenError("PKCE is required but code verifier not provided");
+            }
+        } else {
+            requestBody += "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8);
+        }
+
+        // otherwise, return the code, state, and code verifier
+        // encoded and concatenated with the appropriate ampersands
+
+        requestBody += "&" + CODE_PREFIX + URLEncoder.encode(code, StandardCharsets.UTF_8);
+        if (!StringUtil.isEmpty(state)) {
+            requestBody += "&" + STATE_PREFIX + URLEncoder.encode(state, StandardCharsets.UTF_8);
+        }
+        if (!StringUtil.isEmpty(codeVerifier)) {
+            requestBody += "&" + CODE_VERIFIER_PREFIX + URLEncoder.encode(codeVerifier, StandardCharsets.UTF_8);
+        }
+
+        return requestBody;
     }
 
-    String exchangeAuthCodeForAccessToken(final String authCode) throws ProviderResourceException {
+    String exchangeAuthCodeForAccessToken(final String attestationData) throws ProviderResourceException {
 
-        final String requestBody = "grant_type=authorization_code"
-                + "&code=" + URLEncoder.encode(authCode, StandardCharsets.UTF_8)
-                + "&client_id=" + URLEncoder.encode(clientId, StandardCharsets.UTF_8)
-                + "&redirect_uri=" + URLEncoder.encode(redirectUri, StandardCharsets.UTF_8)
-                + (StringUtil.isEmpty(clientSecret) ? "" :
-                    "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8));
-
-        AccessTokenResponse accessTokenResponse = postTokenRequest(requestBody);
+        AccessTokenResponse accessTokenResponse = postTokenRequest(generateAccessTokenRequestBody(attestationData));
 
         final String accessToken = accessTokenResponse.getAccess_token();
         if (StringUtil.isEmpty(accessToken)) {

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/UserCertificateProvider.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/UserCertificateProvider.java
@@ -60,7 +60,6 @@ public class UserCertificateProvider implements InstanceProvider {
     static final String USER_CERT_PROP_CLIENT_SECRET_KEYNAME  = "athenz.zts.user_cert.idp_client_secret_keyname";
 
     static final String CODE_PREFIX = "code=";
-    static final String STATE_PREFIX = "state=";
     static final String CODE_VERIFIER_PREFIX = "code_verifier=";
 
     static final String DEFAULT_REDIRECT_URI = "http://localhost:9213/oauth2/callback";
@@ -260,7 +259,6 @@ public class UserCertificateProvider implements InstanceProvider {
     String generateAccessTokenRequestBody(final String attestationData) throws ProviderResourceException {
 
         String code = null;
-        String state = null;
         String codeVerifier = null;
 
         String requestBody = "grant_type=authorization_code"
@@ -271,8 +269,6 @@ public class UserCertificateProvider implements InstanceProvider {
         for (String param : params) {
             if (param.startsWith(CODE_PREFIX)) {
                 code = URLDecoder.decode(param.substring(CODE_PREFIX.length()), StandardCharsets.UTF_8);
-            } else if (param.startsWith(STATE_PREFIX)) {
-                state = URLDecoder.decode(param.substring(STATE_PREFIX.length()), StandardCharsets.UTF_8);
             } else if (param.startsWith(CODE_VERIFIER_PREFIX)) {
                 codeVerifier = URLDecoder.decode(param.substring(CODE_VERIFIER_PREFIX.length()), StandardCharsets.UTF_8);
             }
@@ -295,13 +291,10 @@ public class UserCertificateProvider implements InstanceProvider {
             requestBody += "&client_secret=" + URLEncoder.encode(clientSecret, StandardCharsets.UTF_8);
         }
 
-        // otherwise, return the code, state, and code verifier
+        // otherwise, return the code and code verifier
         // encoded and concatenated with the appropriate ampersands
 
         requestBody += "&" + CODE_PREFIX + URLEncoder.encode(code, StandardCharsets.UTF_8);
-        if (!StringUtil.isEmpty(state)) {
-            requestBody += "&" + STATE_PREFIX + URLEncoder.encode(state, StandardCharsets.UTF_8);
-        }
         if (!StringUtil.isEmpty(codeVerifier)) {
             requestBody += "&" + CODE_VERIFIER_PREFIX + URLEncoder.encode(codeVerifier, StandardCharsets.UTF_8);
         }

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/UserCertificateProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/UserCertificateProviderTest.java
@@ -77,6 +77,7 @@ public class UserCertificateProviderTest {
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_TOKEN_ENDPOINT, "https://idp.example.com/oauth2/v1/token");
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_JWKS_ENDPOINT, "https://idp.example.com/oauth2/v1/keys");
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_CLIENT_ID, "test-client-id");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_AUDIENCE, "test-audience");
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_CLIENT_SECRET_KEYNAME, "test-secret-key");
 
         PrivateKeyStore keyStore = Mockito.mock(PrivateKeyStore.class);
@@ -92,6 +93,7 @@ public class UserCertificateProviderTest {
         assertEquals(provider.clientId, "test-client-id");
         assertEquals(provider.clientSecret, "test-secret");
         assertEquals(provider.redirectUri, UserCertificateProvider.DEFAULT_REDIRECT_URI);
+        assertEquals(provider.audience, "test-audience");
         assertEquals(provider.connectTimeout, 10000);
         assertEquals(provider.readTimeout, 15000);
         assertNotNull(provider.signingKeyResolver);
@@ -133,6 +135,7 @@ public class UserCertificateProviderTest {
     public void testInitializeWithConfigEndpoint() throws ProviderResourceException {
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_CONFIG_ENDPOINT, "https://idp.example.com/.well-known/openid-configuration");
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_CLIENT_ID, "test-client-id");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_AUDIENCE, "test-audience");
 
         OpenIdConfiguration openIdConfig = new OpenIdConfiguration();
         openIdConfig.setTokenEndpoint("https://idp.example.com/oauth2/token");
@@ -157,6 +160,7 @@ public class UserCertificateProviderTest {
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_TOKEN_ENDPOINT, "https://idp.example.com/token");
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_JWKS_ENDPOINT, "https://idp.example.com/keys");
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_CLIENT_ID, "test-client-id");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_AUDIENCE, "test-audience");
 
         try (MockedConstruction<JwtsHelper> mocked = Mockito.mockConstruction(JwtsHelper.class,
                 (mock, context) -> Mockito.when(mock.extractOpenIdConfiguration(
@@ -199,6 +203,90 @@ public class UserCertificateProviderTest {
     }
 
     @Test
+    public void testInitializeTokenEndpointNotHttps() {
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_TOKEN_ENDPOINT, "http://idp.example.com/token");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_JWKS_ENDPOINT, "https://idp.example.com/keys");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_CLIENT_ID, "test-client-id");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_AUDIENCE, "test-audience");
+
+        UserCertificateProvider provider = new UserCertificateProvider();
+        try {
+            provider.initialize("sys.auth.user_cert", null, null, null);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), ProviderResourceException.INTERNAL_SERVER_ERROR);
+            assertTrue(ex.getMessage().contains("IdP token endpoint must be an https url"));
+        }
+    }
+
+    @Test
+    public void testInitializeJwksEndpointNotHttps() {
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_TOKEN_ENDPOINT, "https://idp.example.com/token");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_JWKS_ENDPOINT, "http://idp.example.com/keys");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_CLIENT_ID, "test-client-id");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_AUDIENCE, "test-audience");
+
+        UserCertificateProvider provider = new UserCertificateProvider();
+        try {
+            provider.initialize("sys.auth.user_cert", null, null, null);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), ProviderResourceException.INTERNAL_SERVER_ERROR);
+            assertTrue(ex.getMessage().contains("IdP jwks endpoint must be an https url"));
+        }
+    }
+
+    @Test
+    public void testInitializeConfigEndpointTokenNotHttps() throws ProviderResourceException {
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_CONFIG_ENDPOINT, "https://idp.example.com/.well-known/openid-configuration");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_CLIENT_ID, "test-client-id");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_AUDIENCE, "test-audience");
+
+        OpenIdConfiguration openIdConfig = new OpenIdConfiguration();
+        openIdConfig.setTokenEndpoint("http://idp.example.com/oauth2/token");
+        openIdConfig.setJwksUri("https://idp.example.com/oauth2/keys");
+
+        try (MockedConstruction<JwtsHelper> mocked = Mockito.mockConstruction(JwtsHelper.class,
+                (mock, context) -> Mockito.when(mock.extractOpenIdConfiguration(
+                        Mockito.anyString(), Mockito.any(), Mockito.any())).thenReturn(openIdConfig))) {
+
+            UserCertificateProvider provider = new UserCertificateProvider();
+            try {
+                provider.initialize("sys.auth.user_cert", null, null, null);
+                fail();
+            } catch (ProviderResourceException ex) {
+                assertEquals(ex.getCode(), ProviderResourceException.INTERNAL_SERVER_ERROR);
+                assertTrue(ex.getMessage().contains("IdP token endpoint must be an https url"));
+            }
+        }
+    }
+
+    @Test
+    public void testInitializeConfigEndpointJwksNotHttps() throws ProviderResourceException {
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_CONFIG_ENDPOINT, "https://idp.example.com/.well-known/openid-configuration");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_CLIENT_ID, "test-client-id");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_AUDIENCE, "test-audience");
+
+        OpenIdConfiguration openIdConfig = new OpenIdConfiguration();
+        openIdConfig.setTokenEndpoint("https://idp.example.com/oauth2/token");
+        openIdConfig.setJwksUri("http://idp.example.com/oauth2/keys");
+
+        try (MockedConstruction<JwtsHelper> mocked = Mockito.mockConstruction(JwtsHelper.class,
+                (mock, context) -> Mockito.when(mock.extractOpenIdConfiguration(
+                        Mockito.anyString(), Mockito.any(), Mockito.any())).thenReturn(openIdConfig))) {
+
+            UserCertificateProvider provider = new UserCertificateProvider();
+            try {
+                provider.initialize("sys.auth.user_cert", null, null, null);
+                fail();
+            } catch (ProviderResourceException ex) {
+                assertEquals(ex.getCode(), ProviderResourceException.INTERNAL_SERVER_ERROR);
+                assertTrue(ex.getMessage().contains("IdP jwks endpoint must be an https url"));
+            }
+        }
+    }
+
+    @Test
     public void testInitializeMissingClientId() {
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_TOKEN_ENDPOINT, "https://idp.example.com/token");
         System.setProperty(UserCertificateProvider.USER_CERT_PROP_JWKS_ENDPOINT, "https://idp.example.com/keys");
@@ -210,6 +298,22 @@ public class UserCertificateProviderTest {
         } catch (ProviderResourceException ex) {
             assertEquals(ex.getCode(), ProviderResourceException.INTERNAL_SERVER_ERROR);
             assertTrue(ex.getMessage().contains("IdP client id not configured"));
+        }
+    }
+
+    @Test
+    public void testInitializeMissingAudience() {
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_TOKEN_ENDPOINT, "https://idp.example.com/token");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_JWKS_ENDPOINT, "https://idp.example.com/keys");
+        System.setProperty(UserCertificateProvider.USER_CERT_PROP_CLIENT_ID, "test-client-id");
+
+        UserCertificateProvider provider = new UserCertificateProvider();
+        try {
+            provider.initialize("sys.auth.user_cert", null, null, null);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), ProviderResourceException.INTERNAL_SERVER_ERROR);
+            assertTrue(ex.getMessage().contains("IdP audience not configured"));
         }
     }
 
@@ -255,36 +359,10 @@ public class UserCertificateProviderTest {
     }
 
     @Test
-    public void testExtractAuthCodeFromQueryString() {
-        UserCertificateProvider provider = new UserCertificateProvider();
-        assertEquals(provider.extractAuthCode("code=abc123&state=xyz"), "abc123");
-        assertEquals(provider.extractAuthCode("state=xyz&code=def456"), "def456");
-    }
-
-    @Test
-    public void testExtractAuthCodeRawValue() {
-        UserCertificateProvider provider = new UserCertificateProvider();
-        assertEquals(provider.extractAuthCode("raw-auth-code"), "raw-auth-code");
-        assertEquals(provider.extractAuthCode("some-random-string"), "some-random-string");
-    }
-
-    @Test
-    public void testExtractAuthCodeEmptyCode() {
-        UserCertificateProvider provider = new UserCertificateProvider();
-        assertEquals(provider.extractAuthCode("code=&state=xyz"), "");
-    }
-
-    @Test
-    public void testExtractAuthCodeNoCodeParam() {
-        UserCertificateProvider provider = new UserCertificateProvider();
-        assertNull(provider.extractAuthCode("mycode=abc&state=xyz"));
-    }
-
-    @Test
     public void testConfirmInstanceSuccess() throws Exception {
         UserCertificateProvider provider = createTestProvider();
 
-        String accessToken = generateMockAccessToken("johndoe", null, null);
+        String accessToken = generateMockAccessToken("johndoe", "test-audience", null);
         AccessTokenResponse tokenResponse = new AccessTokenResponse();
         tokenResponse.setAccess_token(accessToken);
 
@@ -302,15 +380,8 @@ public class UserCertificateProviderTest {
     }
 
     @Test
-    public void testConfirmInstanceWithRawAuthCode() throws Exception {
+    public void testConfirmInstanceWithRawAuthCode() {
         UserCertificateProvider provider = createTestProvider();
-
-        String accessToken = generateMockAccessToken("johndoe", null, null);
-        AccessTokenResponse tokenResponse = new AccessTokenResponse();
-        tokenResponse.setAccess_token(accessToken);
-
-        UserCertificateProvider spyProvider = Mockito.spy(provider);
-        Mockito.doReturn(tokenResponse).when(spyProvider).postTokenRequest(Mockito.anyString());
 
         InstanceConfirmation confirmation = new InstanceConfirmation();
         confirmation.setDomain("user");
@@ -318,8 +389,13 @@ public class UserCertificateProviderTest {
         confirmation.setProvider("sys.auth.user_cert");
         confirmation.setAttestationData("raw-auth-code-value");
 
-        InstanceConfirmation result = spyProvider.confirmInstance(confirmation);
-        assertNotNull(result);
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), ProviderResourceException.FORBIDDEN);
+            assertTrue(ex.getMessage().contains("Code not provided in attestation data"));
+        }
     }
 
     @Test
@@ -375,29 +451,10 @@ public class UserCertificateProviderTest {
     }
 
     @Test
-    public void testConfirmInstanceEmptyAuthCode() {
-        UserCertificateProvider provider = createTestProvider();
-
-        InstanceConfirmation confirmation = new InstanceConfirmation();
-        confirmation.setDomain("user");
-        confirmation.setService("johndoe");
-        confirmation.setProvider("sys.auth.user_cert");
-        confirmation.setAttestationData("mycode=abc&state=xyz");
-
-        try {
-            provider.confirmInstance(confirmation);
-            fail();
-        } catch (ProviderResourceException ex) {
-            assertEquals(ex.getCode(), ProviderResourceException.FORBIDDEN);
-            assertTrue(ex.getMessage().contains("Unable to extract authorization code"));
-        }
-    }
-
-    @Test
     public void testConfirmInstanceSubjectMismatch() throws Exception {
         UserCertificateProvider provider = createTestProvider();
 
-        String accessToken = generateMockAccessToken("different-user", null, null);
+        String accessToken = generateMockAccessToken("different-user", "test-audience", null);
         AccessTokenResponse tokenResponse = new AccessTokenResponse();
         tokenResponse.setAccess_token(accessToken);
 
@@ -569,7 +626,7 @@ public class UserCertificateProviderTest {
         UserCertificateProvider provider = createTestProvider();
         provider.clientSecret = "";
 
-        String accessToken = generateMockAccessToken("johndoe", null, null);
+        String accessToken = generateMockAccessToken("johndoe", "test-audience", null);
         AccessTokenResponse tokenResponse = new AccessTokenResponse();
         tokenResponse.setAccess_token(accessToken);
 
@@ -580,7 +637,7 @@ public class UserCertificateProviderTest {
         confirmation.setDomain("user");
         confirmation.setService("johndoe");
         confirmation.setProvider("sys.auth.user_cert");
-        confirmation.setAttestationData("code=test-auth-code");
+        confirmation.setAttestationData("code=test-auth-code&code_verifier=test-verifier");
 
         InstanceConfirmation result = spyProvider.confirmInstance(confirmation);
         assertNotNull(result);
@@ -677,7 +734,7 @@ public class UserCertificateProviderTest {
         HttpURLConnection mockConn = createMockConnection(200, tokenResponseJson);
         Mockito.doReturn(mockConn).when(spyProvider).createTokenEndpointConnection();
 
-        String result = spyProvider.exchangeAuthCodeForAccessToken("test-code");
+        String result = spyProvider.exchangeAuthCodeForAccessToken("code=test-code");
         assertEquals(result, accessTokenJwt);
     }
 
@@ -693,7 +750,7 @@ public class UserCertificateProviderTest {
         HttpURLConnection mockConn = createMockConnection(200, tokenResponseJson);
         Mockito.doReturn(mockConn).when(spyProvider).createTokenEndpointConnection();
 
-        String result = spyProvider.exchangeAuthCodeForAccessToken("test-code");
+        String result = spyProvider.exchangeAuthCodeForAccessToken("code=test-code&code_verifier=test-verifier");
         assertEquals(result, accessTokenJwt);
     }
 
@@ -708,7 +765,7 @@ public class UserCertificateProviderTest {
         Mockito.doReturn(mockConn).when(spyProvider).createTokenEndpointConnection();
 
         try {
-            spyProvider.exchangeAuthCodeForAccessToken("test-code");
+            spyProvider.exchangeAuthCodeForAccessToken("code=test-code");
             fail();
         } catch (ProviderResourceException ex) {
             assertEquals(ex.getCode(), ProviderResourceException.FORBIDDEN);
@@ -773,7 +830,7 @@ public class UserCertificateProviderTest {
 
         Map<String, Object> extraClaims = new HashMap<>();
         extraClaims.put("preferred_username", "johndoe");
-        String accessToken = generateMockAccessToken("uid-12345", null, extraClaims);
+        String accessToken = generateMockAccessToken("uid-12345", "test-audience", extraClaims);
         AccessTokenResponse tokenResponse = new AccessTokenResponse();
         tokenResponse.setAccess_token(accessToken);
 
@@ -828,6 +885,92 @@ public class UserCertificateProviderTest {
         conn.disconnect();
     }
 
+    @Test
+    public void testGenerateAccessTokenRequestBodyCodeOnly() throws ProviderResourceException {
+        UserCertificateProvider provider = createTestProvider();
+
+        String body = provider.generateAccessTokenRequestBody("code=my-auth-code");
+        assertTrue(body.contains("grant_type=authorization_code"));
+        assertTrue(body.contains("client_id="));
+        assertTrue(body.contains("redirect_uri="));
+        assertTrue(body.contains("client_secret="));
+        assertTrue(body.contains("code=my-auth-code"));
+        assertFalse(body.contains("state="));
+        assertFalse(body.contains("code_verifier="));
+    }
+
+    @Test
+    public void testGenerateAccessTokenRequestBodyWithAllParams() throws ProviderResourceException {
+        UserCertificateProvider provider = createTestProvider();
+
+        String body = provider.generateAccessTokenRequestBody(
+                "code=my-code&state=my-state&code_verifier=my-verifier");
+        assertTrue(body.contains("grant_type=authorization_code"));
+        assertTrue(body.contains("client_secret="));
+        assertTrue(body.contains("code=my-code"));
+        assertTrue(body.contains("state=my-state"));
+        assertTrue(body.contains("code_verifier=my-verifier"));
+    }
+
+    @Test
+    public void testGenerateAccessTokenRequestBodyMissingCode() {
+        UserCertificateProvider provider = createTestProvider();
+
+        try {
+            provider.generateAccessTokenRequestBody("state=some-state&code_verifier=some-verifier");
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), ProviderResourceException.FORBIDDEN);
+            assertTrue(ex.getMessage().contains("Code not provided in attestation data"));
+        }
+    }
+
+    @Test
+    public void testGenerateAccessTokenRequestBodyPkceRequiredNoVerifier() {
+        UserCertificateProvider provider = createTestProvider();
+        provider.clientSecret = "";
+
+        try {
+            provider.generateAccessTokenRequestBody("code=my-code");
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), ProviderResourceException.FORBIDDEN);
+            assertTrue(ex.getMessage().contains("PKCE is required but code verifier not provided"));
+        }
+    }
+
+    @Test
+    public void testGenerateAccessTokenRequestBodyPkceWithVerifier() throws ProviderResourceException {
+        UserCertificateProvider provider = createTestProvider();
+        provider.clientSecret = "";
+
+        String body = provider.generateAccessTokenRequestBody("code=my-code&code_verifier=my-verifier");
+        assertTrue(body.contains("grant_type=authorization_code"));
+        assertFalse(body.contains("client_secret="));
+        assertTrue(body.contains("code=my-code"));
+        assertTrue(body.contains("code_verifier=my-verifier"));
+    }
+
+    @Test
+    public void testConfirmInstancePkceRequiredNoVerifier() {
+        UserCertificateProvider provider = createTestProvider();
+        provider.clientSecret = "";
+
+        InstanceConfirmation confirmation = new InstanceConfirmation();
+        confirmation.setDomain("user");
+        confirmation.setService("johndoe");
+        confirmation.setProvider("sys.auth.user_cert");
+        confirmation.setAttestationData("code=test-auth-code");
+
+        try {
+            provider.confirmInstance(confirmation);
+            fail();
+        } catch (ProviderResourceException ex) {
+            assertEquals(ex.getCode(), ProviderResourceException.FORBIDDEN);
+            assertTrue(ex.getMessage().contains("PKCE is required but code verifier not provided"));
+        }
+    }
+
     // --- helpers ---
 
     private UserCertificateProvider createTestProvider() {
@@ -836,6 +979,7 @@ public class UserCertificateProviderTest {
         provider.clientId = "test-client-id";
         provider.clientSecret = "test-secret";
         provider.redirectUri = UserCertificateProvider.DEFAULT_REDIRECT_URI;
+        provider.audience = "test-audience";
         provider.connectTimeout = 10000;
         provider.readTimeout = 15000;
         return provider;

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/UserCertificateProviderTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/UserCertificateProviderTest.java
@@ -373,7 +373,7 @@ public class UserCertificateProviderTest {
         confirmation.setDomain("user");
         confirmation.setService("johndoe");
         confirmation.setProvider("sys.auth.user_cert");
-        confirmation.setAttestationData("code=test-auth-code&state=test-state");
+        confirmation.setAttestationData("code=test-auth-code");
 
         InstanceConfirmation result = spyProvider.confirmInstance(confirmation);
         assertNotNull(result);
@@ -465,7 +465,7 @@ public class UserCertificateProviderTest {
         confirmation.setDomain("user");
         confirmation.setService("johndoe");
         confirmation.setProvider("sys.auth.user_cert");
-        confirmation.setAttestationData("code=test-auth-code&state=test-state");
+        confirmation.setAttestationData("code=test-auth-code");
 
         try {
             spyProvider.confirmInstance(confirmation);
@@ -562,7 +562,7 @@ public class UserCertificateProviderTest {
         confirmation.setDomain("user");
         confirmation.setService("johndoe");
         confirmation.setProvider("sys.auth.user_cert");
-        confirmation.setAttestationData("code=invalid-code&state=test-state");
+        confirmation.setAttestationData("code=invalid-code");
 
         try {
             spyProvider.confirmInstance(confirmation);
@@ -895,7 +895,6 @@ public class UserCertificateProviderTest {
         assertTrue(body.contains("redirect_uri="));
         assertTrue(body.contains("client_secret="));
         assertTrue(body.contains("code=my-auth-code"));
-        assertFalse(body.contains("state="));
         assertFalse(body.contains("code_verifier="));
     }
 
@@ -908,7 +907,6 @@ public class UserCertificateProviderTest {
         assertTrue(body.contains("grant_type=authorization_code"));
         assertTrue(body.contains("client_secret="));
         assertTrue(body.contains("code=my-code"));
-        assertTrue(body.contains("state=my-state"));
         assertTrue(body.contains("code_verifier=my-verifier"));
     }
 

--- a/utils/zts-usercert/zts-usercert.go
+++ b/utils/zts-usercert/zts-usercert.go
@@ -44,7 +44,7 @@ func main() {
 	var subjC, subjO, subjOU, spiffeTrustDomain string
 	var scope, callbackPort string
 	var callbackTimeout, expiryTime int
-	var proxy, verbose, showVersion bool
+	var pkce, proxy, verbose, showVersion bool
 
 	flag.StringVar(&ztsURL, "zts", "", "url of the ZTS Service")
 	flag.StringVar(&privateKeyFile, "private-key", "", "private key file")
@@ -61,6 +61,7 @@ func main() {
 	flag.IntVar(&callbackTimeout, "callback-timeout", DefaultCallbackTimeout, "timeout in seconds for IdP auth flow")
 	flag.IntVar(&expiryTime, "expiry-time", 0, "expiry time in minutes for the certificate")
 	flag.StringVar(&caCertFile, "cacert", "", "CA certificate file")
+	flag.BoolVar(&pkce, "pkce", true, "enable PKCE for IdP auth flow")
 	flag.BoolVar(&proxy, "proxy", true, "enable proxy mode for request")
 	flag.BoolVar(&verbose, "verbose", false, "enable verbose logging")
 	flag.BoolVar(&showVersion, "version", false, "show version")
@@ -88,6 +89,7 @@ func main() {
 		CallbackTimeout:   callbackTimeout,
 		ExpiryTime:        expiryTime,
 		CACertFile:        caCertFile,
+		PKCE:              pkce,
 		Proxy:             proxy,
 		Verbose:           verbose,
 	}


### PR DESCRIPTION
# Description

improve security posture for user certificates:

UserCertificateProvider: 
- audience is now required
- token endpoints must be https
- if no secret, then pkce code verifier is required
- attestation data must be code={code}&code_verifier={code_verifier} format

Idp go library:
- state value is verified on return
- option pkce option - default true
- cert stored with 600 mode

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

