### PR TITLE
strict validation for instance id san dns name in certs

### DIFF
--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -293,7 +293,8 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 
 # When requesting TLS certificates for their corresponding ServiceTokens
 # or role certificates, services must use one of the values listed in
-# this dns suffix property in their CSRs (comma separated list)
+# this dns suffix property in their CSRs. Comma separated list
+# of allowed dns suffixes where every suffix must start with a dot.
 #athenz.zts.cert_dns_suffix=.athenz.cloud
 
 # Kerberos Authority Service Principal

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/utils/ZTSUtils.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import com.oath.auth.KeyRefresher;
 import com.oath.auth.Utils;
@@ -61,6 +62,10 @@ public class ZTSUtils {
     static final String ZTS_DEFAULT_EXCLUDED_PROTOCOLS = "SSLv2,SSLv3";
     public static final List<String> ZTS_CERT_DNS_SUFFIX = Arrays.asList(
             System.getProperty(ZTSConsts.ZTS_PROP_CERT_DNS_SUFFIX, ZTSConsts.ZTS_CERT_DNS_SUFFIX).split(","));
+    // generate a list of instance id dns names which based on ZTS_CERT_DNS_SUFFIX values with .instanceid.athenz. prefix
+    public static final List<String> ZTS_CERT_INSTANCE_ID_DNS_NAMES = ZTS_CERT_DNS_SUFFIX.stream()
+            .map(suffix -> ".instanceid.athenz" + suffix)
+            .collect(Collectors.toList());
 
     public static final long CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY = Long.parseLong(System.getProperty(
             ZTSConsts.ZTS_PROP_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY, ZTSConsts.ZTS_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY_DEFAULT));
@@ -248,15 +253,15 @@ public class ZTSUtils {
         }
         
         // the only two formats we're allowed to have in the CSR are:
-        // 1) <service>.<domain-with-dashes>.<provider-dns-suffix>
-        // 2) <service>.<domain-with-dashes>.instanceid.athenz.<provider-dns-suffix>
+        // 1) <service>.<domain-with-dashes>.[<components>.]<provider-dns-suffix>
+        // 2) <instance-id>.instanceid.athenz.<provider-dns-suffix>
         
         final String prefix = service + "." + domain.replace('.', '-') + ".";
         for (String dnsName : dnsNames) {
             if (dnsName.startsWith(prefix) && valueEndsWith(dnsName, ZTS_CERT_DNS_SUFFIX)) {
                 continue;
             }
-            if (dnsName.contains(ZTSConsts.ZTS_CERT_INSTANCE_ID_DNS)) {
+            if (valueEndsWith(dnsName, ZTS_CERT_INSTANCE_ID_DNS_NAMES)) {
                 continue;
             }
             LOGGER.error("validateServiceCertReqDNSNames - Invalid dnsName SAN entry: {}", dnsName);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -265,6 +265,8 @@ public class ZTSImplTest {
         // enable openid scope
 
         AccessTokenScope.setSupportOpenIdScope(true);
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.add(".instanceid.athenz.zts.athenz.cloud");
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.add(".instanceid.athenz.ostk.athenz.cloud");
     }
 
     @AfterMethod
@@ -273,6 +275,8 @@ public class ZTSImplTest {
         ZTSTestUtils.deleteDirectory(new File(ZTS_DATA_STORE_PATH));
         System.clearProperty(ZTSConsts.ZTS_PROP_ROLE_TOKEN_MAX_TIMEOUT);
         System.clearProperty(ZTSConsts.ZTS_PROP_ROLE_TOKEN_DEFAULT_TIMEOUT);
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.zts.athenz.cloud");
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.ostk.athenz.cloud");
     }
 
     private ResourceContext createResourceContext(Principal principal) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
@@ -203,6 +203,7 @@ public class ZTSUtilsTest {
 
         Path path = Paths.get("src/test/resources/athenz.instanceid.csr");
         String csr = new String(Files.readAllBytes(path));
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.add(".instanceid.athenz.ostk.athenz.cloud");
 
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(csr);
         boolean result = ZTSUtils.verifyCertificateRequest(certReq, "athenz", "production");
@@ -210,6 +211,7 @@ public class ZTSUtilsTest {
 
         result = ZTSUtils.verifyCertificateRequest(certReq, "athenz2", "production");
         assertFalse(result);
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.athenz.cloud");
     }
     
     @Test
@@ -228,6 +230,7 @@ public class ZTSUtilsTest {
 
         Path path = Paths.get("src/test/resources/athenz.instanceid.csr");
         String csr = new String(Files.readAllBytes(path));
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.add(".instanceid.athenz.ostk.athenz.cloud");
 
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(csr);
         boolean result = ZTSUtils.verifyCertificateRequest(certReq, "athenz", "production");
@@ -235,6 +238,7 @@ public class ZTSUtilsTest {
 
         result = ZTSUtils.verifyCertificateRequest(certReq, "athenz2", "production");
         assertFalse(result);
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.athenz.cloud");
     }
     
     @Test
@@ -243,7 +247,15 @@ public class ZTSUtilsTest {
         String csr = new String(Files.readAllBytes(path));
 
         PKCS10CertificationRequest certReq = Crypto.getPKCS10CertRequest(csr);
+
+        // first without the expected instance id dns name
         boolean result = ZTSUtils.validateCertReqDNSNames(certReq, "athenz", "production");
+        assertFalse(result);
+
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.add(".instanceid.athenz.ostk.athenz.cloud");
+
+        // now it should be valid
+        result = ZTSUtils.validateCertReqDNSNames(certReq, "athenz", "production");
         assertTrue(result);
 
         result = ZTSUtils.validateCertReqDNSNames(certReq, "athenz2", "production");
@@ -251,6 +263,8 @@ public class ZTSUtilsTest {
 
         result = ZTSUtils.validateCertReqDNSNames(certReq, "athenz2", "productio2");
         assertFalse(result);
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.athenz.cloud");
+
     }
     
     @Test

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/utils/ZTSUtilsTest.java
@@ -211,7 +211,7 @@ public class ZTSUtilsTest {
 
         result = ZTSUtils.verifyCertificateRequest(certReq, "athenz2", "production");
         assertFalse(result);
-        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.athenz.cloud");
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.ostk.athenz.cloud");
     }
     
     @Test
@@ -238,7 +238,7 @@ public class ZTSUtilsTest {
 
         result = ZTSUtils.verifyCertificateRequest(certReq, "athenz2", "production");
         assertFalse(result);
-        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.athenz.cloud");
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.ostk.athenz.cloud");
     }
     
     @Test
@@ -263,7 +263,7 @@ public class ZTSUtilsTest {
 
         result = ZTSUtils.validateCertReqDNSNames(certReq, "athenz2", "productio2");
         assertFalse(result);
-        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.athenz.cloud");
+        ZTSUtils.ZTS_CERT_INSTANCE_ID_DNS_NAMES.remove(".instanceid.athenz.ostk.athenz.cloud");
 
     }
     


### PR DESCRIPTION
# Description

when requesting certs using zts-svccert (not any of the official providers), ZTS has a separate path to validate the certificate request (this is deprecated but not yet removed, instead of using this endpoint the ZTS provider should be used instead).

In this flow, the server would skip any san dns entry that contains "instanceid.athenz" component without checking that it also contains the expected suffix. so you end up with an unvalidated san dns entry but itself it's not that much exploitable since there has to be a hostname including the instanceid.athenz components which is highly unlikely - e.g. id001.instanceid.athenz.yahoo.com. Regardless, the server should reject any san dns entries that are not validated.

This was reported to Yahoo from Bug Bounty program.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

