### PR TITLE
Support parallel domain fetch and upload in CloudZmsSyncer

### DIFF
--- a/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
+++ b/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
@@ -362,6 +362,8 @@ public class CloudZmsSyncer {
                     updateExecutor.shutdown();
                     refreshExecutor.shutdown();
                 }
+                awaitTermination(updateExecutor);
+                awaitTermination(refreshExecutor);
             }
 
         } catch (Exception ex) {
@@ -393,6 +395,19 @@ public class CloudZmsSyncer {
                 " : number-domain-deleted-failures: " + getNumDomainsDeletedFailed();
         LOG.info(sb);
         return retStatus;
+    }
+
+    static void awaitTermination(ExecutorService executor) {
+        try {
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                LOG.warn("executor did not terminate within timeout, forcing shutdown");
+                executor.shutdownNow();
+            }
+        } catch (InterruptedException e) {
+            LOG.warn("interrupted while awaiting executor termination");
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
     }
 
     static ThreadFactory newNamedThreadFactory(String prefix) {

--- a/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
+++ b/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
@@ -34,6 +34,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static io.athenz.syncer.common.zms.Config.SYNC_CFG_PARAM_STATE_PATH;
 
@@ -71,13 +73,23 @@ public class CloudZmsSyncer {
     static final String RUNS_STATUS_SUCCESS_MSG = "Success";
     static final String RUNS_STATUS_FAIL_MSG    = "Failed";
 
-    private int numDomainsUploaded       = 0;
-    private int numDomainsNotUploaded    = 0;
-    private int numDomainsUploadFailed   = 0;
-    private int numDomainsDeleted        = 0;
-    private int numDomainsDeletedFailed  = 0;
-    private int numDomainsRefreshed      = 0;
-    private boolean loadStateSuccess     = false;
+    static class DomainUploadTask {
+        private final String domainName;
+        private final Future<DomainState> future;
+
+        DomainUploadTask(String domainName, Future<DomainState> future) {
+            this.domainName = domainName;
+            this.future = future;
+        }
+    }
+
+    private AtomicInteger numDomainsUploaded       = new AtomicInteger(0);
+    private AtomicInteger numDomainsNotUploaded    = new AtomicInteger(0);
+    private AtomicInteger numDomainsUploadFailed   = new AtomicInteger(0);
+    private AtomicInteger numDomainsDeleted        = new AtomicInteger(0);
+    private AtomicInteger numDomainsDeletedFailed  = new AtomicInteger(0);
+    private AtomicInteger numDomainsRefreshed      = new AtomicInteger(0);
+    private boolean loadStateSuccess               = false;
 
     private final CloudDomainStore cloudStore;
     private final ZmsReader zmsReader;
@@ -162,31 +174,31 @@ public class CloudZmsSyncer {
     }
 
     public int getNumDomainsUploaded() {
-        return numDomainsUploaded;
+        return numDomainsUploaded.get();
     }
 
     public int getNumDomainsRefreshed() {
-        return numDomainsRefreshed;
+        return numDomainsRefreshed.get();
     }
 
     void setNumDomainsRefreshed(int count) {
-        numDomainsRefreshed = count;
+        numDomainsRefreshed.set(count);
     }
 
     public int getNumDomainsNotUploaded() {
-        return numDomainsNotUploaded;
+        return numDomainsNotUploaded.get();
     }
 
     public int getNumDomainsUploadFailed() {
-        return numDomainsUploadFailed;
+        return numDomainsUploadFailed.get();
     }
 
     public int getNumDomainsDeleted() {
-        return numDomainsDeleted;
+        return numDomainsDeleted.get();
     }
 
     public int getNumDomainsDeletedFailed() {
-        return numDomainsDeletedFailed;
+        return numDomainsDeletedFailed.get();
     }
 
     DomainState uploadDomain(final String domainName) {
@@ -208,17 +220,17 @@ public class CloudZmsSyncer {
         } catch (Exception exc) {
             LOG.error("failed to read zms data for domain: {}", domainName, exc);
             stateObj.setModified(LAST_MOD_NO_DATE);
-            ++numDomainsUploadFailed;
+            numDomainsUploadFailed.incrementAndGet();
             return stateObj;
         }
 
         try {
             cloudStore.uploadDomain(domainName, JSON.string(jwsDomain));
-            ++numDomainsUploaded;
+            numDomainsUploaded.incrementAndGet();
         } catch (Exception exc) {
             LOG.error("cloud sync error domain: {}", domainName, exc);
             modified = LAST_MOD_NO_DATE;
-            ++numDomainsUploadFailed;
+            numDomainsUploadFailed.incrementAndGet();
         }
         
         stateObj.setModified(modified);
@@ -233,10 +245,10 @@ public class CloudZmsSyncer {
         LOG.info("delete cloud domain: {}", domName);
         try {
             cloudStore.deleteDomain(domName);
-            ++numDomainsDeleted;
+            numDomainsDeleted.incrementAndGet();
         } catch (Exception ex) {
             LOG.error("error deleting cloud domain: {}", domName, ex);
-            ++numDomainsDeletedFailed;
+            numDomainsDeletedFailed.incrementAndGet();
             DomainState state = new DomainState();
             state.setDomain(domName);
             state.setModified(LAST_MOD_NO_DATE);
@@ -271,6 +283,16 @@ public class CloudZmsSyncer {
         int domainRefreshCountLimit = Integer.parseInt(Config.getInstance().getConfigParam(Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT));
         int domainRefreshTimeout = Integer.parseInt(Config.getInstance().getConfigParam(Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT));
 
+        int domainUpdateFetchThreads = Integer.parseInt(Config.getInstance().getConfigParam(Config.SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS));
+        if (domainUpdateFetchThreads < 1) {
+            domainUpdateFetchThreads = 1;
+        }
+
+        int domainRefreshFetchThreads = Integer.parseInt(Config.getInstance().getConfigParam(Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS));
+        if (domainRefreshFetchThreads < 1) {
+            domainRefreshFetchThreads = 1;
+        }
+
         // get domain list
 
         Set<String> latestZmsDomSet = new HashSet<>();
@@ -290,6 +312,11 @@ public class CloudZmsSyncer {
             processedDomains = new ArrayList<>(sdList.size());
 
             long now = System.currentTimeMillis() / 1000;
+            int allowedRefreshCount = Math.max(0, domainRefreshCountLimit);
+
+            List<String> updateDomains = new ArrayList<>(sdList.size());
+            List<String> refreshDomains = new ArrayList<>(Math.min(sdList.size(), allowedRefreshCount));
+
             for (SignedDomain sDom : sdList) {
 
                 DomainData domainData = sDom.getDomain();
@@ -300,25 +327,41 @@ public class CloudZmsSyncer {
 
                 DomainState domainState = stateMap.get(domainName);
                 boolean uploadDom = domainState == null || !domainModifiedTime.equals(domainState.getModified());
-                boolean refreshDom = shouldRefreshDomain(domainState, now, domainRefreshCountLimit, domainRefreshTimeout);
-                if (uploadDom || refreshDom) {
-                    domainState = uploadDomain(domainName);
-                    // add the updated domain state
-                    processedDomains.add(domainState);
-                    // check if we failed to upload this domain
-                    if (domainState.getModified().equals(LAST_MOD_NO_DATE)) {
-                        retStatus = false;
-                    }
-                    if (refreshDom) {
-                        ++numDomainsRefreshed;
-                    }
+                boolean timeToRefresh = shouldRefreshDomain(domainState, now, domainRefreshTimeout);
+
+                if (uploadDom) {
+                    updateDomains.add(domainName);
+                } else if (timeToRefresh && refreshDomains.size() < allowedRefreshCount) {
+                    refreshDomains.add(domainName);
+                    numDomainsRefreshed.incrementAndGet();
                 } else {
                     // add the old domain state
-                    processedDomains.add(domainState);
-                    ++numDomainsNotUploaded;
+                    numDomainsNotUploaded.incrementAndGet();
                     LOG.debug("no change so no upload of domain: {}", domainName);
+                    processedDomains.add(domainState);
                 }
             }
+
+            LOG.info("processing domain updates with {} thread(s), count: {}", domainUpdateFetchThreads, updateDomains.size());
+            LOG.info("processing domain refreshes with {} thread(s), count: {}", domainRefreshFetchThreads, refreshDomains.size());
+
+            ExecutorService updateExecutor = Executors.newFixedThreadPool(domainUpdateFetchThreads);
+            ExecutorService refreshExecutor = Executors.newFixedThreadPool(domainRefreshFetchThreads);
+            try {
+                List<DomainUploadTask> updateTasks = submitUploadTasks(updateExecutor, updateDomains);
+                List<DomainUploadTask> refreshTasks = submitUploadTasks(refreshExecutor, refreshDomains);
+                retStatus = collectProcessedDomains(updateTasks) && retStatus;
+                retStatus = collectProcessedDomains(refreshTasks) && retStatus;
+            } finally {
+                if (Thread.currentThread().isInterrupted()) {
+                    updateExecutor.shutdownNow();
+                    refreshExecutor.shutdownNow();
+                } else {
+                    updateExecutor.shutdown();
+                    refreshExecutor.shutdown();
+                }
+            }
+
         } catch (Exception ex) {
             LOG.error("domain processing error", ex);
             throw ex;
@@ -350,9 +393,61 @@ public class CloudZmsSyncer {
         return retStatus;
     }
 
-    boolean shouldRefreshDomain(DomainState domainState, long now, int domainRefreshCountLimit, int domainRefreshTimeout) {
-        // if there is no state, or we have reached our limit we return false
-        if (domainState == null || numDomainsRefreshed >= domainRefreshCountLimit) {
+    List<DomainUploadTask> submitUploadTasks(ExecutorService executor, List<String> domainNames) {
+        List<DomainUploadTask> tasks = new ArrayList<>(domainNames.size());
+        for (String domainName : domainNames) {
+            tasks.add(new DomainUploadTask(domainName, executor.submit(() -> uploadDomain(domainName))));
+        }
+        return tasks;
+    }
+
+    DomainState createFailedDomainState(String domainName) {
+        DomainState domainState = new DomainState();
+        domainState.setDomain(domainName);
+        domainState.setModified(LAST_MOD_NO_DATE);
+        return domainState;
+    }
+
+    void addFailedDomainState(String domainName) {
+        processedDomains.add(createFailedDomainState(domainName));
+        numDomainsUploadFailed.incrementAndGet();
+    }
+
+    boolean collectProcessedDomains(List<DomainUploadTask> tasks) {
+        boolean retStatus = true;
+        for (int i = 0; i < tasks.size(); i++) {
+            DomainUploadTask task = tasks.get(i);
+            try {
+                DomainState domainState = task.future.get();
+                // add the updated domain state
+                processedDomains.add(domainState);
+                // check if we failed to upload this domain
+                if (domainState.getModified().equals(LAST_MOD_NO_DATE)) {
+                    retStatus = false;
+                }
+            } catch (InterruptedException e) {
+                LOG.error("interrupted waiting for task", e);
+                Thread.currentThread().interrupt();
+                retStatus = false;
+                // if interrupted, stop processing and ensure remaining domains are represented as failed
+                for (int j = i; j < tasks.size(); j++) {
+                    DomainUploadTask pendingTask = tasks.get(j);
+                    pendingTask.future.cancel(true);
+                    addFailedDomainState(pendingTask.domainName);
+                }
+                break;
+            } catch (ExecutionException e) {
+                LOG.error("error waiting for task for domain: {}", task.domainName, e);
+                addFailedDomainState(task.domainName);
+                retStatus = false;
+            }
+        }
+        return retStatus;
+    }
+
+    boolean shouldRefreshDomain(DomainState domainState, long now, int domainRefreshTimeout) {
+        // if there is no state we return false
+        if (domainState == null) {
             return false;
         }
         long fetchTime = domainState.getFetchTime();

--- a/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
+++ b/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
@@ -345,8 +345,10 @@ public class CloudZmsSyncer {
             LOG.info("processing domain updates with {} thread(s), count: {}", domainUpdateFetchThreads, updateDomains.size());
             LOG.info("processing domain refreshes with {} thread(s), count: {}", domainRefreshFetchThreads, refreshDomains.size());
 
-            ExecutorService updateExecutor = Executors.newFixedThreadPool(domainUpdateFetchThreads);
-            ExecutorService refreshExecutor = Executors.newFixedThreadPool(domainRefreshFetchThreads);
+            ExecutorService updateExecutor = Executors.newFixedThreadPool(domainUpdateFetchThreads,
+                    newNamedThreadFactory("domain-update"));
+            ExecutorService refreshExecutor = Executors.newFixedThreadPool(domainRefreshFetchThreads,
+                    newNamedThreadFactory("domain-refresh"));
             try {
                 List<DomainUploadTask> updateTasks = submitUploadTasks(updateExecutor, updateDomains);
                 List<DomainUploadTask> refreshTasks = submitUploadTasks(refreshExecutor, refreshDomains);
@@ -391,6 +393,16 @@ public class CloudZmsSyncer {
                 " : number-domain-deleted-failures: " + getNumDomainsDeletedFailed();
         LOG.info(sb);
         return retStatus;
+    }
+
+    static ThreadFactory newNamedThreadFactory(String prefix) {
+        AtomicInteger counter = new AtomicInteger(0);
+        return r -> {
+            Thread t = new Thread(r);
+            t.setName(prefix + "-" + counter.incrementAndGet());
+            t.setDaemon(true);
+            return t;
+        };
     }
 
     List<DomainUploadTask> submitUploadTasks(ExecutorService executor, List<String> domainNames) {

--- a/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
+++ b/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
@@ -355,7 +355,7 @@ public class CloudZmsSyncer {
             try {
                 List<DomainUploadTask> updateTasks = submitUploadTasks(updateExecutor, updateDomains, false);
                 List<DomainUploadTask> refreshTasks = submitUploadTasks(refreshExecutor, refreshDomains, true);
-                retStatus = collectProcessedDomains(updateTasks) && retStatus;
+                retStatus = collectProcessedDomains(updateTasks);
                 retStatus = collectProcessedDomains(refreshTasks) && retStatus;
             } finally {
                 if (Thread.currentThread().isInterrupted()) {

--- a/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
+++ b/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/CloudZmsSyncer.java
@@ -201,7 +201,7 @@ public class CloudZmsSyncer {
         return numDomainsDeletedFailed.get();
     }
 
-    DomainState uploadDomain(final String domainName) {
+    DomainState uploadDomain(final String domainName, boolean isRefresh) {
 
         // create a new stateObj to return, update the modified field
         // set the "modified" field to "0" if failed, else set it to value from ZMS
@@ -226,7 +226,11 @@ public class CloudZmsSyncer {
 
         try {
             cloudStore.uploadDomain(domainName, JSON.string(jwsDomain));
-            numDomainsUploaded.incrementAndGet();
+            if (isRefresh) {
+                numDomainsRefreshed.incrementAndGet();
+            } else {
+                numDomainsUploaded.incrementAndGet();
+            }
         } catch (Exception exc) {
             LOG.error("cloud sync error domain: {}", domainName, exc);
             modified = LAST_MOD_NO_DATE;
@@ -333,7 +337,6 @@ public class CloudZmsSyncer {
                     updateDomains.add(domainName);
                 } else if (timeToRefresh && refreshDomains.size() < allowedRefreshCount) {
                     refreshDomains.add(domainName);
-                    numDomainsRefreshed.incrementAndGet();
                 } else {
                     // add the old domain state
                     numDomainsNotUploaded.incrementAndGet();
@@ -350,8 +353,8 @@ public class CloudZmsSyncer {
             ExecutorService refreshExecutor = Executors.newFixedThreadPool(domainRefreshFetchThreads,
                     newNamedThreadFactory("domain-refresh"));
             try {
-                List<DomainUploadTask> updateTasks = submitUploadTasks(updateExecutor, updateDomains);
-                List<DomainUploadTask> refreshTasks = submitUploadTasks(refreshExecutor, refreshDomains);
+                List<DomainUploadTask> updateTasks = submitUploadTasks(updateExecutor, updateDomains, false);
+                List<DomainUploadTask> refreshTasks = submitUploadTasks(refreshExecutor, refreshDomains, true);
                 retStatus = collectProcessedDomains(updateTasks) && retStatus;
                 retStatus = collectProcessedDomains(refreshTasks) && retStatus;
             } finally {
@@ -420,10 +423,10 @@ public class CloudZmsSyncer {
         };
     }
 
-    List<DomainUploadTask> submitUploadTasks(ExecutorService executor, List<String> domainNames) {
+    List<DomainUploadTask> submitUploadTasks(ExecutorService executor, List<String> domainNames, boolean isRefresh) {
         List<DomainUploadTask> tasks = new ArrayList<>(domainNames.size());
         for (String domainName : domainNames) {
-            tasks.add(new DomainUploadTask(domainName, executor.submit(() -> uploadDomain(domainName))));
+            tasks.add(new DomainUploadTask(domainName, executor.submit(() -> uploadDomain(domainName, isRefresh))));
         }
         return tasks;
     }

--- a/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/Config.java
+++ b/libs/java/syncer_common/src/main/java/io/athenz/syncer/common/zms/Config.java
@@ -46,6 +46,8 @@ public class Config {
     static final String DEFAULT_STATE_BUILDER_TIMEOUT = "1800";
     static final String DEFAULT_DOMAIN_REFRESH_COUNT = "10";
     static final String DEFAULT_DOMAIN_REFRESH_TIMEOUT = "2592000";
+    static final String DEFAULT_DOMAIN_UPDATE_FETCH_THREADS = "1";
+    static final String DEFAULT_DOMAIN_REFRESH_FETCH_THREADS = "1";
     static final String DEFAULT_JSON_MAX_NESTING_DEPTH = "1000";
     static final String DEFAULT_JSON_MAX_NUMBER_LENGTH = "1000";
     static final String DEFAULT_JSON_MAX_STRING_LENGTH = "200000000";
@@ -76,6 +78,8 @@ public class Config {
     public static final String SYNC_CFG_PARAM_STATE_BUILDER_TIMEOUT = "state_builder_timeout";
     public static final String SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT = "domain_refresh_count";
     public static final String SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT = "domain_refresh_timeout";
+    public static final String SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS = "domain_update_fetch_threads";
+    public static final String SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS = "domain_refresh_fetch_threads";
     public static final String SYNC_CFG_PARAM_JSON_MAX_NESTING_DEPTH = "json_max_nesting_depth";
     public static final String SYNC_CFG_PARAM_JSON_MAX_NUMBER_LENGTH = "json_max_number_length";
     public static final String SYNC_CFG_PARAM_JSON_MAX_STRING_LENGTH = "json_max_string_length";
@@ -103,6 +107,8 @@ public class Config {
             SYNC_CFG_PARAM_STATE_BUILDER_TIMEOUT,
             SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT,
             SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT,
+            SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS,
+            SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS,
             SYNC_CFG_PARAM_JSON_MAX_NESTING_DEPTH,
             SYNC_CFG_PARAM_JSON_MAX_NUMBER_LENGTH,
             SYNC_CFG_PARAM_JSON_MAX_STRING_LENGTH
@@ -262,6 +268,8 @@ public class Config {
             propertyMap.putIfAbsent(SYNC_CFG_PARAM_STATE_BUILDER_TIMEOUT, DEFAULT_STATE_BUILDER_TIMEOUT);
             propertyMap.putIfAbsent(SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT, DEFAULT_DOMAIN_REFRESH_COUNT);
             propertyMap.putIfAbsent(SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT, DEFAULT_DOMAIN_REFRESH_TIMEOUT);
+            propertyMap.putIfAbsent(SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS, DEFAULT_DOMAIN_UPDATE_FETCH_THREADS);
+            propertyMap.putIfAbsent(SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS, DEFAULT_DOMAIN_REFRESH_FETCH_THREADS);
             propertyMap.putIfAbsent(SYNC_CFG_PARAM_JSON_MAX_NESTING_DEPTH, DEFAULT_JSON_MAX_NESTING_DEPTH);
             propertyMap.putIfAbsent(SYNC_CFG_PARAM_JSON_MAX_NUMBER_LENGTH, DEFAULT_JSON_MAX_NUMBER_LENGTH);
             propertyMap.putIfAbsent(SYNC_CFG_PARAM_JSON_MAX_STRING_LENGTH, DEFAULT_JSON_MAX_STRING_LENGTH);

--- a/libs/java/syncer_common/src/test/java/io/athenz/syncer/common/zms/CloudZmsSyncerTest.java
+++ b/libs/java/syncer_common/src/test/java/io/athenz/syncer/common/zms/CloudZmsSyncerTest.java
@@ -35,10 +35,14 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
@@ -484,6 +488,50 @@ public class CloudZmsSyncerTest {
     }
 
     @Test
+    public void testSyncDomainsParallel() throws Exception {
+        System.out.println("testSyncDomainsParallel");
+        // set state file that will cause some domains to be deleted
+        Config.getInstance().loadConfigParams();
+        System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS, "4");
+        System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS, "4");
+        Config.getInstance().loadConfigParams();
+
+        try {
+            DomainValidator validator = Mockito.mock(DomainValidator.class);
+            when(validator.validateJWSDomain(any())).thenReturn(true);
+            DomainValidator domainValidator = new DomainValidator();
+            when(validator.getDomainData(any())).thenAnswer(invocationOnMock -> {
+                Object[] arguments = invocationOnMock.getArguments();
+                return domainValidator.getDomainData((JWSDomain) arguments[0]);
+            });
+
+            CloudDomainStore cloudDomainStore = Mockito.mock(CloudDomainStore.class);
+            ZmsReader zmsReader = new ZmsReader(mockZMSClt, validator);
+
+            S3Client s3Client = Mockito.mock(S3Client.class);
+            StateFileBuilder stateFileBuilder = Mockito.mock(StateFileBuilder.class);
+
+            CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder);
+
+            Map<String, DomainState> stateMap = zmsSyncer.loadState();
+            assertNotNull(stateMap);
+            assertTrue(zmsSyncer.syncDomains(stateMap));
+            assertTrue(zmsSyncer.saveDomainsState());
+            assertEquals(zmsSyncer.getNumDomainsUploaded(), 4);
+            // 1 was up-to-date
+            assertEquals(zmsSyncer.getNumDomainsNotUploaded(), 1);
+            assertEquals(zmsSyncer.getNumDomainsUploadFailed(), 0);
+            // delete paas
+            assertEquals(zmsSyncer.getNumDomainsDeleted(), 1);
+            assertEquals(zmsSyncer.getNumDomainsDeletedFailed(), 0);
+        } finally {
+            System.clearProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS);
+            System.clearProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS);
+            Config.getInstance().loadConfigParams();
+        }
+    }
+
+    @Test
     public void testSyncDomainsNoList() {
         System.out.println("testSyncDomainsNoList");
 
@@ -612,36 +660,27 @@ public class CloudZmsSyncerTest {
         StateFileBuilder stateFileBuilder = Mockito.mock(StateFileBuilder.class);
 
         CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder);
-        assertFalse(zmsSyncer.shouldRefreshDomain(null, 10000, 10, 3600));
+        assertFalse(zmsSyncer.shouldRefreshDomain(null, 10000, 3600));
 
-        // test refresh limit reached
-
-        zmsSyncer.setNumDomainsRefreshed(10);
         DomainState state = new DomainState();
         state.setFetchTime(1000);
 
-        assertFalse(zmsSyncer.shouldRefreshDomain(state, 10000, 10, 9500));
+        // with time matching we should get success
 
-        zmsSyncer.setNumDomainsRefreshed(11);
-        assertFalse(zmsSyncer.shouldRefreshDomain(state, 10000, 10, 9500));
-
-        // with limit lower we should get success
-
-        zmsSyncer.setNumDomainsRefreshed(9);
-        assertTrue(zmsSyncer.shouldRefreshDomain(state, 10000, 10, 8500));
+        assertTrue(zmsSyncer.shouldRefreshDomain(state, 10000, 8500));
 
         // if the value is 0 then it's false
 
         state.setFetchTime(0);
-        assertFalse(zmsSyncer.shouldRefreshDomain(state, 10000, 10, 9500));
+        assertFalse(zmsSyncer.shouldRefreshDomain(state, 10000, 9500));
 
         // test where refresh is not necessary
 
         state.setFetchTime(600);
-        assertFalse(zmsSyncer.shouldRefreshDomain(state, 10000, 10, 9500));
+        assertFalse(zmsSyncer.shouldRefreshDomain(state, 10000, 9500));
 
         state.setFetchTime(400);
-        assertTrue(zmsSyncer.shouldRefreshDomain(state, 10000, 10, 9500));
+        assertTrue(zmsSyncer.shouldRefreshDomain(state, 10000, 9500));
     }
 
     @Test
@@ -651,7 +690,10 @@ public class CloudZmsSyncerTest {
 
         // Set up a short refresh timeout to ensure domains need refreshing
         System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT, "300");
-        System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT, "5");
+        // Set the limit lower than the number of domains that need refresh
+        System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT, "2");
+        System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS, "4");
+        System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS, "4");
         Config.getInstance().loadConfigParams();
 
         DomainValidator validator = Mockito.mock(DomainValidator.class);
@@ -668,23 +710,34 @@ public class CloudZmsSyncerTest {
 
         CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder);
 
-        // Create a state map with a domain that needs refreshing
+        // Create a state map with domains that need refreshing
         Map<String, DomainState> stateMap = new HashMap<>();
-        DomainState staleState = new DomainState();
-        staleState.setDomain("clouds");
-        staleState.setModified("2023-01-01T00:00:00.000Z"); // Make sure modified time matches what ZMS returns
-        staleState.setFetchTime(System.currentTimeMillis()/1000 - 600); // Set fetch time to 10 minutes ago
-        stateMap.put("clouds", staleState);
+
+        // Use domains that are part of the mock ZMS response in MockZmsClient
+        // coretech, clouds, moon, pluto, coriander
 
         try {
+            // First we need to get the exact modification times from the mock to prevent "uploadDom = true"
+            List<SignedDomain> mockDomainList = zmsReader.getDomainList();
+            for (SignedDomain sDom : mockDomainList) {
+                String domName = sDom.getDomain().getName();
+                DomainState staleState = new DomainState();
+                staleState.setDomain(domName);
+                // Modified time matching exactly what ZMS returns will force refresh logic (not upload)
+                staleState.setModified(sDom.getDomain().getModified().toString());
+                staleState.setFetchTime(System.currentTimeMillis()/1000 - 600); // 10 minutes ago
+                stateMap.put(domName, staleState);
+            }
+
             // Before syncing, the count should be 0
-            assertEquals(0, zmsSyncer.getNumDomainsRefreshed());
+            assertEquals(zmsSyncer.getNumDomainsRefreshed(), 0);
 
             // Perform sync
             zmsSyncer.syncDomains(stateMap);
 
-            // After syncing, verify that numDomainsRefreshed was incremented
-            assertEquals(1, zmsSyncer.getNumDomainsRefreshed());
+            // After syncing, verify that numDomainsRefreshed was incremented,
+            // but exactly up to the limit (2)
+            assertEquals(zmsSyncer.getNumDomainsRefreshed(), 2);
 
         } catch (Exception e) {
             fail("Test failed with exception: " + e.getMessage());
@@ -692,6 +745,8 @@ public class CloudZmsSyncerTest {
             // Clean up
             System.clearProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_TIMEOUT);
             System.clearProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT);
+            System.clearProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS);
+            System.clearProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS);
         }
     }
 
@@ -729,6 +784,173 @@ public class CloudZmsSyncerTest {
         // delete paas
         assertEquals(zmsSyncer.getNumDomainsDeleted(), 0);
         assertEquals(zmsSyncer.getNumDomainsDeletedFailed(), 1);
+    }
+
+    @Test
+    public void testSyncDomainsThreadConfigNormalization() throws Exception {
+        System.out.println("testSyncDomainsThreadConfigNormalization");
+        Config.getInstance().loadConfigParams();
+        System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS, "0");
+        System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS, "0");
+        System.setProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT, "-1");
+        Config.getInstance().loadConfigParams();
+
+        try {
+            DomainValidator validator = Mockito.mock(DomainValidator.class);
+            when(validator.validateJWSDomain(any())).thenReturn(true);
+            DomainValidator domainValidator = new DomainValidator();
+            when(validator.getDomainData(any())).thenAnswer(invocationOnMock -> {
+                Object[] arguments = invocationOnMock.getArguments();
+                return domainValidator.getDomainData((JWSDomain) arguments[0]);
+            });
+
+            CloudDomainStore cloudDomainStore = Mockito.mock(CloudDomainStore.class);
+            ZmsReader zmsReader = new ZmsReader(mockZMSClt, validator);
+            StateFileBuilder stateFileBuilder = Mockito.mock(StateFileBuilder.class);
+
+            CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder);
+            Map<String, DomainState> stateMap = zmsSyncer.loadState();
+            assertNotNull(stateMap);
+            assertTrue(zmsSyncer.syncDomains(stateMap));
+        } finally {
+            System.clearProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS);
+            System.clearProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS);
+            System.clearProperty(Config.PROP_PREFIX + Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_COUNT);
+            Config.getInstance().loadConfigParams();
+        }
+    }
+
+    @Test
+    public void testSyncDomainsExecutionExceptionPath() throws Exception {
+        System.out.println("testSyncDomainsExecutionExceptionPath");
+        Config.getInstance().loadConfigParams();
+
+        DomainValidator validator = Mockito.mock(DomainValidator.class);
+        when(validator.validateJWSDomain(any())).thenReturn(true);
+        DomainValidator domainValidator = new DomainValidator();
+        when(validator.getDomainData(any())).thenAnswer(invocationOnMock -> {
+            Object[] arguments = invocationOnMock.getArguments();
+            return domainValidator.getDomainData((JWSDomain) arguments[0]);
+        });
+
+        CloudDomainStore cloudDomainStore = Mockito.mock(CloudDomainStore.class);
+        ZmsReader zmsReader = new ZmsReader(mockZMSClt, validator);
+        StateFileBuilder stateFileBuilder = Mockito.mock(StateFileBuilder.class);
+
+        CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder) {
+            @Override
+            DomainState uploadDomain(final String domainName) {
+                throw new RuntimeException("injected upload failure");
+            }
+        };
+
+        assertFalse(zmsSyncer.syncDomains(new HashMap<>()));
+        assertTrue(zmsSyncer.getNumDomainsUploadFailed() > 0);
+        assertTrue(zmsSyncer.saveRunState(null));
+
+        String stateFileName = Config.getInstance().getConfigParam(Config.SYNC_CFG_PARAM_STATE_PATH) + CloudZmsSyncer.RUN_STATE_FILE;
+        Struct rState = Config.getInstance().parseJsonConfigFile(stateFileName);
+        assertEquals(rState.getInt(CloudZmsSyncer.RUN_STATUS_FIELD), 1);
+    }
+
+    @Test
+    public void testAddFailedDomainStateIncrementsUploadFailed() throws Exception {
+        System.out.println("testAddFailedDomainStateIncrementsUploadFailed");
+
+        CloudDomainStore cloudDomainStore = Mockito.mock(CloudDomainStore.class);
+        ZmsReader zmsReader = Mockito.mock(ZmsReader.class);
+        StateFileBuilder stateFileBuilder = Mockito.mock(StateFileBuilder.class);
+        CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder);
+
+        java.lang.reflect.Field field = CloudZmsSyncer.class.getDeclaredField("processedDomains");
+        field.setAccessible(true);
+        field.set(zmsSyncer, new ArrayList<DomainState>());
+
+        Method addFailedMethod = CloudZmsSyncer.class.getDeclaredMethod("addFailedDomainState", String.class);
+        addFailedMethod.setAccessible(true);
+        addFailedMethod.invoke(zmsSyncer, "domain.one");
+
+        @SuppressWarnings("unchecked")
+        List<DomainState> processed = (List<DomainState>) field.get(zmsSyncer);
+        assertEquals(processed.size(), 1);
+        assertEquals(processed.get(0).getDomain(), "domain.one");
+        assertEquals(processed.get(0).getModified(), CloudZmsSyncer.LAST_MOD_NO_DATE);
+        assertEquals(zmsSyncer.getNumDomainsUploadFailed(), 1);
+    }
+
+    @Test
+    public void testCollectProcessedDomainsInterruptedPath() throws Exception {
+        System.out.println("testCollectProcessedDomainsInterruptedPath");
+
+        CloudDomainStore cloudDomainStore = Mockito.mock(CloudDomainStore.class);
+        ZmsReader zmsReader = Mockito.mock(ZmsReader.class);
+        StateFileBuilder stateFileBuilder = Mockito.mock(StateFileBuilder.class);
+        CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder);
+
+        // initialize processedDomains so collectProcessedDomains can store fallback states
+        Method method = CloudZmsSyncer.class.getDeclaredMethod("collectProcessedDomains", List.class);
+        method.setAccessible(true);
+
+        java.lang.reflect.Field field = CloudZmsSyncer.class.getDeclaredField("processedDomains");
+        field.setAccessible(true);
+        field.set(zmsSyncer, new ArrayList<DomainState>());
+
+        class InterruptFuture implements Future<DomainState> {
+            boolean cancelled = false;
+
+            @Override
+            public boolean cancel(boolean mayInterruptIfRunning) {
+                cancelled = true;
+                return true;
+            }
+
+            @Override
+            public boolean isCancelled() {
+                return cancelled;
+            }
+
+            @Override
+            public boolean isDone() {
+                return false;
+            }
+
+            @Override
+            public DomainState get() throws InterruptedException, ExecutionException {
+                throw new InterruptedException("interrupted");
+            }
+
+            @Override
+            public DomainState get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException {
+                throw new InterruptedException("interrupted");
+            }
+        }
+
+        InterruptFuture firstFuture = new InterruptFuture();
+        InterruptFuture secondFuture = new InterruptFuture();
+
+        List<CloudZmsSyncer.DomainUploadTask> tasks = new ArrayList<>();
+        tasks.add(new CloudZmsSyncer.DomainUploadTask("domain.one", firstFuture));
+        tasks.add(new CloudZmsSyncer.DomainUploadTask("domain.two", secondFuture));
+
+        try {
+            boolean result = (boolean) method.invoke(zmsSyncer, tasks);
+            assertFalse(result);
+            assertTrue(Thread.currentThread().isInterrupted());
+        } finally {
+            // clear interrupt flag so other tests are not affected
+            Thread.interrupted();
+        }
+
+        @SuppressWarnings("unchecked")
+        List<DomainState> processed = (List<DomainState>) field.get(zmsSyncer);
+        assertEquals(processed.size(), 2);
+        assertEquals(processed.get(0).getDomain(), "domain.one");
+        assertEquals(processed.get(0).getModified(), CloudZmsSyncer.LAST_MOD_NO_DATE);
+        assertEquals(processed.get(1).getDomain(), "domain.two");
+        assertEquals(processed.get(1).getModified(), CloudZmsSyncer.LAST_MOD_NO_DATE);
+        assertEquals(zmsSyncer.getNumDomainsUploadFailed(), 2);
+        assertTrue(firstFuture.cancelled);
+        assertTrue(secondFuture.cancelled);
     }
 
     @Test

--- a/libs/java/syncer_common/src/test/java/io/athenz/syncer/common/zms/CloudZmsSyncerTest.java
+++ b/libs/java/syncer_common/src/test/java/io/athenz/syncer/common/zms/CloudZmsSyncerTest.java
@@ -266,7 +266,7 @@ public class CloudZmsSyncerTest {
         StateFileBuilder stateFileBuilder = Mockito.mock(StateFileBuilder.class);
 
         CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder);
-        DomainState stateObj = zmsSyncer.uploadDomain("clouds");
+        DomainState stateObj = zmsSyncer.uploadDomain("clouds", false);
         assertNotNull(stateObj);
         assertNotEquals(stateObj.getModified(), "0");
         assertEquals(zmsSyncer.getNumDomainsUploaded(), 1);
@@ -292,7 +292,7 @@ public class CloudZmsSyncerTest {
         StateFileBuilder stateFileBuilder = Mockito.mock(StateFileBuilder.class);
 
         CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder);
-        DomainState stateObj = zmsSyncer.uploadDomain("no_such_domain");
+        DomainState stateObj = zmsSyncer.uploadDomain("no_such_domain", false);
         assertNotNull(stateObj);
         assertEquals(stateObj.getModified(), "0");
         assertEquals(zmsSyncer.getNumDomainsUploaded(), 0);
@@ -375,7 +375,7 @@ public class CloudZmsSyncerTest {
         StateFileBuilder stateFileBuilder = Mockito.mock(StateFileBuilder.class);
 
         CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder);
-        DomainState stateObj = zmsSyncer.uploadDomain("clouds");
+        DomainState stateObj = zmsSyncer.uploadDomain("clouds", false);
         assertNotNull(stateObj);
         assertEquals(stateObj.getModified(), "0");
         assertEquals(zmsSyncer.getNumDomainsUploaded(), 0);
@@ -839,7 +839,7 @@ public class CloudZmsSyncerTest {
 
         CloudZmsSyncer zmsSyncer = new CloudZmsSyncer(cloudDomainStore, zmsReader, stateFileBuilder) {
             @Override
-            DomainState uploadDomain(final String domainName) {
+            DomainState uploadDomain(final String domainName, boolean isRefresh) {
                 throw new RuntimeException("injected upload failure");
             }
         };

--- a/libs/java/syncer_common/src/test/java/io/athenz/syncer/common/zms/ConfigTest.java
+++ b/libs/java/syncer_common/src/test/java/io/athenz/syncer/common/zms/ConfigTest.java
@@ -70,6 +70,8 @@ public class ConfigTest {
         Assert.assertEquals(configInstance.getConfigParam(Config.SYNC_CFG_PARAM_TRUST_STORE_PASSWORD), "truststore_password");
         Assert.assertEquals(configInstance.getConfigParam(Config.SYNC_CFG_PARAM_STATE_BUILDER_THREADS), "10");
         Assert.assertEquals(configInstance.getConfigParam(Config.SYNC_CFG_PARAM_STATE_BUILDER_TIMEOUT), "1800");
+        Assert.assertEquals(configInstance.getConfigParam(Config.SYNC_CFG_PARAM_DOMAIN_UPDATE_FETCH_THREADS), "1");
+        Assert.assertEquals(configInstance.getConfigParam(Config.SYNC_CFG_PARAM_DOMAIN_REFRESH_FETCH_THREADS), "1");
     }
 
     @Test
@@ -219,4 +221,3 @@ public class ConfigTest {
     }
 
 }
-

--- a/syncers/zms_aws_domain_syncer/README.md
+++ b/syncers/zms_aws_domain_syncer/README.md
@@ -44,3 +44,11 @@ aws_s3_ca_cert=<path to CA certificate file>
 \# ResponseChecksumValidation.WHEN_REQUIRED for S3 client operations
 \# If not specified, uses SDK default behavior (WHEN_SUPPORTED)
 aws_s3_use_checksum_validation_when_required=<true|false>
+
+\# Number of threads to use for change-based domain updates.
+\# Default = 1
+domain_update_fetch_threads=<number of threads>
+
+\# Number of threads to use for timeout-based domain refreshes.
+\# Default = 1
+domain_refresh_fetch_threads=<number of threads>


### PR DESCRIPTION
# Description
Parallelize domain fetch and upload in CloudZmsSyncer to improve sync performance in environments with a large number of domains. Separate thread pools are used for updates and refreshes respectively. Thread counts are configurable, defaulting to 1 (same as existing behavior) for backward compatibility.

- Add parallel domain fetch and upload support to `CloudZmsSyncer` using configurable thread pools for both domain updates and domain refreshes
- Introduce `DomainUploadTask` class to track async upload tasks with `Future`-based result handling
- Convert domain counters from `int` to `AtomicInteger` for thread-safe concurrent access
- Separate refresh count limiting from `shouldRefreshDomain()` into the caller, making the method simpler and the limit enforcement more explicit
- Add robust error handling: `InterruptedException` restores the interrupt flag and marks remaining tasks as failed; `ExecutionException` records individual domain failures
- New configuration parameters: `domain_update_fetch_threads` and `domain_refresh_fetch_threads` (default: 1, preserving single-threaded behavior)

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

