### PR TITLE
update "go" version to 1.26.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.25.0
+go 1.26.2
 
 module github.com/AthenZ/athenz
 


### PR DESCRIPTION
# Description
There are various CVEs associated with 1.25.0, so upgrading to 1.26.2 is recommended - see announcement:

https://groups.google.com/g/golang-announce/c/0uYbvbPZRWU

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

