### PR TITLE
introduce retry logic when reading gcp metadata

### DIFF
--- a/libs/go/sia/gcp/meta/meta.go
+++ b/libs/go/sia/gcp/meta/meta.go
@@ -42,7 +42,9 @@ func GetData(base, path string) ([]byte, error) {
 			return nil, lastErr
 		}
 		log.Printf("Transient error fetching metadata %s/%s (attempt %d/10): %v", base, path, i+1, lastErr)
-		time.Sleep(time.Second)
+		if i < 9 {
+			time.Sleep(time.Second * time.Duration(i+1))
+		}
 	}
 	return nil, lastErr
 }

--- a/libs/go/sia/gcp/meta/meta.go
+++ b/libs/go/sia/gcp/meta/meta.go
@@ -24,62 +24,89 @@ import (
 	"time"
 )
 
-// GetData makes a http call to the local metadata end point and returns the metadata document as bytes
+// GetData makes a http call to the local metadata end point and returns the metadata document as bytes.
+// If the request fails with a transient error, it retries up to 10 times with a 1 second delay.
 func GetData(base, path string) ([]byte, error) {
 	headers := make(map[string]string)
 	headers["Metadata-Flavor"] = "Google"
-	return processHttpRequest(base, path, "GET", headers)
+	var data []byte
+	var lastErr error
+	for i := range 10 {
+		var statusCode int
+		data, statusCode, lastErr = processHttpRequest(base, path, "GET", headers)
+		if lastErr == nil {
+			return data, nil
+		}
+		if !isTransientError(statusCode) {
+			log.Printf("Error fetching metadata %s/%s: %v", base, path, lastErr)
+			return nil, lastErr
+		}
+		log.Printf("Transient error fetching metadata %s/%s (attempt %d/10): %v", base, path, i+1, lastErr)
+		time.Sleep(time.Second)
+	}
+	return nil, lastErr
 }
 
-func processHttpRequest(base, path, method string, headers map[string]string) ([]byte, error) {
+func isTransientError(statusCode int) bool {
+	if statusCode == 0 {
+		return true
+	}
+	return statusCode == http.StatusTooManyRequests ||
+		statusCode == http.StatusInternalServerError ||
+		statusCode == http.StatusBadGateway ||
+		statusCode == http.StatusServiceUnavailable ||
+		statusCode == http.StatusGatewayTimeout
+}
+
+func processHttpRequest(base, path, method string, headers map[string]string) ([]byte, int, error) {
 	c := &http.Client{}
 	c.Timeout = 5 * time.Second
 	req, err := http.NewRequest(method, base+path, nil)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
-	if headers != nil {
-		for key, value := range headers {
-			req.Header.Set(key, value)
-		}
+	for key, value := range headers {
+		req.Header.Set(key, value)
 	}
 	res, err := c.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	body, err := io.ReadAll(res.Body)
 	_ = res.Body.Close()
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 	if res.StatusCode == 200 {
-		return body, nil
+		return body, res.StatusCode, nil
 	}
-	return nil, fmt.Errorf("cannot get metadata, url: %q, headers: %v status code is %d", base+path, headers, res.StatusCode)
+	return nil, res.StatusCode, fmt.Errorf("cannot get metadata, url: %q, headers: %v status code is %d", base+path, headers, res.StatusCode)
 }
 
-// GetRegion get current region from identity document
-func GetRegion(metaEndPoint string) string {
+// GetRegion get current region from metadata server
+func GetRegion(metaEndPoint string) (string, error) {
 	var region string
-	zone := GetZone(metaEndPoint)
+	zone, err := GetZone(metaEndPoint)
+	if err != nil {
+		return "", err
+	}
 	if idx := strings.LastIndex(zone, "-"); idx > 0 {
 		region = zone[:idx]
+		return region, nil
 	}
-
-	return region
+	return "", fmt.Errorf("unable to derive region from zone: %s", zone)
 }
 
-func GetZone(metaEndPoint string) string {
-	var zone string
-	zone = getZoneFromMeta(metaEndPoint)
-	if zone == "" {
-		log.Println("No zone information available. Defaulting to us-west1-a")
-		zone = "us-west1-a"
+// GetZone get current zone from metadata server
+func GetZone(metaEndPoint string) (string, error) {
+	zone, err := getZoneFromMeta(metaEndPoint)
+	if err != nil {
+		return "", err
 	}
-	return zone
+	return zone, nil
 }
 
-func getZoneFromMeta(metaEndPoint string) string {
+func getZoneFromMeta(metaEndPoint string) (string, error) {
 	var zone string
 	log.Println("Trying to determine zone from metadata server ...")
 	fullOutput, err := GetData(metaEndPoint, "/computeMetadata/v1/instance/zone")
@@ -88,9 +115,10 @@ func getZoneFromMeta(metaEndPoint string) string {
 			zone = string(fullOutput[idx+1:])
 		}
 	}
-	return zone
+	return zone, err
 }
 
+// GetDomain get domain from metadata server
 func GetDomain(metaEndpoint string) (string, error) {
 	domainBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/project/attributes/athenz-domain")
 	if err != nil {
@@ -99,6 +127,7 @@ func GetDomain(metaEndpoint string) (string, error) {
 	return string(domainBytes), nil
 }
 
+// GetProject get project from metadata server
 func GetProject(metaEndpoint string) (string, error) {
 	projectBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/project/project-id")
 	if err != nil {
@@ -107,11 +136,13 @@ func GetProject(metaEndpoint string) (string, error) {
 	return string(projectBytes), nil
 }
 
+// GetService get service from metadata server
 func GetService(metaEndpoint string) (string, error) {
 	service, _, err := getGCPService(metaEndpoint)
 	return service, err
 }
 
+// GetServiceAccountInfo get service account info from metadata server
 func GetServiceAccountInfo(metaEndpoint string) (string, string, error) {
 	serviceName, servicePostfix, err := getGCPService(metaEndpoint)
 	if err == nil {
@@ -133,6 +164,7 @@ func getGCPService(metaEndpoint string) (string, []byte, error) {
 	return "", nil, fmt.Errorf("unable to derive service name from metadata")
 }
 
+// GetProfile get profile from metadata server
 func GetProfile(metaEndpoint string) (string, error) {
 	profileBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/instance/attributes/accessProfile")
 	if err != nil {
@@ -141,6 +173,7 @@ func GetProfile(metaEndpoint string) (string, error) {
 	return string(profileBytes), nil
 }
 
+// GetInstanceAttributeValue get instance attribute value from metadata server
 func GetInstanceAttributeValue(metaEndpoint, key string) (string, error) {
 	tagBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/instance/attributes/"+key)
 	if err != nil {
@@ -149,6 +182,7 @@ func GetInstanceAttributeValue(metaEndpoint, key string) (string, error) {
 	return string(tagBytes), nil
 }
 
+// GetInstanceId get instance id from metadata server
 func GetInstanceId(metaEndpoint string) (string, error) {
 	instanceIdBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/instance/id")
 	if err != nil {
@@ -156,6 +190,8 @@ func GetInstanceId(metaEndpoint string) (string, error) {
 	}
 	return string(instanceIdBytes), nil
 }
+
+// GetInstancePrivateIp get instance private ip from metadata server
 func GetInstancePrivateIp(metaEndpoint string) (string, error) {
 	instanceIdBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/instance/network-interfaces/0/ip")
 	if err != nil {
@@ -163,6 +199,8 @@ func GetInstancePrivateIp(metaEndpoint string) (string, error) {
 	}
 	return string(instanceIdBytes), nil
 }
+
+// GetInstancePublicIp get instance public ip from metadata server
 func GetInstancePublicIp(metaEndpoint string) (string, error) {
 	pubIpBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip")
 	if err != nil {
@@ -170,6 +208,8 @@ func GetInstancePublicIp(metaEndpoint string) (string, error) {
 	}
 	return string(pubIpBytes), nil
 }
+
+// GetInstanceName get instance name from metadata server
 func GetInstanceName(metaEndpoint string) (string, error) {
 	nameBytes, err := GetData(metaEndpoint, "/computeMetadata/v1/instance/name")
 	if err != nil {

--- a/libs/go/sia/gcp/meta/meta_test.go
+++ b/libs/go/sia/gcp/meta/meta_test.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 )
 
@@ -53,7 +54,11 @@ func TestGetRegion(test *testing.T) {
 	metaServer := httptest.NewServer(router)
 	defer metaServer.Close()
 
-	region := GetRegion(metaServer.URL)
+	region, err := GetRegion(metaServer.URL)
+	if err != nil {
+		test.Errorf("Unable to get region: %v", err)
+		return
+	}
 	if region != "us-west2" {
 		test.Errorf("Unable to match expected region: %s", region)
 	}
@@ -70,7 +75,11 @@ func TestGetZone(test *testing.T) {
 	metaServer := httptest.NewServer(router)
 	defer metaServer.Close()
 
-	zone := GetZone(metaServer.URL)
+	zone, err := GetZone(metaServer.URL)
+	if err != nil {
+		test.Errorf("Unable to get zone: %v", err)
+		return
+	}
 	if zone != "us-west2-a" {
 		test.Errorf("Unable to match expected zone: %s", zone)
 	}
@@ -209,5 +218,375 @@ func TestGetInstanceName(test *testing.T) {
 	instanceName, _ := GetInstanceName(metaServer.URL)
 	if instanceName != "my-vm" {
 		test.Errorf("want instanceName=my-vm got instanceName=%s", instanceName)
+	}
+}
+
+func TestGetServiceAccountInfo(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/service-accounts/default/email", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "my-sa@my-gcp-project.iam.gserviceaccount.com")
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	serviceName, servicePostfix, err := GetServiceAccountInfo(metaServer.URL)
+	if err != nil {
+		test.Errorf("Unexpected error: %v", err)
+		return
+	}
+	if serviceName != "my-sa" {
+		test.Errorf("want serviceName=my-sa got serviceName=%s", serviceName)
+	}
+	if servicePostfix != "@my-gcp-project.iam.gserviceaccount.com" {
+		test.Errorf("want servicePostfix=@my-gcp-project.iam.gserviceaccount.com got servicePostfix=%s", servicePostfix)
+	}
+}
+
+func TestGetServiceAccountInfoError(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/service-accounts/default/email", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, _, err := GetServiceAccountInfo(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for failed metadata fetch")
+	}
+}
+
+func TestGetServiceAccountInfoNoAtSign(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/service-accounts/default/email", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "invalid-service-account")
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, _, err := GetServiceAccountInfo(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for service account without @")
+	}
+}
+
+func TestGetInstanceAttributeValue(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/attributes/my-key", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "my-value")
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	value, err := GetInstanceAttributeValue(metaServer.URL, "my-key")
+	if err != nil {
+		test.Errorf("Unexpected error: %v", err)
+		return
+	}
+	if value != "my-value" {
+		test.Errorf("want value=my-value got value=%s", value)
+	}
+}
+
+func TestGetInstanceAttributeValueError(test *testing.T) {
+	router := http.NewServeMux()
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetInstanceAttributeValue(metaServer.URL, "nonexistent-key")
+	if err == nil {
+		test.Error("Expected error for missing attribute")
+	}
+}
+
+func TestGetRegionError(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/zone", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetRegion(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error when zone fetch fails")
+	}
+}
+
+func TestGetRegionBadZoneFormat(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/zone", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "projects/123/zones/uswest2a")
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetRegion(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error when zone has no dash separator")
+	}
+}
+
+func TestGetZoneError(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/zone", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetZone(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error when zone fetch fails")
+	}
+}
+
+func TestGetZoneNoSlashInResponse(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/zone", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "us-west2-a")
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	zone, err := GetZone(metaServer.URL)
+	if err != nil {
+		test.Errorf("Unexpected error: %v", err)
+		return
+	}
+	if zone != "" {
+		test.Errorf("Expected empty zone when no slash in response, got: %s", zone)
+	}
+}
+
+func TestGetServiceNoAtSign(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/service-accounts/default/email", func(w http.ResponseWriter, r *http.Request) {
+		io.WriteString(w, "invalid-service-account")
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetService(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for service account without @")
+	}
+}
+
+func TestGetServiceError(test *testing.T) {
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/service-accounts/default/email", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetService(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for failed metadata fetch")
+	}
+}
+
+func TestGetDomainError(test *testing.T) {
+	router := http.NewServeMux()
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetDomain(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for failed metadata fetch")
+	}
+}
+
+func TestGetProjectError(test *testing.T) {
+	router := http.NewServeMux()
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetProject(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for failed metadata fetch")
+	}
+}
+
+func TestGetProfileError(test *testing.T) {
+	router := http.NewServeMux()
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetProfile(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for failed metadata fetch")
+	}
+}
+
+func TestGetInstanceIdError(test *testing.T) {
+	router := http.NewServeMux()
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetInstanceId(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for failed metadata fetch")
+	}
+}
+
+func TestGetInstancePrivateIpError(test *testing.T) {
+	router := http.NewServeMux()
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetInstancePrivateIp(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for failed metadata fetch")
+	}
+}
+
+func TestGetInstancePublicIpError(test *testing.T) {
+	router := http.NewServeMux()
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetInstancePublicIp(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for failed metadata fetch")
+	}
+}
+
+func TestGetInstanceNameError(test *testing.T) {
+	router := http.NewServeMux()
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetInstanceName(metaServer.URL)
+	if err == nil {
+		test.Error("Expected error for failed metadata fetch")
+	}
+}
+
+func TestGetDataConnectionRefused(test *testing.T) {
+	metaServer := httptest.NewServer(http.NewServeMux())
+	url := metaServer.URL
+	metaServer.Close()
+
+	_, err := GetData(url, "/computeMetadata/v1/instance/zone")
+	if err == nil {
+		test.Error("Expected error for closed server")
+	}
+}
+
+func TestIsTransientError(test *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		want       bool
+	}{
+		{"zero status is transient", 0, true},
+		{"429 Too Many Requests is transient", http.StatusTooManyRequests, true},
+		{"500 Internal Server Error is transient", http.StatusInternalServerError, true},
+		{"502 Bad Gateway is transient", http.StatusBadGateway, true},
+		{"503 Service Unavailable is transient", http.StatusServiceUnavailable, true},
+		{"504 Gateway Timeout is transient", http.StatusGatewayTimeout, true},
+		{"400 Bad Request is not transient", http.StatusBadRequest, false},
+		{"401 Unauthorized is not transient", http.StatusUnauthorized, false},
+		{"403 Forbidden is not transient", http.StatusForbidden, false},
+		{"404 Not Found is not transient", http.StatusNotFound, false},
+		{"200 OK is not transient", http.StatusOK, false},
+	}
+	for _, tt := range tests {
+		test.Run(tt.name, func(t *testing.T) {
+			got := isTransientError(tt.statusCode)
+			if got != tt.want {
+				t.Errorf("isTransientError(%d) = %v, want %v", tt.statusCode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDataRetryOnTransientError(test *testing.T) {
+	var callCount int32
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/zone", func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&callCount, 1)
+		if count <= 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		io.WriteString(w, "projects/123/zones/us-west1-a")
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	data, err := GetData(metaServer.URL, "/computeMetadata/v1/instance/zone")
+	if err != nil {
+		test.Errorf("Expected success after transient errors, got: %v", err)
+		return
+	}
+	if string(data) != "projects/123/zones/us-west1-a" {
+		test.Errorf("Unexpected data: %s", string(data))
+	}
+	if atomic.LoadInt32(&callCount) != 4 {
+		test.Errorf("Expected 4 calls, got %d", atomic.LoadInt32(&callCount))
+	}
+}
+
+func TestGetDataNoRetryOnNonTransientError(test *testing.T) {
+	var callCount int32
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/zone", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetData(metaServer.URL, "/computeMetadata/v1/instance/zone")
+	if err == nil {
+		test.Error("Expected error for 404 response")
+		return
+	}
+	if atomic.LoadInt32(&callCount) != 1 {
+		test.Errorf("Expected 1 call (no retries for 404), got %d", atomic.LoadInt32(&callCount))
+	}
+}
+
+func TestGetDataExhaustsRetries(test *testing.T) {
+	var callCount int32
+	router := http.NewServeMux()
+	router.HandleFunc("GET /computeMetadata/v1/instance/zone", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&callCount, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	metaServer := httptest.NewServer(router)
+	defer metaServer.Close()
+
+	_, err := GetData(metaServer.URL, "/computeMetadata/v1/instance/zone")
+	if err == nil {
+		test.Error("Expected error after exhausting retries")
+		return
+	}
+	if atomic.LoadInt32(&callCount) != 10 {
+		test.Errorf("Expected 10 calls (all retries exhausted), got %d", atomic.LoadInt32(&callCount))
 	}
 }

--- a/provider/gcp/sia-gce/cmd/siad/main.go
+++ b/provider/gcp/sia-gce/cmd/siad/main.go
@@ -89,7 +89,10 @@ func main() {
 	}
 
 	log.Printf("SIA-GCE version: %s \n", Version)
-	region := meta.GetRegion(*gceMetaEndPoint)
+	region, err := meta.GetRegion(*gceMetaEndPoint)
+	if err != nil {
+		log.Fatalf("Unable to get region, error: %v\n", err)
+	}
 
 	provider := sia.GCEProvider{
 		Name: fmt.Sprintf("%s.%s", *providerPrefix, region),

--- a/provider/gcp/sia-gke/cmd/siad/main.go
+++ b/provider/gcp/sia-gke/cmd/siad/main.go
@@ -74,7 +74,10 @@ func main() {
 	}
 
 	log.Printf("SIA-GKE version: %s \n", Version)
-	region := meta.GetRegion(*gkeMetaEndPoint)
+	region, err := meta.GetRegion(*gkeMetaEndPoint)
+	if err != nil {
+		log.Fatalf("Unable to get region, error: %v\n", err)
+	}
 
 	provider := sia.GKEProvider{
 		Name: fmt.Sprintf("%s.%s", *providerPrefix, region),

--- a/provider/gcp/sia-run/cmd/siad/main.go
+++ b/provider/gcp/sia-run/cmd/siad/main.go
@@ -71,7 +71,10 @@ func main() {
 	}
 
 	log.Printf("SIA-RUN version: %s \n", Version)
-	region := meta.GetRegion(*gcpMetaEndPoint)
+	region, err := meta.GetRegion(*gcpMetaEndPoint)
+	if err != nil {
+		log.Fatalf("Unable to get region, error: %v\n", err)
+	}
 
 	provider := sia.GCPRunProvider{
 		Name: fmt.Sprintf("%s.%s", *providerPrefix, region),


### PR DESCRIPTION
# Description

typically when launching a new pod in GKE, the sia agent connects to the metadata server to retrieve the region, zone, and other instance details. However, we've noticed on some rare occasions the metadata server is not returning any data which then causes sia (incorrectly) default to us-west1-a zone and eventually we end up with a wrong certificate. According to gemini:

Transient failures hitting the metadata server during pod startup are actually quite common. This usually happens because the Kubernetes CNI (networking) or a service mesh proxy (like Istio or Linkerd) hasn't fully initialized the network interfaces by the time your init container fires off its first curl.

So we now introduce a retry when reading data from the metadata server in case of transient errors and retry for up to 10 seconds before returning an error.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

