### PR TITLE
disallow * member in roles if filters are configured

### DIFF
--- a/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/Principal.java
+++ b/libs/java/auth_core/src/main/java/com/yahoo/athenz/auth/Principal.java
@@ -24,7 +24,7 @@ import java.util.List;
 public interface Principal {
 
     /**
-     * Principal type - user, service, group, external or unknown
+     * Principal type - user, service, group, external, all or unknown
      */
     enum Type {
         UNKNOWN(0),
@@ -32,7 +32,8 @@ public interface Principal {
         SERVICE(2),
         GROUP(3),
         USER_HEADLESS(4),
-        EXTERNAL(5);
+        EXTERNAL(5),
+        ALL(6);
 
         private final int principalType;
         Type(int type) {

--- a/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/PrincipalTest.java
+++ b/libs/java/auth_core/src/test/java/com/yahoo/athenz/auth/PrincipalTest.java
@@ -119,12 +119,19 @@ public class PrincipalTest {
         type = Principal.Type.USER_HEADLESS;
         assertEquals(type.getValue(), 4);
 
+        type = Principal.Type.EXTERNAL;
+        assertEquals(type.getValue(), 5);
+
+        type = Principal.Type.ALL;
+        assertEquals(type.getValue(), 6);
+
         assertEquals(Principal.Type.getType(0), Principal.Type.UNKNOWN);
         assertEquals(Principal.Type.getType(1), Principal.Type.USER);
         assertEquals(Principal.Type.getType(2), Principal.Type.SERVICE);
         assertEquals(Principal.Type.getType(3), Principal.Type.GROUP);
         assertEquals(Principal.Type.getType(4), Principal.Type.USER_HEADLESS);
         assertEquals(Principal.Type.getType(5), Principal.Type.EXTERNAL);
-        assertEquals(Principal.Type.getType(6), Principal.Type.UNKNOWN);
+        assertEquals(Principal.Type.getType(6), Principal.Type.ALL);
+        assertEquals(Principal.Type.getType(7), Principal.Type.UNKNOWN);
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/PrincipalUtils.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/util/PrincipalUtils.java
@@ -27,6 +27,10 @@ public class PrincipalUtils {
     public static Principal.Type principalType(final String memberName, final String userDomainPrefix,
             final List<String> addlUserCheckDomainPrefixList, final String headlessUserDomainPrefix) {
 
+        if ("*".equals(memberName)) {
+            return Principal.Type.ALL;
+        }
+
         if (isUserDomainPrincipal(memberName, userDomainPrefix, addlUserCheckDomainPrefixList)) {
             return Principal.Type.USER;
         } else if (isHeadlessUserDomainPrincipal(memberName, headlessUserDomainPrefix)) {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/AthenzDomainTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/AthenzDomainTest.java
@@ -345,4 +345,21 @@ public class AthenzDomainTest {
         assertEquals(athenzDomain.getRoles().get(0).getRoleMembers().get(0).getPrincipalType(), 
                 Principal.Type.GROUP.getValue());
     }
+
+    @Test
+    public void testSetRoleMemberPrincipalTypesAllType() {
+        AthenzDomain athenzDomain = new AthenzDomain("test-domain");
+        List<Role> roles = new ArrayList<>();
+        Role role = new Role().setName("role1");
+        List<RoleMember> roleMembers = new ArrayList<>();
+        roleMembers.add(new RoleMember().setMemberName("*"));
+        role.setRoleMembers(roleMembers);
+        roles.add(role);
+        athenzDomain.setRoles(roles);
+
+        athenzDomain.setRoleMemberPrincipalTypes("user", null, "headless");
+
+        assertEquals(athenzDomain.getRoles().get(0).getRoleMembers().get(0).getPrincipalType(),
+                Principal.Type.ALL.getValue());
+    }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/PrincipalUtilsTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/util/PrincipalUtilsTest.java
@@ -36,6 +36,9 @@ public class PrincipalUtilsTest {
         String groupSep = ":group";
         List<String> addlUserCheckDomainPrefixList = Arrays.asList(userDomain2);
 
+        // ALL
+        assertEquals(PrincipalUtils.principalType("*", userDomain, addlUserCheckDomainPrefixList,
+            headlessDomain), Principal.Type.ALL);
         // GROUP
         assertEquals(PrincipalUtils.principalType(homeDomain + ".joe" + groupSep + ".test-group", userDomain,
                 addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);
@@ -68,6 +71,9 @@ public class PrincipalUtilsTest {
         userDomain = "personal";
         homeDomain = userDomain;
 
+        // ALL
+        assertEquals(PrincipalUtils.principalType("*", userDomain, addlUserCheckDomainPrefixList,
+            headlessDomain), Principal.Type.ALL);
         // GROUP
         assertEquals(PrincipalUtils.principalType(homeDomain + ".joe" + groupSep + ".test-group", userDomain,
                 addlUserCheckDomainPrefixList, headlessDomain), Principal.Type.GROUP);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBService.java
@@ -7714,6 +7714,7 @@ public class DBService implements RolesProvider, DomainProvider {
                 case SERVICE:
                 case USER_HEADLESS:
                 case EXTERNAL:
+                case ALL:
 
                     if (isEarlierDueDate(serviceExpiryMillis, expiration)) {
                         expirationSetter.accept(member, serviceExpiration);

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -4910,6 +4910,21 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
                 externalMemberValidatorManager.validateMember(domainName, memberName, caller);
                 break;
+
+            case ALL:
+
+                // if we have a full wildcard member then we're going to allow it
+                // as long as there are no other user filtering rules in place
+
+                if (userAuthority != null && validateUserRoleMembers.get()
+                        && (userAuthorityFilterSet != null || !StringUtil.isEmpty(userAuthorityExpiration))) {
+                    throw ZMSUtils.requestError("Wildcard member is not allowed with user authority filter or expiration", caller);
+                }
+
+                break;
+
+            default:
+                break;
         }
 
         return userType;
@@ -4922,9 +4937,10 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         Authority.UserType userType = Authority.UserType.USER_ACTIVE;
         Principal.Type type = Principal.Type.getType(principalType);
 
-        // we do not support group members and any type of wildcards in group members
+        // we do not support group members, all/wildcard members, and any type of wildcards in group members
 
-        if (type == Principal.Type.UNKNOWN || type == Principal.Type.GROUP || memberName.indexOf('*') != -1) {
+        if (type == Principal.Type.UNKNOWN || type == Principal.Type.GROUP || type == Principal.Type.ALL
+                || memberName.indexOf('*') != -1) {
             throw ZMSUtils.requestError("Principal " + memberName + " is not valid", caller);
         }
 
@@ -4961,8 +4977,11 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
             case EXTERNAL:
 
-            externalMemberValidatorManager.validateMember(domainName, memberName, caller);
-            break;
+                externalMemberValidatorManager.validateMember(domainName, memberName, caller);
+                break;
+
+            default:
+                break;
         }
 
         return userType;
@@ -5177,6 +5196,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 case SERVICE:
                 case USER_HEADLESS:
                 case EXTERNAL:
+                case ALL:
                     if (cfgServiceMemberDueDateMillis != 0) {
                         Timestamp newDueDate = getMemberDueDate(cfgServiceMemberDueDateMillis, currentDueDate);
                         dueDateSetter.accept(member, newDueDate);
@@ -5187,6 +5207,8 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                         Timestamp newDueDate = getMemberDueDate(cfgGroupMemberDueDateMillis, currentDueDate);
                         dueDateSetter.accept(member, newDueDate);
                     }
+                    break;
+                default:
                     break;
             }
         }
@@ -5368,6 +5390,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             case SERVICE:
             case USER_HEADLESS:
             case EXTERNAL:
+            case ALL:
 
                 roleMember.setExpiration(getMemberDueDate(memberExpiryDueDays.getServiceDueDateMillis(), membership.getExpiration()));
                 break;
@@ -5375,6 +5398,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             case GROUP:
 
                 roleMember.setExpiration(getMemberDueDate(memberExpiryDueDays.getGroupDueDateMillis(), membership.getExpiration()));
+                break;
+
+            default:
                 break;
         }
     }
@@ -5391,11 +5417,15 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             case SERVICE:
             case USER_HEADLESS:
             case EXTERNAL:
+            case ALL:
                 roleMember.setReviewReminder(getMemberDueDate(memberReminderDueDays.getServiceDueDateMillis(), membership.getReviewReminder()));
                 break;
 
             case GROUP:
                 roleMember.setReviewReminder(getMemberDueDate(memberReminderDueDays.getGroupDueDateMillis(), membership.getReviewReminder()));
+                break;
+
+            default:
                 break;
         }
     }
@@ -11819,6 +11849,12 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
             case GROUP:
                 throw ZMSUtils.requestError("Group member can't be of type group", caller);
+
+            case ALL:
+                throw ZMSUtils.requestError("Group member can't be of type all", caller);
+
+            default:
+                break;
         }
     }
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/PrincipalDomainFilter.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/utils/PrincipalDomainFilter.java
@@ -71,6 +71,14 @@ public class PrincipalDomainFilter {
             return true;
         }
 
+        // the ALL type represents the wildcard "*" member which applies
+        // to all principals - so if we have any type of filtering enabled
+        // then having an ALL type is not allowed
+
+        if (type == Principal.Type.ALL) {
+            return false;
+        }
+
         // let's first extract our domain name: special handling
         // for groups while all other types are standard service names
         // since we're given the principal type, it's already been

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -21776,6 +21776,83 @@ public class ZMSImplTest {
     }
 
     @Test
+    public void testValidateRoleMemberPrincipalAll() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+
+        Authority savedAuthority = zmsImpl.userAuthority;
+        DynamicConfigBoolean savedValidateUserRoleMembers = zmsImpl.validateUserRoleMembers;
+
+        // case 1: userAuthority is null - wildcard member should be accepted
+
+        zmsImpl.userAuthority = null;
+        zmsImpl.validateUserRoleMembers = new DynamicConfigBoolean(true);
+
+        zmsImpl.validateRoleMemberPrincipal("athenz", "role1", "*", Principal.Type.ALL.getValue(), null, null,
+                null, null, false, "unittest");
+
+        // case 2: userAuthority is set but validateUserRoleMembers is false
+
+        zmsImpl.userAuthority = new TestUserPrincipalAuthority();
+        zmsImpl.validateUserRoleMembers = new DynamicConfigBoolean(false);
+
+        zmsImpl.validateRoleMemberPrincipal("athenz", "role1", "*", Principal.Type.ALL.getValue(),
+                Set.of("employee"), null, null, null, false, "unittest");
+
+        // case 3: userAuthority is set, validateUserRoleMembers is true,
+        // but both filterSet and expiration are null - should succeed
+
+        zmsImpl.validateUserRoleMembers = new DynamicConfigBoolean(true);
+
+        zmsImpl.validateRoleMemberPrincipal("athenz", "role1", "*", Principal.Type.ALL.getValue(), null, null,
+                null, null, false, "unittest");
+
+        // also with empty string expiration - should succeed
+
+        zmsImpl.validateRoleMemberPrincipal("athenz", "role1", "*", Principal.Type.ALL.getValue(), null, "",
+                null, null, false, "unittest");
+
+        // case 4: userAuthority is set, validateUserRoleMembers is true,
+        // userAuthorityFilterSet is not null - should throw
+
+        try {
+            zmsImpl.validateRoleMemberPrincipal("athenz", "role1", "*", Principal.Type.ALL.getValue(),
+                    Set.of("employee"), null, null, null, false, "unittest");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
+            assertTrue(ex.getMessage().contains("Wildcard member is not allowed"));
+        }
+
+        // case 5: userAuthority is set, validateUserRoleMembers is true,
+        // userAuthorityExpiration is not empty - should throw
+
+        try {
+            zmsImpl.validateRoleMemberPrincipal("athenz", "role1", "*", Principal.Type.ALL.getValue(),
+                    null, "expiry", null, null, false, "unittest");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
+            assertTrue(ex.getMessage().contains("Wildcard member is not allowed"));
+        }
+
+        // case 6: userAuthority is set, validateUserRoleMembers is true,
+        // both filterSet and expiration are set - should throw
+
+        try {
+            zmsImpl.validateRoleMemberPrincipal("athenz", "role1", "*", Principal.Type.ALL.getValue(),
+                    Set.of("contractor"), "expiry", null, null, false, "unittest");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
+            assertTrue(ex.getMessage().contains("Wildcard member is not allowed"));
+        }
+
+        zmsImpl.userAuthority = savedAuthority;
+        zmsImpl.validateUserRoleMembers = savedValidateUserRoleMembers;
+    }
+
+    @Test
     public void testValidateRoleMemberPrincipalService() {
 
         ZMSImpl zmsImpl = zmsTestInitializer.getZms();
@@ -21913,6 +21990,14 @@ public class ZMSImplTest {
 
         try {
             zmsImpl.validateGroupMemberPrincipal("athenz", "group1", "*", Principal.Type.SERVICE.getValue(), null,
+                    null, "unittest");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.BAD_REQUEST);
+        }
+
+        try {
+            zmsImpl.validateGroupMemberPrincipal("athenz", "group1", "*", Principal.Type.ALL.getValue(), null,
                     null, "unittest");
             fail();
         } catch (ResourceException ex) {

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/PrincipalDomainFilterTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/utils/PrincipalDomainFilterTest.java
@@ -63,6 +63,7 @@ public class PrincipalDomainFilterTest {
         assertNull(filter.allowedSubDomains);
         assertTrue(filter.validate(null, Principal.Type.USER));
         assertTrue(filter.validate(null, Principal.Type.GROUP));
+        assertTrue(filter.validate(null, Principal.Type.ALL));
 
         filter = new PrincipalDomainFilter(null);
         assertNull(filter.allowedDomains);
@@ -70,6 +71,7 @@ public class PrincipalDomainFilterTest {
         assertNull(filter.allowedSubDomains);
         assertTrue(filter.validate(null, Principal.Type.USER));
         assertTrue(filter.validate(null, Principal.Type.GROUP));
+        assertTrue(filter.validate(null, Principal.Type.ALL));
 
         // now let's test some valid filters
 
@@ -149,6 +151,13 @@ public class PrincipalDomainFilterTest {
                 { "+sports,-sports.prod", "sports:ext.partner", Principal.Type.EXTERNAL, true },
                 { "+sports,-sports.prod", "sports.dev:ext.partner", Principal.Type.EXTERNAL, true },
                 { "+sports,-sports.prod", "sports.prod:ext.partner", Principal.Type.EXTERNAL, false },
+                { "user", "*", Principal.Type.ALL, false },
+                { "+sports", "*", Principal.Type.ALL, false },
+                { "-home", "*", Principal.Type.ALL, false },
+                { "+sports,-sports.prod", "*", Principal.Type.ALL, false },
+                { "user,+sports", "*", Principal.Type.ALL, false },
+                { "user,-home", "*", Principal.Type.ALL, false },
+                { "user,+sports,-sports.prod", "*", Principal.Type.ALL, false },
         };
     }
     @Test(dataProvider = "DomainFilterData")
@@ -209,7 +218,22 @@ public class PrincipalDomainFilterTest {
         role1.setPrincipalDomainFilter("user,+sports,-sports.prod");
         zmsImpl.putRole(ctx, domainName, roleName1, auditRef, false, null, role1);
 
-        // add a role with the domain filter and no allowed members
+        // wildcard * member should be rejected when domain filter is set
+
+        roleMembers = new ArrayList<>();
+        roleMembers.add(new RoleMember().setMemberName("user.user1"));
+        roleMembers.add(new RoleMember().setMemberName("*"));
+        role1.setRoleMembers(roleMembers);
+
+        try {
+            zmsImpl.putRole(ctx, domainName, roleName1, auditRef, false, null, role1);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Principal * is not allowed for the role"));
+        }
+
+        // add a role with the domain filter and disallowed members
 
         roleMembers = new ArrayList<>();
         roleMembers.add(new RoleMember().setMemberName("user.user1"));
@@ -313,6 +337,17 @@ public class PrincipalDomainFilterTest {
             assertEquals(ex.getMessage().contains("Principal sports.prod.api is not allowed for the role"), true);
         }
 
+        // wildcard * member should be rejected when domain filter is set
+
+        membership = new Membership().setMemberName("*");
+        try {
+            zmsImpl.putMembership(ctx, domainName, roleName1, "*", auditRef, false, null, membership);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Principal * is not allowed for the role"));
+        }
+
         zmsImpl.deleteSubDomain(ctx, "sports", "dev", auditRef, null);
         zmsImpl.deleteSubDomain(ctx, "sports", "prod", auditRef, null);
         zmsImpl.deleteMembership(ctx, domainName, roleName1, "sports:group.group1", auditRef, null);
@@ -368,7 +403,7 @@ public class PrincipalDomainFilterTest {
         group1.setPrincipalDomainFilter("user,+sports,-sports.prod");
         zmsImpl.putGroup(ctx, domainName, groupName1, auditRef, false, null, group1);
 
-        // add a group with the domain filter and no allowed members
+        // add a group with the domain filter and disallowed members
 
         groupMembers = new ArrayList<>();
         groupMembers.add(new GroupMember().setMemberName("user.user1"));


### PR DESCRIPTION
# Description

currently zms server treats * as a service member. however, this * member matches both user and service principals. So if we have a role that is configured with some user authority/expiration requirements, then these checks are not properly enforced. For example, we have a role that checks that all users must have completed some required training before being added to the role. When we had user.joe to the role, it is property executed. However, when we add *, then it's skipped which is not correct according to our governance requirements.

So we're treating * as a new principal type in the server. It's still treated as a service member for role expiry settings, however, when validating role membership, if there are any user authority/expiration requirements configured, it will be automatically rejected as an invalid member.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

