### PR TITLE
Add OIDCAuthority for authenticating end users via external OIDC ID tokens

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/OIDCAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/OIDCAuthority.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.auth.impl;
+
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.yahoo.athenz.auth.Authority;
+import com.yahoo.athenz.auth.Principal;
+import com.yahoo.athenz.auth.token.jwts.JwtsHelper;
+import com.yahoo.athenz.auth.token.jwts.JwtsSigningKeyResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.ParseException;
+import java.util.Locale;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * Authority that validates OIDC ID tokens (signed JWTs) from an external OpenID
+ * Connect provider and creates Athenz user principals. This allows an Athenz
+ * service (typically the UI) to forward an end user's ID token to ZMS in the
+ * {@code Authorization: Bearer} header and have ZMS API calls attributed to the
+ * individual user rather than a service identity.
+ *
+ * <p>Configuration via system properties (default prefix
+ * {@value #DEFAULT_PROPERTY_PREFIX}; subclasses may override
+ * {@link #propertyPrefix()} to namespace a second instance):
+ *
+ * <ul>
+ *   <li>{@code athenz.auth.oidc.issuer} (required): OIDC issuer URL. Must use
+ *       {@code https://}. Used for both OIDC discovery
+ *       ({@code /.well-known/openid-configuration}) and verification of the
+ *       JWT {@code iss} claim. The value is preserved as configured for exact
+ *       {@code iss} matching; a trailing slash is only appended when building
+ *       the discovery URL.</li>
+ *   <li>{@code athenz.auth.oidc.audience} (required): Expected {@code aud}
+ *       claim value, typically the OIDC client ID.</li>
+ *   <li>{@code athenz.auth.oidc.email_domain} (required when
+ *       {@code claim_mapping=email}): Email domain stripped from the email
+ *       claim to derive the username. Compared case-insensitively.</li>
+ *   <li>{@code athenz.auth.oidc.claim_mapping} (optional, default
+ *       {@code email}): JWT claim used to derive the Athenz username. If set
+ *       to {@code email}, the configured domain is stripped and the
+ *       {@code email_verified} claim (when present) must be {@code true}.
+ *       Any other value is used as the username verbatim (lowercased).</li>
+ *   <li>{@code athenz.auth.oidc.domain} (optional, default {@code user}):
+ *       Athenz domain for the resulting principal.</li>
+ *   <li>{@code athenz.auth.oidc.name} (optional, default derived from the
+ *       issuer host): Short name used in the authority ID, which takes the
+ *       form {@code Auth-OIDC-{name}}.</li>
+ *   <li>{@code athenz.auth.oidc.username_pattern} (optional, default
+ *       {@value #DEFAULT_USERNAME_PATTERN}): Regex that the final username
+ *       must match. The pattern is applied <em>after</em> the username is
+ *       lowercased, so character classes should target lowercase characters.
+ *       The default is a strict Athenz-style identifier; deployments with
+ *       dotted or underscored usernames (for example from Okta or Azure AD)
+ *       should loosen it, e.g. to {@code [a-z0-9][a-z0-9._-]*}. An invalid
+ *       regex causes initialization to fail.</li>
+ * </ul>
+ *
+ * <p>Tokens that produce a username not matching the configured pattern
+ * (after claim extraction and, when applicable, domain stripping) are
+ * rejected.
+ *
+ * <p><b>Coexistence with other Bearer authorities.</b> Athenz dispatches
+ * credentials to each configured authority in order; each authority returns
+ * {@code null} for tokens it does not recognise. This class performs an early
+ * unverified parse of the JWT to check the {@code iss} claim before consulting
+ * the JWKS endpoint, so tokens issued by other providers (for example Athenz
+ * access tokens handled by {@link ServiceAccessTokenAuthority}) are quickly
+ * passed through without key resolution or log noise.
+ *
+ * <p><b>Multiple OIDC providers.</b> To support more than one external
+ * provider, configure a trivial subclass per provider and override
+ * {@link #propertyPrefix()} so each instance reads its own system properties:
+ *
+ * <pre>
+ *     public class OktaOIDCAuthority extends OIDCAuthority {
+ *         &#064;Override protected String propertyPrefix() {
+ *             return "athenz.auth.oidc.okta";
+ *         }
+ *     }
+ * </pre>
+ *
+ * Then register both classes in {@code athenz.zms.authority_classes}.
+ *
+ * @see ServiceAccessTokenAuthority
+ * @see UserAuthority
+ */
+public class OIDCAuthority implements Authority {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OIDCAuthority.class);
+
+    public static final String DEFAULT_PROPERTY_PREFIX = "athenz.auth.oidc";
+
+    public static final String PROP_ISSUER           = "issuer";
+    public static final String PROP_AUDIENCE         = "audience";
+    public static final String PROP_EMAIL_DOMAIN     = "email_domain";
+    public static final String PROP_CLAIM_MAPPING    = "claim_mapping";
+    public static final String PROP_DOMAIN           = "domain";
+    public static final String PROP_NAME             = "name";
+    public static final String PROP_USERNAME_PATTERN = "username_pattern";
+
+    public static final String DEFAULT_CLAIM_MAPPING    = "email";
+    public static final String DEFAULT_DOMAIN           = "user";
+    public static final String DEFAULT_USERNAME_PATTERN = "[a-z][a-z0-9]*";
+
+    public static final String BEARER_PREFIX  = "Bearer ";
+
+    static final String EMAIL_CLAIM           = "email";
+    static final String EMAIL_VERIFIED_CLAIM  = "email_verified";
+
+    private String issuer;
+    private String audience;
+    private String emailDomain;
+    private String claimMapping;
+    private String principalDomain;
+    private String authorityId;
+    private Pattern validUsernamePattern;
+    private ConfigurableJWTProcessor<SecurityContext> jwtProcessor;
+
+    /**
+     * @return the system-property prefix this authority reads its configuration
+     *     from. Subclasses override this to support multiple OIDC provider
+     *     instances in a single ZMS deployment.
+     */
+    protected String propertyPrefix() {
+        return DEFAULT_PROPERTY_PREFIX;
+    }
+
+    @Override
+    public void initialize() {
+
+        final String prefix = propertyPrefix();
+        issuer          = System.getProperty(prefix + "." + PROP_ISSUER);
+        audience        = System.getProperty(prefix + "." + PROP_AUDIENCE);
+        emailDomain     = System.getProperty(prefix + "." + PROP_EMAIL_DOMAIN);
+        claimMapping    = System.getProperty(prefix + "." + PROP_CLAIM_MAPPING, DEFAULT_CLAIM_MAPPING);
+        principalDomain = System.getProperty(prefix + "." + PROP_DOMAIN, DEFAULT_DOMAIN);
+        final String configuredName = System.getProperty(prefix + "." + PROP_NAME);
+
+        if (issuer == null || issuer.isEmpty()) {
+            throw new IllegalStateException("Required property " + prefix + "." + PROP_ISSUER + " is not set");
+        }
+        if (!issuer.startsWith("https://")) {
+            throw new IllegalStateException("Property " + prefix + "." + PROP_ISSUER
+                    + " must use https scheme (got: " + issuer + ")");
+        }
+        // Keep the configured issuer as-is for exact iss-claim comparison:
+        // OIDC providers differ in trailing-slash convention (Google and Okta
+        // omit it; JumpCloud and Auth0 include it) and the iss claim must
+        // match the issuer string byte-for-byte.
+        final String discoveryIssuer = issuer.endsWith("/") ? issuer : issuer + "/";
+        if (audience == null || audience.isEmpty()) {
+            throw new IllegalStateException("Required property " + prefix + "." + PROP_AUDIENCE + " is not set");
+        }
+        if (EMAIL_CLAIM.equals(claimMapping)) {
+            if (emailDomain == null || emailDomain.isEmpty()) {
+                throw new IllegalStateException("Property " + prefix + "." + PROP_EMAIL_DOMAIN
+                        + " is required when " + PROP_CLAIM_MAPPING + "=" + EMAIL_CLAIM);
+            }
+            emailDomain = emailDomain.toLowerCase(Locale.ROOT);
+        }
+
+        // An explicitly empty property value falls back to the default. Without
+        // this guard, Pattern.compile("") produces a pattern that matches only
+        // the empty string, which would silently reject every authentication.
+        final String configuredPattern = System.getProperty(prefix + "." + PROP_USERNAME_PATTERN);
+        final String patternSource = (configuredPattern == null || configuredPattern.isEmpty())
+                ? DEFAULT_USERNAME_PATTERN : configuredPattern;
+        try {
+            validUsernamePattern = Pattern.compile(patternSource);
+        } catch (PatternSyntaxException e) {
+            throw new IllegalStateException("Invalid regex for " + prefix + "." + PROP_USERNAME_PATTERN
+                    + ": " + patternSource + " (" + e.getDescription() + ")", e);
+        }
+
+        authorityId = "Auth-OIDC-" +
+                ((configuredName != null && !configuredName.isEmpty()) ? configuredName : deriveNameFromIssuer(issuer));
+
+        if (jwtProcessor == null) {
+            final String discoveryUrl = discoveryIssuer + ".well-known/openid-configuration";
+            final String jwksUri = new JwtsHelper().extractJwksUri(discoveryUrl, null);
+            if (jwksUri == null) {
+                throw new IllegalStateException("Failed to discover JWKS URI from " + discoveryUrl);
+            }
+            final JwtsSigningKeyResolver keyResolver = new JwtsSigningKeyResolver(jwksUri, null, true);
+            jwtProcessor = JwtsHelper.getJWTProcessor(keyResolver);
+        }
+
+        LOG.info("{} initialized: issuer={}, audience={}, claimMapping={}, principalDomain={}",
+                authorityId, issuer, audience, claimMapping, principalDomain);
+    }
+
+    /**
+     * Derive a short authority name from the issuer host by taking the
+     * second-to-last dotted label (e.g. {@code oauth.id.jumpcloud.com} ->
+     * {@code jumpcloud}, {@code accounts.google.com} -> {@code google}). Falls
+     * back to the full host when it has fewer than two labels or when the URL
+     * cannot be parsed.
+     *
+     * <p>This heuristic picks the wrong label for issuer hosts under multi-part
+     * ccTLDs (for example {@code login.example.co.uk} yields {@code co}).
+     * Operators in that situation should set the
+     * {@code athenz.auth.oidc.name} property explicitly.
+     */
+    static String deriveNameFromIssuer(String issuer) {
+        String host;
+        try {
+            host = new URI(issuer).getHost();
+        } catch (URISyntaxException e) {
+            host = null;
+        }
+        if (host == null || host.isEmpty()) {
+            return "default";
+        }
+        final String[] labels = host.split("\\.");
+        if (labels.length < 2) {
+            return host.toLowerCase(Locale.ROOT);
+        }
+        return labels[labels.length - 2].toLowerCase(Locale.ROOT);
+    }
+
+    // Visible for testing.
+    void setJwtProcessor(ConfigurableJWTProcessor<SecurityContext> jwtProcessor) {
+        this.jwtProcessor = jwtProcessor;
+    }
+
+    void setIssuer(String issuer) {
+        this.issuer = issuer;
+    }
+
+    void setAudience(String audience) {
+        this.audience = audience;
+    }
+
+    void setEmailDomain(String emailDomain) {
+        this.emailDomain = emailDomain;
+    }
+
+    void setClaimMapping(String claimMapping) {
+        this.claimMapping = claimMapping;
+    }
+
+    void setPrincipalDomain(String principalDomain) {
+        this.principalDomain = principalDomain;
+    }
+
+    void setAuthorityId(String authorityId) {
+        this.authorityId = authorityId;
+    }
+
+    void setValidUsernamePattern(Pattern validUsernamePattern) {
+        this.validUsernamePattern = validUsernamePattern;
+    }
+
+    @Override
+    public String getID() {
+        return authorityId;
+    }
+
+    @Override
+    public String getDomain() {
+        return principalDomain;
+    }
+
+    @Override
+    public String getHeader() {
+        return "Authorization";
+    }
+
+    @Override
+    public String getAuthenticateChallenge() {
+        return "Bearer realm=\"athenz\"";
+    }
+
+    /**
+     * Returns {@code true} because a validated OIDC ID token is itself the
+     * credential; unlike {@link UserAuthority}, no subsequent NToken exchange
+     * is required before the principal may authorize actions.
+     */
+    @Override
+    public boolean allowAuthorization() {
+        return true;
+    }
+
+    @Override
+    public Principal authenticate(String creds, String remoteAddr, String httpMethod, StringBuilder errMsg) {
+
+        errMsg = errMsg == null ? new StringBuilder(512) : errMsg;
+
+        if (creds == null || !creds.startsWith(BEARER_PREFIX)) {
+            errMsg.append(authorityId).append(": credentials do not start with 'Bearer '");
+            return null;
+        }
+
+        final String token = creds.substring(BEARER_PREFIX.length());
+        if (token.isEmpty()) {
+            errMsg.append(authorityId).append(": no token after 'Bearer '");
+            return null;
+        }
+
+        // Pre-parse to check issuer before full JWKS validation. This avoids
+        // unnecessary key resolution and log noise for tokens issued by other
+        // Bearer authorities (for example ServiceAccessTokenAuthority).
+        try {
+            final SignedJWT parsed = SignedJWT.parse(token);
+            final String tokenIssuer = parsed.getJWTClaimsSet().getIssuer();
+            if (!issuer.equals(tokenIssuer)) {
+                errMsg.append(authorityId).append(": issuer mismatch (token issuer: ")
+                        .append(tokenIssuer).append(")");
+                return null;
+            }
+        } catch (ParseException e) {
+            errMsg.append(authorityId).append(": failed to parse JWT: ").append(e.getMessage());
+            return null;
+        }
+
+        final JWTClaimsSet claims;
+        try {
+            claims = jwtProcessor.process(token, null);
+        } catch (Exception e) {
+            errMsg.append(authorityId).append(": JWT validation failed: ").append(e.getMessage());
+            return null;
+        }
+
+        if (claims.getAudience() == null || !claims.getAudience().contains(audience)) {
+            errMsg.append(authorityId).append(": token audience ").append(claims.getAudience())
+                    .append(" does not contain expected: ").append(audience);
+            return null;
+        }
+
+        final String username = extractUsername(claims, errMsg);
+        if (username == null) {
+            return null;
+        }
+
+        final long issueTime = claims.getIssueTime() != null ? claims.getIssueTime().getTime() / 1000 : 0;
+
+        final Principal principal = SimplePrincipal.create(principalDomain, username, creds, issueTime, this);
+        if (principal == null) {
+            errMsg.append(authorityId).append(": failed to create principal for user: ").append(username);
+            return null;
+        }
+
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("{}: authenticated {}.{} from {}", authorityId, principalDomain, username, remoteAddr);
+        }
+
+        return principal;
+    }
+
+    private String extractUsername(JWTClaimsSet claims, StringBuilder errMsg) {
+
+        final String rawValue;
+        try {
+            rawValue = claims.getStringClaim(claimMapping);
+        } catch (ParseException e) {
+            errMsg.append(authorityId).append(": failed to parse claim '").append(claimMapping)
+                    .append("': ").append(e.getMessage());
+            return null;
+        }
+
+        if (rawValue == null || rawValue.isEmpty()) {
+            errMsg.append(authorityId).append(": missing claim '").append(claimMapping).append("'");
+            return null;
+        }
+
+        final String username;
+        if (EMAIL_CLAIM.equals(claimMapping)) {
+            try {
+                final Boolean emailVerified = claims.getBooleanClaim(EMAIL_VERIFIED_CLAIM);
+                if (emailVerified != null && !emailVerified) {
+                    errMsg.append(authorityId).append(": email not verified for: ").append(rawValue);
+                    return null;
+                }
+            } catch (ParseException e) {
+                errMsg.append(authorityId).append(": failed to parse ").append(EMAIL_VERIFIED_CLAIM)
+                        .append(" claim: ").append(e.getMessage());
+                return null;
+            }
+
+            final String emailLower = rawValue.toLowerCase(Locale.ROOT);
+            if (!emailLower.endsWith(emailDomain)) {
+                errMsg.append(authorityId).append(": email '").append(rawValue)
+                        .append("' does not end with '").append(emailDomain).append("'");
+                return null;
+            }
+            username = emailLower.substring(0, emailLower.length() - emailDomain.length());
+        } else {
+            username = rawValue.toLowerCase(Locale.ROOT);
+        }
+
+        if (username.isEmpty() || !validUsernamePattern.matcher(username).matches()) {
+            errMsg.append(authorityId).append(": invalid username '").append(username)
+                    .append("' from claim '").append(claimMapping).append("' value: ").append(rawValue);
+            return null;
+        }
+
+        return username;
+    }
+}

--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/ServiceAccessTokenAuthority.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/impl/ServiceAccessTokenAuthority.java
@@ -22,6 +22,24 @@ import com.yahoo.athenz.auth.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Authority that validates Athenz-issued OAuth2 access tokens (JWTs) presented
+ * in the {@code Authorization: Bearer} header and creates the corresponding
+ * Athenz principal.
+ *
+ * <p><b>Coexistence with other Bearer-token authorities.</b> This authority
+ * can be registered alongside other authorities that also consume the
+ * {@code Authorization: Bearer} header (for example {@link OIDCAuthority},
+ * which validates external OIDC ID tokens). Athenz dispatches credentials to
+ * each configured authority in order and uses the first non-null principal;
+ * each authority is expected to return {@code null} for tokens it does not
+ * recognise. When coexistence is needed, authorities downstream of this one
+ * should pre-check the JWT {@code iss} claim before consulting their JWKS
+ * source so that tokens issued by other providers bail out cheaply;
+ * {@link OIDCAuthority} implements that pattern.
+ *
+ * @see OIDCAuthority
+ */
 public class ServiceAccessTokenAuthority implements Authority, AuthorityKeyStore {
 
     private static final Logger LOG = LoggerFactory.getLogger(ServiceAccessTokenAuthority.class);

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/OIDCAuthorityTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/impl/OIDCAuthorityTest.java
@@ -1,0 +1,950 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.auth.impl;
+
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.JWSSigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet;
+import com.nimbusds.jose.proc.JWSVerificationKeySelector;
+import com.nimbusds.jose.proc.SecurityContext;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import com.nimbusds.jwt.proc.ConfigurableJWTProcessor;
+import com.nimbusds.jwt.proc.DefaultJWTProcessor;
+import com.yahoo.athenz.auth.Principal;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.testng.Assert.*;
+
+public class OIDCAuthorityTest {
+
+    private static final String ISSUER = "https://oauth.id.jumpcloud.com/";
+    private static final String AUDIENCE = "test-client-id";
+    private static final String EMAIL_DOMAIN = "@example.com";
+    private static final String PROPERTY_PREFIX = "athenz.auth.oidc";
+
+    private RSAKey rsaKey;
+    private JWSSigner signer;
+    private OIDCAuthority authority;
+
+    @BeforeMethod
+    public void setUp() throws JOSEException {
+        rsaKey = new RSAKeyGenerator(2048).keyID("test-key-1").generate();
+        signer = new RSASSASigner(rsaKey);
+
+        authority = new OIDCAuthority();
+        authority.setJwtProcessor(buildTestProcessor());
+        authority.setIssuer(ISSUER);
+        authority.setAudience(AUDIENCE);
+        authority.setEmailDomain(EMAIL_DOMAIN);
+        authority.setClaimMapping(OIDCAuthority.DEFAULT_CLAIM_MAPPING);
+        authority.setPrincipalDomain(OIDCAuthority.DEFAULT_DOMAIN);
+        authority.setAuthorityId("Auth-OIDC-jumpcloud");
+        authority.setValidUsernamePattern(Pattern.compile(OIDCAuthority.DEFAULT_USERNAME_PATTERN));
+    }
+
+    /**
+     * Build a JWT processor that verifies signatures against {@link #rsaKey}.
+     * Used by {@link #setUp} and by tests that construct a second authority
+     * instance (for example those exercising {@code initialize()}).
+     */
+    private ConfigurableJWTProcessor<SecurityContext> buildTestProcessor() {
+        ConfigurableJWTProcessor<SecurityContext> processor = new DefaultJWTProcessor<>();
+        processor.setJWSKeySelector(new JWSVerificationKeySelector<>(
+                Set.of(JWSAlgorithm.RS256),
+                new ImmutableJWKSet<>(new JWKSet(rsaKey.toPublicJWK()))));
+        return processor;
+    }
+
+    private void clearSystemProperties() {
+        System.clearProperty(PROPERTY_PREFIX + "." + OIDCAuthority.PROP_ISSUER);
+        System.clearProperty(PROPERTY_PREFIX + "." + OIDCAuthority.PROP_AUDIENCE);
+        System.clearProperty(PROPERTY_PREFIX + "." + OIDCAuthority.PROP_EMAIL_DOMAIN);
+        System.clearProperty(PROPERTY_PREFIX + "." + OIDCAuthority.PROP_CLAIM_MAPPING);
+        System.clearProperty(PROPERTY_PREFIX + "." + OIDCAuthority.PROP_DOMAIN);
+        System.clearProperty(PROPERTY_PREFIX + "." + OIDCAuthority.PROP_NAME);
+        System.clearProperty(PROPERTY_PREFIX + "." + OIDCAuthority.PROP_USERNAME_PATTERN);
+    }
+
+    // ---------------------------------------------------------------
+    // Basic accessors
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testGetters() {
+        assertEquals(authority.getID(), "Auth-OIDC-jumpcloud");
+        assertEquals(authority.getDomain(), "user");
+        assertEquals(authority.getHeader(), "Authorization");
+        assertEquals(authority.getAuthenticateChallenge(), "Bearer realm=\"athenz\"");
+        assertTrue(authority.allowAuthorization());
+    }
+
+    @Test
+    public void testPropertyPrefixDefault() {
+        OIDCAuthority instance = new OIDCAuthority();
+        assertEquals(instance.propertyPrefix(), "athenz.auth.oidc");
+    }
+
+    // ---------------------------------------------------------------
+    // Successful authentication scenarios
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testSuccessfulAuthentication() throws Exception {
+        Date now = new Date();
+        String token = createToken(ISSUER, AUDIENCE, "gv@example.com", now,
+                new Date(now.getTime() + 3600_000));
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + token, "10.0.0.1", "GET", errMsg);
+
+        assertNotNull(principal, "Expected non-null principal, error: " + errMsg);
+        assertEquals(principal.getDomain(), "user");
+        assertEquals(principal.getName(), "gv");
+        assertEquals(principal.getFullName(), "user.gv");
+        assertEquals(principal.getIssueTime(), now.getTime() / 1000);
+        assertSame(principal.getAuthority(), authority);
+    }
+
+    @Test
+    public void testMixedCaseUsername() throws Exception {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken("GV@example.com"), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "gv");
+    }
+
+    @Test
+    public void testMixedCaseDomain() throws Exception {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken("gv@Example.COM"), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "gv");
+    }
+
+    @Test
+    public void testAudienceAsListIncludesExpected() throws Exception {
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(List.of("other-client", AUDIENCE))
+                .claim("email", "gv@example.com")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "gv");
+    }
+
+    @Test
+    public void testValidUsernameWithDigit() throws Exception {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken("gv2@example.com"), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "gv2");
+    }
+
+    @Test
+    public void testCustomPrincipalDomain() throws Exception {
+        authority.setPrincipalDomain("myusers");
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken("gv@example.com"), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getDomain(), "myusers");
+        assertEquals(principal.getFullName(), "myusers.gv");
+    }
+
+    // ---------------------------------------------------------------
+    // Bearer header handling
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testNonBearerCredentials() {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Basic dXNlcjpwYXNz", "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("do not start with 'Bearer '"));
+    }
+
+    @Test
+    public void testNullCredentials() {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(null, "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("do not start with 'Bearer '"));
+    }
+
+    @Test
+    public void testEmptyBearerToken() {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer ", "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("no token after 'Bearer '"));
+    }
+
+    @Test
+    public void testNullErrMsgDoesNotThrow() {
+        assertNull(authority.authenticate("Basic foo", "10.0.0.1", "GET", null));
+    }
+
+    // ---------------------------------------------------------------
+    // Token validation failures
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testInvalidJwt() {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer not-a-valid-jwt", "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("failed to parse JWT"));
+    }
+
+    @Test
+    public void testWrongIssuerBailsOutEarly() throws Exception {
+        String token = createToken("https://evil.example.com/", AUDIENCE, "gv@example.com",
+                new Date(), new Date(System.currentTimeMillis() + 3600_000));
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + token, "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("issuer mismatch"));
+    }
+
+    @Test
+    public void testWrongAudience() throws Exception {
+        String token = createToken(ISSUER, "wrong-client-id", "gv@example.com",
+                new Date(), new Date(System.currentTimeMillis() + 3600_000));
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + token, "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("does not contain expected"));
+    }
+
+    @Test
+    public void testMissingAudience() throws Exception {
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .claim("email", "gv@example.com")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("does not contain expected"));
+    }
+
+    @Test
+    public void testExpiredToken() throws Exception {
+        Date past = new Date(System.currentTimeMillis() - 7200_000);
+        Date expired = new Date(System.currentTimeMillis() - 3600_000);
+        String token = createToken(ISSUER, AUDIENCE, "gv@example.com", past, expired);
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + token, "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("JWT validation failed"));
+    }
+
+    @Test
+    public void testTokenSignedWithWrongKey() throws Exception {
+        RSAKey wrongKey = new RSAKeyGenerator(2048).keyID("wrong-key").generate();
+        JWSSigner wrongSigner = new RSASSASigner(wrongKey);
+
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .claim("email", "gv@example.com")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+        SignedJWT jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID("wrong-key").build(), claims);
+        jwt.sign(wrongSigner);
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + jwt.serialize(), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("JWT validation failed"));
+    }
+
+    // ---------------------------------------------------------------
+    // Claim extraction (email mapping)
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testMissingEmailClaim() throws Exception {
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .subject("user-id-123")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("missing claim 'email'"));
+    }
+
+    @Test
+    public void testWrongEmailDomain() throws Exception {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken("gv@evil.com"), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("does not end with"));
+    }
+
+    @Test
+    public void testEmailNotVerified() throws Exception {
+        String token = createTokenWithEmailVerified("gv@example.com", false);
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + token, "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("email not verified"));
+    }
+
+    @Test
+    public void testEmailVerifiedTrue() throws Exception {
+        String token = createTokenWithEmailVerified("gv@example.com", true);
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + token, "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "gv");
+    }
+
+    @Test
+    public void testEmailVerifiedAbsent() throws Exception {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken("gv@example.com"), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+    }
+
+    @Test
+    public void testEmailEmptyUsername() throws Exception {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken("@example.com"), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("invalid username"));
+    }
+
+    @Test
+    public void testEmailClaimIsNotString() throws Exception {
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .claim("email", 42)
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("failed to parse claim 'email'"));
+    }
+
+    @Test
+    public void testEmailVerifiedClaimIsNotBoolean() throws Exception {
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .claim("email", "gv@example.com")
+                .claim("email_verified", "not-a-boolean")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("failed to parse email_verified"));
+    }
+
+    // ---------------------------------------------------------------
+    // Claim mapping to a non-email claim
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testAlternateClaimMapping() throws Exception {
+        authority.setClaimMapping("preferred_username");
+        authority.setEmailDomain(null);
+
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .claim("preferred_username", "alice")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "alice");
+    }
+
+    @Test
+    public void testAlternateClaimMappingIsLowercased() throws Exception {
+        authority.setClaimMapping("preferred_username");
+        authority.setEmailDomain(null);
+
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .claim("preferred_username", "ALICE")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "alice");
+    }
+
+    @Test
+    public void testAlternateClaimMappingMissingClaim() throws Exception {
+        authority.setClaimMapping("preferred_username");
+        authority.setEmailDomain(null);
+
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("missing claim 'preferred_username'"));
+    }
+
+    @Test
+    public void testAlternateClaimMappingSkipsEmailVerified() throws Exception {
+        authority.setClaimMapping("preferred_username");
+        authority.setEmailDomain(null);
+
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .claim("preferred_username", "alice")
+                .claim("email_verified", false)
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "alice");
+    }
+
+    // ---------------------------------------------------------------
+    // Username pattern validation
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testUsernameWithDotsRejected() throws Exception {
+        assertInvalidUsername("first.last@example.com");
+    }
+
+    @Test
+    public void testUsernameWithPlusRejected() throws Exception {
+        assertInvalidUsername("user+tag@example.com");
+    }
+
+    @Test
+    public void testUsernameWithHyphenRejected() throws Exception {
+        assertInvalidUsername("my-user@example.com");
+    }
+
+    @Test
+    public void testUsernameWithUnderscoreRejected() throws Exception {
+        assertInvalidUsername("my_user@example.com");
+    }
+
+    @Test
+    public void testUsernameStartingWithDigitRejected() throws Exception {
+        assertInvalidUsername("1user@example.com");
+    }
+
+    private void assertInvalidUsername(String email) throws Exception {
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken(email), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("invalid username"));
+    }
+
+    // ---------------------------------------------------------------
+    // Configurable username pattern
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testCustomPatternAcceptsDottedUsername() throws Exception {
+        authority.setValidUsernamePattern(Pattern.compile("[a-z0-9][a-z0-9._-]*"));
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken("first.last@example.com"), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "first.last");
+    }
+
+    @Test
+    public void testCustomPatternAcceptsUnderscoreAndHyphen() throws Exception {
+        authority.setValidUsernamePattern(Pattern.compile("[a-z0-9][a-z0-9._-]*"));
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + createValidToken("my_user-name@example.com"), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "my_user-name");
+    }
+
+    @Test
+    public void testCustomPatternStillRejectsMismatch() throws Exception {
+        // Permissive pattern still excludes '@' so an unstripped email fails.
+        authority.setValidUsernamePattern(Pattern.compile("[a-z0-9][a-z0-9._-]*"));
+        authority.setClaimMapping("preferred_username");
+        authority.setEmailDomain(null);
+
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .claim("preferred_username", "bad@value")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("invalid username"));
+    }
+
+    @Test
+    public void testInitializeLoadsUsernamePatternFromProperty() throws Exception {
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", ISSUER);
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        System.setProperty(PROPERTY_PREFIX + ".email_domain", EMAIL_DOMAIN);
+        System.setProperty(PROPERTY_PREFIX + ".username_pattern", "[a-z0-9][a-z0-9._-]*");
+        try {
+            OIDCAuthority instance = newInstanceWithTestKey();
+            instance.initialize();
+
+            StringBuilder errMsg = new StringBuilder();
+            Principal principal = instance.authenticate(
+                    "Bearer " + createValidToken("first.last@example.com"), "10.0.0.1", "GET", errMsg);
+            assertNotNull(principal, errMsg.toString());
+            assertEquals(principal.getName(), "first.last");
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testInitializeUsesDefaultPatternWhenPropertyAbsent() throws Exception {
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", ISSUER);
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        System.setProperty(PROPERTY_PREFIX + ".email_domain", EMAIL_DOMAIN);
+        try {
+            OIDCAuthority instance = newInstanceWithTestKey();
+            instance.initialize();
+
+            // The default pattern rejects dotted usernames.
+            StringBuilder errMsg = new StringBuilder();
+            Principal principal = instance.authenticate(
+                    "Bearer " + createValidToken("first.last@example.com"), "10.0.0.1", "GET", errMsg);
+            assertNull(principal);
+            assertTrue(errMsg.toString().contains("invalid username"));
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testInitializeRejectsInvalidRegex() {
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", ISSUER);
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        System.setProperty(PROPERTY_PREFIX + ".email_domain", EMAIL_DOMAIN);
+        System.setProperty(PROPERTY_PREFIX + ".username_pattern", "[invalid(");
+        try {
+            OIDCAuthority instance = new OIDCAuthority();
+            instance.setJwtProcessor(new DefaultJWTProcessor<>());
+            instance.initialize();
+            fail("Expected IllegalStateException for invalid regex");
+        } catch (IllegalStateException ex) {
+            assertTrue(ex.getMessage().contains("username_pattern"));
+            assertTrue(ex.getMessage().contains("[invalid("));
+            assertTrue(ex.getCause() instanceof java.util.regex.PatternSyntaxException,
+                    "Expected PatternSyntaxException cause, got: " + ex.getCause());
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testInitializeTreatsEmptyPatternAsDefault() throws Exception {
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", ISSUER);
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        System.setProperty(PROPERTY_PREFIX + ".email_domain", EMAIL_DOMAIN);
+        System.setProperty(PROPERTY_PREFIX + ".username_pattern", "");
+        try {
+            OIDCAuthority instance = newInstanceWithTestKey();
+            instance.initialize();
+
+            // Default pattern accepts a simple username, proving empty didn't
+            // leak through as Pattern.compile("").
+            StringBuilder errMsg = new StringBuilder();
+            Principal principal = instance.authenticate(
+                    "Bearer " + createValidToken("gv@example.com"), "10.0.0.1", "GET", errMsg);
+            assertNotNull(principal, errMsg.toString());
+            assertEquals(principal.getName(), "gv");
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testDefaultPatternRejectsDottedNonEmailClaim() throws Exception {
+        authority.setClaimMapping("preferred_username");
+        authority.setEmailDomain(null);
+
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .claim("preferred_username", "first.last")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate("Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNull(principal);
+        assertTrue(errMsg.toString().contains("invalid username"));
+    }
+
+    /**
+     * Build an OIDCAuthority instance wired with the test JWT processor, so
+     * tests that call initialize() can still authenticate tokens produced by
+     * the test helpers.
+     */
+    private OIDCAuthority newInstanceWithTestKey() {
+        OIDCAuthority instance = new OIDCAuthority();
+        instance.setJwtProcessor(buildTestProcessor());
+        return instance;
+    }
+
+    // ---------------------------------------------------------------
+    // initialize() — system property loading & validation
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testInitializeRequiresIssuer() {
+        clearSystemProperties();
+        try {
+            OIDCAuthority instance = new OIDCAuthority();
+            instance.initialize();
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException ex) {
+            assertTrue(ex.getMessage().contains("issuer"));
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testInitializeRequiresAudience() {
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", ISSUER);
+        try {
+            OIDCAuthority instance = new OIDCAuthority();
+            instance.initialize();
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException ex) {
+            assertTrue(ex.getMessage().contains("audience"));
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testInitializeRequiresEmailDomainWhenMappingIsEmail() {
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", ISSUER);
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        try {
+            OIDCAuthority instance = new OIDCAuthority();
+            instance.setJwtProcessor(new DefaultJWTProcessor<>()); // bypass JWKS discovery
+            instance.initialize();
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException ex) {
+            assertTrue(ex.getMessage().contains("email_domain"));
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testInitializeAllowsMissingEmailDomainForOtherClaim() {
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", ISSUER);
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        System.setProperty(PROPERTY_PREFIX + ".claim_mapping", "preferred_username");
+        try {
+            OIDCAuthority instance = new OIDCAuthority();
+            instance.setJwtProcessor(new DefaultJWTProcessor<>()); // bypass JWKS discovery
+            instance.initialize();
+            assertEquals(instance.getID(), "Auth-OIDC-jumpcloud");
+            assertEquals(instance.getDomain(), "user");
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testInitializeAcceptsIssuerWithoutTrailingSlash() {
+        // The iss claim must match the configured issuer byte-for-byte; Google
+        // and Okta issuer URLs omit the trailing slash, JumpCloud and Auth0
+        // include it. initialize() must preserve the configured form.
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", "https://accounts.google.com");
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        System.setProperty(PROPERTY_PREFIX + ".email_domain", EMAIL_DOMAIN);
+        try {
+            OIDCAuthority instance = new OIDCAuthority();
+            instance.setJwtProcessor(new DefaultJWTProcessor<>()); // bypass JWKS discovery
+            instance.initialize();
+            assertEquals(instance.getID(), "Auth-OIDC-google");
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testIssuerWithoutTrailingSlashMatchesTokenIss() throws Exception {
+        // Operator configures Google-style issuer (no trailing slash); tokens
+        // must authenticate even though the iss claim also lacks a slash.
+        final String noSlashIssuer = "https://accounts.google.com";
+        authority.setIssuer(noSlashIssuer);
+
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(noSlashIssuer)
+                .audience(AUDIENCE)
+                .claim("email", "gv@example.com")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+
+        StringBuilder errMsg = new StringBuilder();
+        Principal principal = authority.authenticate(
+                "Bearer " + sign(claims), "10.0.0.1", "GET", errMsg);
+        assertNotNull(principal, errMsg.toString());
+        assertEquals(principal.getName(), "gv");
+    }
+
+    @Test
+    public void testInitializeRejectsNonHttpsIssuer() {
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", "http://insecure.example.com/");
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        System.setProperty(PROPERTY_PREFIX + ".email_domain", EMAIL_DOMAIN);
+        try {
+            OIDCAuthority instance = new OIDCAuthority();
+            instance.setJwtProcessor(new DefaultJWTProcessor<>());
+            instance.initialize();
+            fail("Expected IllegalStateException for non-HTTPS issuer");
+        } catch (IllegalStateException ex) {
+            assertTrue(ex.getMessage().contains("must use https"));
+            assertTrue(ex.getMessage().contains("http://insecure.example.com/"));
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testInitializeUsesConfiguredName() {
+        clearSystemProperties();
+        System.setProperty(PROPERTY_PREFIX + ".issuer", ISSUER);
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        System.setProperty(PROPERTY_PREFIX + ".email_domain", EMAIL_DOMAIN);
+        System.setProperty(PROPERTY_PREFIX + ".name", "my-idp");
+        try {
+            OIDCAuthority instance = new OIDCAuthority();
+            instance.setJwtProcessor(new DefaultJWTProcessor<>());
+            instance.initialize();
+            assertEquals(instance.getID(), "Auth-OIDC-my-idp");
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testInitializeDiscoversJwksUriFailure() {
+        clearSystemProperties();
+        // Use an unreachable URL so OIDC discovery fails deterministically.
+        // Port 1 is closed, so the connection fails regardless of scheme.
+        System.setProperty(PROPERTY_PREFIX + ".issuer", "https://127.0.0.1:1/");
+        System.setProperty(PROPERTY_PREFIX + ".audience", AUDIENCE);
+        System.setProperty(PROPERTY_PREFIX + ".email_domain", EMAIL_DOMAIN);
+        try {
+            new OIDCAuthority().initialize();
+            fail("Expected IllegalStateException");
+        } catch (IllegalStateException ex) {
+            assertTrue(ex.getMessage().contains("Failed to discover JWKS URI"));
+        } finally {
+            clearSystemProperties();
+        }
+    }
+
+    @Test
+    public void testSubclassOverridesPropertyPrefix() {
+        final String customPrefix = "athenz.auth.oidc.okta";
+        System.setProperty(customPrefix + ".issuer", ISSUER);
+        System.setProperty(customPrefix + ".audience", AUDIENCE);
+        System.setProperty(customPrefix + ".email_domain", EMAIL_DOMAIN);
+        System.setProperty(customPrefix + ".name", "okta");
+        try {
+            OIDCAuthority instance = new OIDCAuthority() {
+                @Override protected String propertyPrefix() { return customPrefix; }
+            };
+            instance.setJwtProcessor(new DefaultJWTProcessor<>());
+            instance.initialize();
+            assertEquals(instance.getID(), "Auth-OIDC-okta");
+        } finally {
+            System.clearProperty(customPrefix + ".issuer");
+            System.clearProperty(customPrefix + ".audience");
+            System.clearProperty(customPrefix + ".email_domain");
+            System.clearProperty(customPrefix + ".name");
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Authority name derivation from issuer host
+    // ---------------------------------------------------------------
+
+    @Test
+    public void testDeriveNameFromIssuerStandardHosts() {
+        assertEquals(OIDCAuthority.deriveNameFromIssuer("https://oauth.id.jumpcloud.com/"), "jumpcloud");
+        assertEquals(OIDCAuthority.deriveNameFromIssuer("https://accounts.google.com/"), "google");
+        assertEquals(OIDCAuthority.deriveNameFromIssuer("https://login.microsoftonline.com/"), "microsoftonline");
+        assertEquals(OIDCAuthority.deriveNameFromIssuer("https://dev-123.okta.com/"), "okta");
+    }
+
+    @Test
+    public void testDeriveNameFromIssuerShortHost() {
+        assertEquals(OIDCAuthority.deriveNameFromIssuer("https://localhost/"), "localhost");
+    }
+
+    @Test
+    public void testDeriveNameFromIssuerLowercasesResult() {
+        assertEquals(OIDCAuthority.deriveNameFromIssuer("https://LOGIN.EXAMPLE.COM/"), "example");
+    }
+
+    @Test
+    public void testDeriveNameFromIssuerInvalidUrl() {
+        // Malformed URL (bad authority); falls back to "default".
+        assertEquals(OIDCAuthority.deriveNameFromIssuer("ht!tp://[bad"), "default");
+    }
+
+    @Test
+    public void testDeriveNameFromIssuerNoHost() {
+        // URI with no host component.
+        assertEquals(OIDCAuthority.deriveNameFromIssuer("file:///tmp/config"), "default");
+    }
+
+    // ---------------------------------------------------------------
+    // JWT helpers
+    // ---------------------------------------------------------------
+
+    private String createValidToken(String email) throws JOSEException {
+        Date now = new Date();
+        return createToken(ISSUER, AUDIENCE, email, now, new Date(now.getTime() + 3600_000));
+    }
+
+    private String createTokenWithEmailVerified(String email, boolean emailVerified) throws JOSEException {
+        Date now = new Date();
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(ISSUER)
+                .audience(AUDIENCE)
+                .claim("email", email)
+                .claim("email_verified", emailVerified)
+                .subject("user-id-123")
+                .issueTime(now)
+                .expirationTime(new Date(now.getTime() + 3600_000))
+                .build();
+        return sign(claims);
+    }
+
+    private String createToken(String issuer, String audience, String email,
+                               Date issueTime, Date expirationTime) throws JOSEException {
+        JWTClaimsSet claims = new JWTClaimsSet.Builder()
+                .issuer(issuer)
+                .audience(audience)
+                .claim("email", email)
+                .subject("user-id-123")
+                .issueTime(issueTime)
+                .expirationTime(expirationTime)
+                .build();
+        return sign(claims);
+    }
+
+    private String sign(JWTClaimsSet claims) throws JOSEException {
+        SignedJWT jwt = new SignedJWT(
+                new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(rsaKey.getKeyID()).build(),
+                claims);
+        jwt.sign(signer);
+        return jwt.serialize();
+    }
+}


### PR DESCRIPTION
Adds a generic `com.yahoo.athenz.auth.impl.OIDCAuthority` that validates signed OIDC ID tokens (JWTs) from any configured external OpenID Connect provider and maps them to Athenz user principals. Enables Athenz UI deployments to forward an end user's ID token to ZMS in `Authorization: Bearer` so that API calls are attributed to the individual user instead of the UI service identity.

Fixes #3311.

## Design decisions (resolved in #3311)

Per @abvaidya's feedback in the issue:

- **Property-based config** — follows the existing authority convention so multiple authorities can be active simultaneously.
- **Subclass-based multi-instance** — for the rare case of more than one external IdP, operators write a trivial subclass that overrides `propertyPrefix()`; the common single-IdP case uses the defaults and needs no subclass.
- **Coexistence note in `ServiceAccessTokenAuthority`** — new class-level Javadoc documents the `Authorization: Bearer` dispatch contract and cross-references `OIDCAuthority` as an example of the recommended `iss`-based pre-check pattern.

## Configuration

System properties under the default prefix `athenz.auth.oidc` (subclasses override `propertyPrefix()` to namespace a second instance):

| Property | Required | Default | Description |
| --- | --- | --- | --- |
| `athenz.auth.oidc.issuer` | yes | — | OIDC issuer URL; used for discovery and JWT `iss` verification. |
| `athenz.auth.oidc.audience` | yes | — | Expected `aud` claim (OIDC client ID). |
| `athenz.auth.oidc.email_domain` | when `claim_mapping=email` | — | Email domain stripped (case-insensitively) to derive the username. |
| `athenz.auth.oidc.claim_mapping` | no | `email` | JWT claim used to derive the Athenz username. |
| `athenz.auth.oidc.domain` | no | `user` | Athenz principal domain. |
| `athenz.auth.oidc.name` | no | derived from issuer host | Short name used in authority ID `Auth-OIDC-{name}`. |
| `athenz.auth.oidc.username_pattern` | no | `[a-z][a-z0-9]*` | Regex applied to the (lowercased) final username. Deployments with dotted/underscored usernames (Okta, Azure AD, corporate IdPs) can loosen this. An invalid regex fails `initialize()`. |

`Auth-OIDC-{name}` is derived from the issuer host by default (e.g. `oauth.id.jumpcloud.com` → `Auth-OIDC-jumpcloud`); multi-part ccTLDs can be overridden via `athenz.auth.oidc.name`.

## Implementation notes

- Reuses existing Athenz utilities: `JwtsHelper.getJWTProcessor()`, `JwtsHelper.extractJwksUri()`, `JwtsSigningKeyResolver` (JWKS caching + outage tolerance), `SimplePrincipal.create()`.
- `allowAuthorization()` returns `true` — the validated ID token is itself the credential; no subsequent NToken exchange is required.
- `email_verified` is enforced when `claim_mapping=email`.
- Multi-instance example (`OktaOIDCAuthority` against `athenz.auth.oidc.okta.*` properties) is in the class Javadoc.

## Coexistence with `ServiceAccessTokenAuthority`

Both authorities consume `Authorization: Bearer`. ZMS dispatches credentials to each configured authority in order and uses the first non-null principal; each authority returns `null` for tokens it does not recognise. `OIDCAuthority` performs an unverified parse of the JWT to check the `iss` claim before consulting the JWKS endpoint, so tokens issued by other providers bail out cheaply without key resolution or log noise. `ServiceAccessTokenAuthority`'s Javadoc now documents this pattern.

## Testing

- 56 TestNG tests in `OIDCAuthorityTest` covering success paths, header handling, signature/expiry/audience/issuer failures, `email_verified` variants, alternate claim mappings, configurable and default username patterns (including empty-string and invalid-regex cases), property loading, subclass prefix override, and authority-name derivation.
- 97% line coverage on the new class (module threshold 95.04% is met).
