### PR TITLE
make usercert.Run to return error so it can be used as library call

### DIFF
--- a/libs/go/usercert/usercert.go
+++ b/libs/go/usercert/usercert.go
@@ -144,15 +144,13 @@ func RequestCertificate(opts Options) (string, error) {
 	return userCert.X509Certificate, nil
 }
 
-// Run executes the full user certificate request flow. Any zero-value
-// fields in opts are populated from command-line flags before execution.
-// It writes the certificate to CertFile (or stdout) and calls
-// log.Fatalf on fatal errors.
-func Run(opts Options) {
+// Run executes the full user certificate request flow.
+// It writes the certificate to CertFile and returns
+// the certificate string and any errors that occur.
+func Run(opts Options) (string, error) {
 
 	if opts.PrivateKeyFile == "" || opts.UserName == "" {
-		log.Println("Error: missing required attributes. Run with -help for command line arguments")
-		os.Exit(1)
+		return "", fmt.Errorf("missing required Private Key File or User Name")
 	}
 
 	if opts.ZtsURL == "" || opts.IdpEndpoint == "" || opts.IdpClientId == "" {
@@ -161,27 +159,22 @@ func Run(opts Options) {
 			opts.ZtsURL = defaultConfig.Zts
 		}
 		if opts.ZtsURL == "" || opts.IdpEndpoint == "" || opts.IdpClientId == "" {
-			log.Println("Error: missing required attributes. Run with -help for command line arguments")
-			os.Exit(1)
+			return "", fmt.Errorf("missing required ZTS URL, IdP Endpoint, or IdP Client ID")
 		}
 	}
 
 	cert, err := RequestCertificate(opts)
 	if err != nil {
-		log.Fatalf("%v\n", err)
+		return "", fmt.Errorf("RequestCertificate failed: %v", err)
 	}
 
 	if opts.CertFile != "" {
 		err = os.WriteFile(opts.CertFile, []byte(cert), 0600)
 		if err != nil {
-			log.Fatalf("Unable to save user certificate to %s: %v\n", opts.CertFile, err)
+			return "", fmt.Errorf("Unable to save user certificate to %s: %v", opts.CertFile, err)
 		}
-		if opts.Verbose {
-			log.Printf("User certificate saved to %s\n", opts.CertFile)
-		}
-	} else {
-		fmt.Println(cert)
 	}
+	return cert, nil
 }
 
 func generateCSR(keySigner *signer, principalName, subjC, subjO, subjOU, spiffeTrustDomain string) (string, error) {

--- a/utils/zts-usercert/zts-usercert.go
+++ b/utils/zts-usercert/zts-usercert.go
@@ -12,6 +12,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 
 	"github.com/AthenZ/athenz/libs/go/usercert"
 )
@@ -94,5 +95,14 @@ func main() {
 		Verbose:           verbose,
 	}
 
-	usercert.Run(opts)
+	cert, err := usercert.Run(opts)
+	if err != nil {
+		log.Fatalf("Error: %v\n", err)
+	}
+
+	if opts.CertFile == "" {
+		fmt.Println(cert)
+	} else if opts.Verbose {
+		log.Printf("User certificate saved to %s\n", opts.CertFile)
+	}
 }


### PR DESCRIPTION
# Description
instead of calling exit or log.fatal in case of errors, the Run method in usercert now just returns an appropriate error so the method can be used within other tools as a library method call and doesn't just exist when it encounters an error
# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

