### PR TITLE
enforce tls 1.2 for our go client connections

### DIFF
--- a/.github/workflows/docker-build-publish.yaml
+++ b/.github/workflows/docker-build-publish.yaml
@@ -5,6 +5,19 @@ on:
     tags:
       - '*'
 
+permissions:
+  actions: none
+  checks: none
+  contents: read
+  deployments: none
+  issues: none
+  discussions: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
 env:
   DOCKER_BUILDX_PLATFORM: linux/amd64,linux/arm64
   DOCKER_REGISTRY_OWNER: athenz

--- a/clients/go/zts/token/client.go
+++ b/clients/go/zts/token/client.go
@@ -176,6 +176,8 @@ func createTLSConfig(certPath, keyPath string) (*tls.Config, error) {
 		return nil, fmt.Errorf("failed to load client certificate and key: %v", err)
 	}
 	tlsConfig := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		SessionTicketsDisabled: true,
 		Certificates: []tls.Certificate{cert},
 	}
 	return tlsConfig, nil

--- a/libs/go/tls/config/config.go
+++ b/libs/go/tls/config/config.go
@@ -17,7 +17,7 @@ func GetTLSConfigFromFiles(certFile, keyFile string) (*tls.Config, error) {
 }
 
 func ClientTLSConfigFromPEM(keypem, certpem, cacertpem []byte) (*tls.Config, error) {
-	config := &tls.Config{}
+	config := ClientTLSConfig()
 	if certpem != nil && keypem != nil {
 		mycert, err := tls.X509KeyPair(certpem, keypem)
 		if err != nil {

--- a/libs/go/usercert/usercert.go
+++ b/libs/go/usercert/usercert.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/AthenZ/athenz/clients/go/zts"
 	"github.com/AthenZ/athenz/libs/go/athenzutils"
+	"github.com/AthenZ/athenz/libs/go/tls/config"
 )
 
 // Options configures the user certificate request flow.
@@ -229,7 +230,7 @@ func newSigner(privateKeyPEM []byte) (*signer, error) {
 }
 
 func tlsConfigFromPEM(cacertFile string) (*tls.Config, error) {
-	config := &tls.Config{}
+	config := config.ClientTLSConfig()
 	if cacertFile == "" {
 		return config, nil
 	}

--- a/utils/athenz-conf/athenz-conf.go
+++ b/utils/athenz-conf/athenz-conf.go
@@ -20,6 +20,7 @@ import (
 	"golang.org/x/net/proxy"
 
 	"github.com/AthenZ/athenz/clients/go/zms"
+	"github.com/AthenZ/athenz/libs/go/tls/config"
 )
 
 var (
@@ -344,7 +345,7 @@ func GetTLSConfigFromFiles(certFile, keyFile, caCertFile *string) (*tls.Config, 
 }
 
 func GetTLSConfig(certPem, keyPem, caCertPem []byte) (*tls.Config, error) {
-	config := &tls.Config{}
+	config := config.ClientTLSConfig()
 	if keyPem != nil {
 		clientCert, err := tls.X509KeyPair(certPem, keyPem)
 		if err != nil {

--- a/utils/zms-cli/zms-cli.go
+++ b/utils/zms-cli/zms-cli.go
@@ -384,7 +384,7 @@ func getHttpTransport(socksProxy, caCertFile *string, skipVerify bool) *http.Tra
 		}
 	}
 	if caCertFile != nil || skipVerify {
-		config := config.ClientTLSConfig()
+		tlsConfig := config.ClientTLSConfig()
 		if caCertFile != nil {
 			capem, err := os.ReadFile(*caCertFile)
 			if err != nil {
@@ -394,12 +394,14 @@ func getHttpTransport(socksProxy, caCertFile *string, skipVerify bool) *http.Tra
 			if !certPool.AppendCertsFromPEM(capem) {
 				log.Fatalf("Unable to append CA Certificate to pool")
 			}
-			config.RootCAs = certPool
+			tlsConfig.RootCAs = certPool
 		}
 		if skipVerify {
-			config.InsecureSkipVerify = skipVerify
+			tlsConfig.InsecureSkipVerify = skipVerify
 		}
-		tr.TLSClientConfig = config
+		tr.TLSClientConfig = tlsConfig
+	} else {
+		tr.TLSClientConfig = config.ClientTLSConfig()
 	}
 	return &tr
 }

--- a/utils/zms-cli/zms-cli.go
+++ b/utils/zms-cli/zms-cli.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -25,6 +24,7 @@ import (
 	"golang.org/x/net/proxy"
 
 	"github.com/AthenZ/athenz/clients/go/zms"
+	"github.com/AthenZ/athenz/libs/go/tls/config"
 	"github.com/AthenZ/athenz/libs/go/zmscli"
 )
 
@@ -384,7 +384,7 @@ func getHttpTransport(socksProxy, caCertFile *string, skipVerify bool) *http.Tra
 		}
 	}
 	if caCertFile != nil || skipVerify {
-		config := &tls.Config{}
+		config := config.ClientTLSConfig()
 		if caCertFile != nil {
 			capem, err := os.ReadFile(*caCertFile)
 			if err != nil {

--- a/utils/zts-svccert/zts-svccert.go
+++ b/utils/zts-svccert/zts-svccert.go
@@ -8,7 +8,6 @@ import (
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
-	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"

--- a/utils/zts-svccert/zts-svccert.go
+++ b/utils/zts-svccert/zts-svccert.go
@@ -466,15 +466,17 @@ func ntokenClient(ztsURL, ntoken, caCertFile, hdr string) (*zts.ZTSClient, error
 		ResponseHeaderTimeout: 30 * time.Second,
 	}
 	if caCertFile != "" {
-		config := config.ClientTLSConfig()
+		tlsConfig := config.ClientTLSConfig()
 		certPool := x509.NewCertPool()
 		caCert, err := os.ReadFile(caCertFile)
 		if err != nil {
 			return nil, err
 		}
 		certPool.AppendCertsFromPEM(caCert)
-		config.RootCAs = certPool
-		transport.TLSClientConfig = config
+		tlsConfig.RootCAs = certPool
+		transport.TLSClientConfig = tlsConfig
+	} else {
+		transport.TLSClientConfig = config.ClientTLSConfig()
 	}
 	// use the ntoken to talk to Athenz
 	client := zts.NewClient(ztsURL, transport)

--- a/utils/zts-svccert/zts-svccert.go
+++ b/utils/zts-svccert/zts-svccert.go
@@ -466,7 +466,7 @@ func ntokenClient(ztsURL, ntoken, caCertFile, hdr string) (*zts.ZTSClient, error
 		ResponseHeaderTimeout: 30 * time.Second,
 	}
 	if caCertFile != "" {
-		config := &tls.Config{}
+		config := config.ClientTLSConfig()
 		certPool := x509.NewCertPool()
 		caCert, err := os.ReadFile(caCertFile)
 		if err != nil {


### PR DESCRIPTION
# Description

Don't expect this to be a breaking change as ZTS itself should never run with 1.1 and everyone should be using 1.2+ at this point.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

