### PR TITLE
fix token validation for k8s provider

### DIFF
--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/CommonKubernetesDistributionValidator.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/CommonKubernetesDistributionValidator.java
@@ -101,6 +101,10 @@ public abstract class CommonKubernetesDistributionValidator implements Kubernete
 
     IdToken validateIdToken(final String issuer, IdTokenAttestationData attestationData, StringBuilder errMsg) {
         JwtsSigningKeyResolver signingKeyResolver = getSigningKeyResolverForIssuer(issuer, errMsg);
+        if (signingKeyResolver == null) {
+            errMsg.append("unable to get signing key resolver for issuer");
+            return null;
+        }
         IdToken idToken = null;
         try {
             idToken = new IdToken(attestationData.getIdentityToken(), signingKeyResolver);

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/CommonKubernetesDistributionValidator.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/CommonKubernetesDistributionValidator.java
@@ -90,7 +90,7 @@ public abstract class CommonKubernetesDistributionValidator implements Kubernete
             String openIdConfigUri = idTokenIssuer + "/.well-known/openid-configuration";
             String oidcProviderJwksUri = this.jwtsHelper.extractJwksUri(openIdConfigUri, null);
             if (StringUtil.isEmpty(oidcProviderJwksUri)) {
-                errMsg.append("id_token issuer does not have valid jwks uri.");
+                errMsg.append("id_token issuer does not have valid jwks uri");
                 return null;
             }
             signingKeyResolver = new JwtsSigningKeyResolver(oidcProviderJwksUri, null, true);
@@ -102,7 +102,6 @@ public abstract class CommonKubernetesDistributionValidator implements Kubernete
     IdToken validateIdToken(final String issuer, IdTokenAttestationData attestationData, StringBuilder errMsg) {
         JwtsSigningKeyResolver signingKeyResolver = getSigningKeyResolverForIssuer(issuer, errMsg);
         if (signingKeyResolver == null) {
-            errMsg.append("unable to get signing key resolver for issuer");
             return null;
         }
         IdToken idToken = null;

--- a/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/DefaultGCPGoogleKubernetesEngineValidator.java
+++ b/libs/java/instance_provider/src/main/java/com/yahoo/athenz/instance/provider/impl/DefaultGCPGoogleKubernetesEngineValidator.java
@@ -91,7 +91,7 @@ public class DefaultGCPGoogleKubernetesEngineValidator extends CommonKubernetesD
             return null;
         }
         String gcpProject = confirmation.getAttributes().get(InstanceProvider.ZTS_INSTANCE_GCP_PROJECT);
-        if (!issuer.startsWith(GCP_OIDC_ISSUER_PREFIX + gcpProject)) {
+        if (!issuer.startsWith(GCP_OIDC_ISSUER_PREFIX + gcpProject + "/")) {
             // could be a multi-tenant setup where the issuer is not present in the identity's GCP project
             if (attrValidator != null) {
                 confirmation.getAttributes().put(ZTS_INSTANCE_UNATTESTED_ISSUER, issuer);

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/DefaultGCPGoogleKubernetesEngineValidatorTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/DefaultGCPGoogleKubernetesEngineValidatorTest.java
@@ -76,6 +76,24 @@ public class DefaultGCPGoogleKubernetesEngineValidatorTest {
     }
 
     @Test
+    public void testValidateIssuerProjectPrefixMismatch() {
+        DefaultGCPGoogleKubernetesEngineValidator validator = DefaultGCPGoogleKubernetesEngineValidator.getInstance();
+        try {
+            IdTokenAttestationData attestationData = new IdTokenAttestationData();
+            attestationData.setIdentityToken(createToken());
+            InstanceConfirmation confirmation = new InstanceConfirmation();
+            confirmation.setAttributes(new HashMap<>());
+            confirmation.getAttributes().put(InstanceProvider.ZTS_INSTANCE_GCP_PROJECT, "my-proj");
+            StringBuilder errMsg = new StringBuilder();
+            String issuer = validator.validateIssuer(confirmation, attestationData, errMsg);
+            assertNull(issuer);
+            assertTrue(errMsg.toString().contains("Issuer is not present in the GCP project associated with the domain"));
+        } catch (Exception re){
+            fail();
+        }
+    }
+
+    @Test
     public void testValidateIssuerNoIssuerInToken() {
         DefaultGCPGoogleKubernetesEngineValidator validator = DefaultGCPGoogleKubernetesEngineValidator.getInstance();
         try {
@@ -245,6 +263,25 @@ public class DefaultGCPGoogleKubernetesEngineValidatorTest {
                 attestationData, new StringBuilder());
         assertNotNull(idToken);
         removeOpenIdConfigFile(configFile, jwksUri);
+        validator.jwtsHelper = new JwtsHelper();
+    }
+
+    @Test
+    public void testValidateIdTokenSigningKeyResolverNull() {
+        DefaultGCPGoogleKubernetesEngineValidator validator = DefaultGCPGoogleKubernetesEngineValidator.getInstance();
+        validator.issuersMap.clear();
+        validator.jwtsHelper = Mockito.mock(JwtsHelper.class);
+        when(validator.jwtsHelper.extractJwksUri(any(), any())).thenReturn("");
+
+        String testToken = IdTokenTestsHelper.createToken();
+        IdTokenAttestationData attestationData = new IdTokenAttestationData();
+        attestationData.setIdentityToken(testToken);
+
+        StringBuilder errMsg = new StringBuilder();
+        IdToken idToken = validator.validateIdToken("https://container.googleapis.com/v1/projects/my-project/zones/us-east1-a/clusters/my-cluster",
+                attestationData, errMsg);
+        assertNull(idToken);
+        assertTrue(errMsg.toString().contains("unable to get signing key resolver for issuer"));
         validator.jwtsHelper = new JwtsHelper();
     }
 

--- a/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/DefaultGCPGoogleKubernetesEngineValidatorTest.java
+++ b/libs/java/instance_provider/src/test/java/com/yahoo/athenz/instance/provider/impl/DefaultGCPGoogleKubernetesEngineValidatorTest.java
@@ -281,7 +281,7 @@ public class DefaultGCPGoogleKubernetesEngineValidatorTest {
         IdToken idToken = validator.validateIdToken("https://container.googleapis.com/v1/projects/my-project/zones/us-east1-a/clusters/my-cluster",
                 attestationData, errMsg);
         assertNull(idToken);
-        assertTrue(errMsg.toString().contains("unable to get signing key resolver for issuer"));
+        assertTrue(errMsg.toString().contains("id_token issuer does not have valid jwks uri"));
         validator.jwtsHelper = new JwtsHelper();
     }
 


### PR DESCRIPTION
# Description
 
two security issues to address in the k8s validator:
a) if for some reason the server is not able to fetch jwks uri, we return null for the singing key resolver. the validate function doesn't check this and passes is to the token validator which basically means don't validate the signature
b) the gke validator doesn't include / after the gcp project check in the issuer check so it would match if the gcp project was only the prefix of the issuer passed.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

