### PR TITLE
add single flight to ZTSClient token fetches

### DIFF
--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/SingleFlightCache.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/SingleFlightCache.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.zts;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class SingleFlightCache<T> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SingleFlightCache.class);
+
+    interface Fetcher<T> {
+        T fetch() throws Exception;
+    }
+
+    private final ConcurrentHashMap<String, CompletableFuture<T>> inFlight = new ConcurrentHashMap<>();
+    private volatile long timeoutMs;
+
+    SingleFlightCache(long timeoutMs) {
+        this.timeoutMs = timeoutMs;
+    }
+
+    void setTimeoutMs(long timeoutMs) {
+        this.timeoutMs = timeoutMs;
+    }
+
+    T execute(String key, Fetcher<T> fetcher) throws Exception {
+
+        CompletableFuture<T> future = new CompletableFuture<>();
+        CompletableFuture<T> existing = inFlight.putIfAbsent(key, future);
+
+        if (existing != null) {
+            if (LOG.isDebugEnabled()) {
+                LOG.debug("SingleFlight: waiting for in-flight request key={}", key);
+            }
+            return waitForResult(existing);
+        }
+
+        try {
+            T result = fetcher.fetch();
+            future.complete(result);
+            return result;
+        } catch (Exception ex) {
+            future.completeExceptionally(ex);
+            throw ex;
+        } finally {
+            inFlight.remove(key, future);
+        }
+    }
+
+    private T waitForResult(CompletableFuture<T> future) throws Exception {
+        try {
+            return future.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (ExecutionException ex) {
+            Throwable cause = ex.getCause();
+            if (cause instanceof Exception) {
+                throw (Exception) cause;
+            }
+            throw new RuntimeException(cause);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw ex;
+        } catch (TimeoutException ex) {
+            throw new ZTSClientException(ClientResourceException.SERVICE_UNAVAILABLE,
+                    "single flight timeout waiting for in-flight request");
+        }
+    }
+
+    int inFlightSize() {
+        return inFlight.size();
+    }
+}

--- a/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
+++ b/clients/java/zts/src/main/java/com/yahoo/athenz/zts/ZTSClient.java
@@ -115,7 +115,12 @@ public class ZTSClient implements Closeable {
     static private String confZtsUrl = null;
     static private JwtsSigningKeyResolver jwtsSigningKeyResolver = null;
     static private DnsResolver dnsResolver = null;
-    
+
+    static final SingleFlightCache<RoleToken> ROLE_TOKEN_FLIGHT = new SingleFlightCache<>(30000);
+    static final SingleFlightCache<AccessTokenResponse> ACCESS_TOKEN_FLIGHT = new SingleFlightCache<>(30000);
+    static final SingleFlightCache<AWSTemporaryCredentials> AWS_CREDS_FLIGHT = new SingleFlightCache<>(30000);
+    static final SingleFlightCache<OIDCResponse> ID_TOKEN_FLIGHT = new SingleFlightCache<>(30000);
+
     private boolean enablePrefetch = true;
     private boolean ztsClientOverride = false;
 
@@ -136,6 +141,7 @@ public class ZTSClient implements Closeable {
     public static final String ZTS_CLIENT_PROP_X509CSR_DN                = "athenz.zts.client.x509csr_dn";
     public static final String ZTS_CLIENT_PROP_X509CSR_DOMAIN            = "athenz.zts.client.x509csr_domain";
     public static final String ZTS_CLIENT_PROP_DISABLE_CACHE             = "athenz.zts.client.disable_cache";
+    public static final String ZTS_CLIENT_PROP_SINGLE_FLIGHT_TIMEOUT     = "athenz.zts.client.single_flight_timeout";
 
     public static final String ZTS_CLIENT_PROP_CERT_ALIAS                       = "athenz.zts.client.cert_alias";
     
@@ -222,6 +228,10 @@ public class ZTSClient implements Closeable {
         
         setCacheDisable(Boolean.parseBoolean(System.getProperty(ZTS_CLIENT_PROP_DISABLE_CACHE, "false")));
 
+        // set the timeout for single flight token fetch
+
+        setSingleFlightTimeout(Long.parseLong(System.getProperty(ZTS_CLIENT_PROP_SINGLE_FLIGHT_TIMEOUT, "30000")));
+
         // set x509 csr details
         
         setX509CsrDetails(System.getProperty(ZTS_CLIENT_PROP_X509CSR_DN),
@@ -280,6 +290,17 @@ public class ZTSClient implements Closeable {
         cacheDisabled = cacheState;
     }
     
+    /**
+     * Set the timeout for single flight token fetch in milliseconds.
+     * @param timeoutMs timeout in milliseconds
+     */
+    public static void setSingleFlightTimeout(long timeoutMs) {
+        ROLE_TOKEN_FLIGHT.setTimeoutMs(timeoutMs);
+        ACCESS_TOKEN_FLIGHT.setTimeoutMs(timeoutMs);
+        AWS_CREDS_FLIGHT.setTimeoutMs(timeoutMs);
+        ID_TOKEN_FLIGHT.setTimeoutMs(timeoutMs);
+    }
+
     /**
      * Enable prefetch of role tokens
      * @param fetchState state of prefetch
@@ -1176,8 +1197,14 @@ public class ZTSClient implements Closeable {
         
         updateServicePrincipal();
         try {
-            roleToken = ztsClient.getRoleToken(domainName, roleNames,
-                    minExpiryTime, maxExpiryTime, proxyForPrincipal);
+            if (cacheKey != null) {
+                roleToken = ROLE_TOKEN_FLIGHT.execute(cacheKey,
+                        () -> ztsClient.getRoleToken(domainName, roleNames,
+                                minExpiryTime, maxExpiryTime, proxyForPrincipal));
+            } else {
+                roleToken = ztsClient.getRoleToken(domainName, roleNames,
+                        minExpiryTime, maxExpiryTime, proxyForPrincipal);
+            }
         } catch (ClientResourceException ex) {
 
             // if we have an entry in our cache then we'll return that
@@ -1399,7 +1426,12 @@ public class ZTSClient implements Closeable {
                 final String requestBody = generateAccessTokenRequestBody(domainName, roleNames,
                         idTokenServiceName, proxyForPrincipal, authorizationDetails, proxyPrincipalSpiffeUris,
                         clientAssertionType, clientAssertion, expiryTime, openIdIssuer);
-                accessTokenResponse = ztsClient.postAccessTokenRequest(requestBody);
+                if (cacheKey != null) {
+                    accessTokenResponse = ACCESS_TOKEN_FLIGHT.execute(cacheKey,
+                            () -> ztsClient.postAccessTokenRequest(requestBody));
+                } else {
+                    accessTokenResponse = ztsClient.postAccessTokenRequest(requestBody);
+                }
             } catch (ClientResourceException ex) {
                 if (cacheKey != null && !ignoreCache) {
                     accessTokenResponse = lookupAccessTokenResponseInCache(cacheKey, -1);
@@ -3248,8 +3280,14 @@ public class ZTSClient implements Closeable {
         updateServicePrincipal();
 
         try {
-            awsCred = ztsClient.getAWSTemporaryCredentials(domainName, encodeAWSRoleName(roleName),
-                    maxExpiryTime, externalId);
+            if (cacheKey != null) {
+                awsCred = AWS_CREDS_FLIGHT.execute(cacheKey,
+                        () -> ztsClient.getAWSTemporaryCredentials(domainName, encodeAWSRoleName(roleName),
+                                maxExpiryTime, externalId));
+            } else {
+                awsCred = ztsClient.getAWSTemporaryCredentials(domainName, encodeAWSRoleName(roleName),
+                        maxExpiryTime, externalId);
+            }
         } catch (ClientResourceException ex) {
 
             // if we have an entry in our cache then we'll return that
@@ -3735,10 +3773,19 @@ public class ZTSClient implements Closeable {
 
         updateServicePrincipal();
         try {
-            Map<String, List<String>> responseHeaders = new HashMap<>();
-            oidcResponse = ztsClient.getOIDCResponse(responseType, clientId, redirectUri, scope,
-                    state, Crypto.randomSalt(), keyType, fullArn, expiryTime, "json", false,
-                    allRolesPresent, responseHeaders);
+            if (cacheKey != null) {
+                oidcResponse = ID_TOKEN_FLIGHT.execute(cacheKey, () -> {
+                    Map<String, List<String>> responseHeaders = new HashMap<>();
+                    return ztsClient.getOIDCResponse(responseType, clientId, redirectUri, scope,
+                            state, Crypto.randomSalt(), keyType, fullArn, expiryTime, "json", false,
+                            allRolesPresent, responseHeaders);
+                });
+            } else {
+                Map<String, List<String>> responseHeaders = new HashMap<>();
+                oidcResponse = ztsClient.getOIDCResponse(responseType, clientId, redirectUri, scope,
+                        state, Crypto.randomSalt(), keyType, fullArn, expiryTime, "json", false,
+                        allRolesPresent, responseHeaders);
+            }
 
         } catch (ClientResourceException ex) {
 
@@ -3829,10 +3876,21 @@ public class ZTSClient implements Closeable {
 
         updateServicePrincipal();
         try {
-            Map<String, List<String>> responseHeaders = new HashMap<>();
-            oidcResponse = ztsClient.getOIDCResponse(builder.responseType, builder.clientId, builder.redirectUri,
-                    builder.scope, builder.state, builder.salt, builder.keyType, builder.fullArn, builder.expiryTime,
-                    builder.outputType, builder.roleInAudtClaim, builder.allRolesPresent, responseHeaders);
+            if (cacheKey != null) {
+                oidcResponse = ID_TOKEN_FLIGHT.execute(cacheKey, () -> {
+                    Map<String, List<String>> responseHeaders = new HashMap<>();
+                    return ztsClient.getOIDCResponse(builder.responseType, builder.clientId, builder.redirectUri,
+                            builder.scope, builder.state, builder.salt, builder.keyType, builder.fullArn,
+                            builder.expiryTime, builder.outputType, builder.roleInAudtClaim,
+                            builder.allRolesPresent, responseHeaders);
+                });
+            } else {
+                Map<String, List<String>> responseHeaders = new HashMap<>();
+                oidcResponse = ztsClient.getOIDCResponse(builder.responseType, builder.clientId, builder.redirectUri,
+                        builder.scope, builder.state, builder.salt, builder.keyType, builder.fullArn,
+                        builder.expiryTime, builder.outputType, builder.roleInAudtClaim,
+                        builder.allRolesPresent, responseHeaders);
+            }
 
         } catch (ClientResourceException ex) {
 

--- a/clients/java/zts/src/test/java/com/yahoo/athenz/zts/SingleFlightCacheTest.java
+++ b/clients/java/zts/src/test/java/com/yahoo/athenz/zts/SingleFlightCacheTest.java
@@ -1,0 +1,242 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.yahoo.athenz.zts;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.testng.annotations.Test;
+
+public class SingleFlightCacheTest {
+
+    @Test
+    public void testSingleFetch() throws Exception {
+        SingleFlightCache<String> cache = new SingleFlightCache<>(5000);
+        AtomicInteger fetchCount = new AtomicInteger(0);
+
+        String result = cache.execute("key1", () -> {
+            fetchCount.incrementAndGet();
+            return "value1";
+        });
+
+        assertEquals(result, "value1");
+        assertEquals(fetchCount.get(), 1);
+        assertEquals(cache.inFlightSize(), 0);
+    }
+
+    @Test
+    public void testConcurrentFetchSameKey() throws Exception {
+        SingleFlightCache<String> cache = new SingleFlightCache<>(5000);
+        AtomicInteger fetchCount = new AtomicInteger(0);
+        int threadCount = 10;
+
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicReference<String> firstResult = new AtomicReference<>();
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    String result = cache.execute("same-key", () -> {
+                        fetchCount.incrementAndGet();
+                        Thread.sleep(100);
+                        return "shared-value";
+                    });
+                    firstResult.compareAndSet(null, result);
+                    assertEquals(result, "shared-value");
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    // timeout or interruption - acceptable in test
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals(fetchCount.get(), 1, "Only one fetch should have been executed");
+        assertEquals(successCount.get(), threadCount, "All threads should have received the result");
+        assertEquals(cache.inFlightSize(), 0);
+    }
+
+    @Test
+    public void testConcurrentFetchDifferentKeys() throws Exception {
+        SingleFlightCache<String> cache = new SingleFlightCache<>(5000);
+        AtomicInteger fetchCount = new AtomicInteger(0);
+
+        CyclicBarrier barrier = new CyclicBarrier(3);
+        CountDownLatch latch = new CountDownLatch(3);
+
+        ExecutorService executor = Executors.newFixedThreadPool(3);
+        for (int i = 0; i < 3; i++) {
+            final String key = "key-" + i;
+            executor.submit(() -> {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    cache.execute(key, () -> {
+                        fetchCount.incrementAndGet();
+                        Thread.sleep(50);
+                        return "value-" + key;
+                    });
+                } catch (Exception e) {
+                    // ignore
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals(fetchCount.get(), 3, "Each key should trigger its own fetch");
+        assertEquals(cache.inFlightSize(), 0);
+    }
+
+    @Test
+    public void testFetcherException() throws Exception {
+        SingleFlightCache<String> cache = new SingleFlightCache<>(5000);
+        AtomicInteger fetchCount = new AtomicInteger(0);
+        int threadCount = 5;
+
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        CountDownLatch latch = new CountDownLatch(threadCount);
+        AtomicInteger exceptionCount = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        for (int i = 0; i < threadCount; i++) {
+            executor.submit(() -> {
+                try {
+                    barrier.await(5, TimeUnit.SECONDS);
+                    cache.execute("error-key", () -> {
+                        fetchCount.incrementAndGet();
+                        Thread.sleep(50);
+                        throw new ClientResourceException(ClientResourceException.NOT_FOUND, "not found");
+                    });
+                    fail("Should have thrown exception");
+                } catch (ClientResourceException e) {
+                    assertEquals(e.getCode(), ClientResourceException.NOT_FOUND);
+                    exceptionCount.incrementAndGet();
+                } catch (Exception e) {
+                    // barrier/other exceptions
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+
+        latch.await(10, TimeUnit.SECONDS);
+        executor.shutdown();
+
+        assertEquals(fetchCount.get(), 1, "Only one fetch should have been executed");
+        assertEquals(exceptionCount.get(), threadCount, "All threads should have received the exception");
+        assertEquals(cache.inFlightSize(), 0);
+    }
+
+    @Test
+    public void testTimeout() throws Exception {
+        SingleFlightCache<String> cache = new SingleFlightCache<>(100);
+        CountDownLatch fetchStarted = new CountDownLatch(1);
+        CountDownLatch latch = new CountDownLatch(1);
+
+        // start a slow fetch in another thread
+        Thread fetcher = new Thread(() -> {
+            try {
+                cache.execute("slow-key", () -> {
+                    fetchStarted.countDown();
+                    Thread.sleep(5000);
+                    return "slow-value";
+                });
+            } catch (Exception e) {
+                // expected interruption
+            }
+        });
+        fetcher.start();
+
+        fetchStarted.await(5, TimeUnit.SECONDS);
+
+        // this thread should timeout waiting for the slow fetch
+        try {
+            cache.execute("slow-key", () -> "fast-value");
+            fail("Should have thrown timeout exception");
+        } catch (ZTSClientException e) {
+            assertEquals(e.getCode(), ClientResourceException.SERVICE_UNAVAILABLE);
+            assertTrue(e.getMessage().contains("single flight timeout"));
+        }
+
+        fetcher.interrupt();
+        fetcher.join(5000);
+    }
+
+    @Test
+    public void testCleanupAfterCompletion() throws Exception {
+        SingleFlightCache<String> cache = new SingleFlightCache<>(5000);
+
+        cache.execute("cleanup-key", () -> "value");
+        assertEquals(cache.inFlightSize(), 0, "In-flight map should be empty after completion");
+    }
+
+    @Test
+    public void testCleanupAfterException() throws Exception {
+        SingleFlightCache<String> cache = new SingleFlightCache<>(5000);
+
+        try {
+            cache.execute("error-cleanup-key", () -> {
+                throw new RuntimeException("test error");
+            });
+            fail("Should have thrown exception");
+        } catch (RuntimeException e) {
+            assertEquals(e.getMessage(), "test error");
+        }
+
+        assertEquals(cache.inFlightSize(), 0, "In-flight map should be empty after exception");
+    }
+
+    @Test
+    public void testSequentialFetchesSameKey() throws Exception {
+        SingleFlightCache<String> cache = new SingleFlightCache<>(5000);
+        AtomicInteger fetchCount = new AtomicInteger(0);
+
+        String result1 = cache.execute("seq-key", () -> {
+            fetchCount.incrementAndGet();
+            return "value1";
+        });
+
+        String result2 = cache.execute("seq-key", () -> {
+            fetchCount.incrementAndGet();
+            return "value2";
+        });
+
+        assertEquals(result1, "value1");
+        assertEquals(result2, "value2");
+        assertEquals(fetchCount.get(), 2, "Sequential fetches should each execute independently");
+    }
+}

--- a/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSClientTest.java
+++ b/clients/java/zts/src/test/java/com/yahoo/athenz/zts/ZTSClientTest.java
@@ -5577,4 +5577,192 @@ public class ZTSClientTest {
         }
         client.close();
     }
+
+    private static class CountingZTSRDLClientMock extends ZTSRDLClientMock {
+        final java.util.concurrent.atomic.AtomicInteger getRoleTokenCalls = new java.util.concurrent.atomic.AtomicInteger();
+        final java.util.concurrent.atomic.AtomicInteger postAccessTokenCalls = new java.util.concurrent.atomic.AtomicInteger();
+        final java.util.concurrent.atomic.AtomicInteger getOIDCResponseCalls = new java.util.concurrent.atomic.AtomicInteger();
+        final java.util.concurrent.atomic.AtomicInteger getAWSCredsCalls = new java.util.concurrent.atomic.AtomicInteger();
+        final long sleepMs;
+
+        CountingZTSRDLClientMock(long sleepMs) {
+            this.sleepMs = sleepMs;
+        }
+
+        private void sleepQuietly() {
+            try {
+                Thread.sleep(sleepMs);
+            } catch (InterruptedException ie) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+        @Override
+        public RoleToken getRoleToken(String domainName, String rName, Integer minExpiryTime,
+                Integer maxExpiryTime, String proxyForPrincipal) {
+            getRoleTokenCalls.incrementAndGet();
+            sleepQuietly();
+            return super.getRoleToken(domainName, rName, minExpiryTime, maxExpiryTime, proxyForPrincipal);
+        }
+
+        @Override
+        public AccessTokenResponse postAccessTokenRequest(String request) {
+            postAccessTokenCalls.incrementAndGet();
+            sleepQuietly();
+            return super.postAccessTokenRequest(request);
+        }
+
+        @Override
+        public OIDCResponse getOIDCResponse(String responseType, String clientId, String redirectUri, String scope,
+                String state, String nonce, String keyType, Boolean fullArn, Integer expiryTime,
+                String output, Boolean roleInAudClaim, Boolean allScopePresent, Map<String, List<String>> headers)
+                throws URISyntaxException, IOException {
+            getOIDCResponseCalls.incrementAndGet();
+            sleepQuietly();
+            return super.getOIDCResponse(responseType, clientId, redirectUri, scope, state, nonce, keyType,
+                    fullArn, expiryTime, output, roleInAudClaim, allScopePresent, headers);
+        }
+
+        @Override
+        public AWSTemporaryCredentials getAWSTemporaryCredentials(String domainName, String roleName,
+                Integer durationSeconds, String externalId) {
+            getAWSCredsCalls.incrementAndGet();
+            sleepQuietly();
+            return super.getAWSTemporaryCredentials(domainName, roleName, durationSeconds, externalId);
+        }
+    }
+
+    private static void runConcurrently(int threadCount, Runnable task) throws InterruptedException {
+        java.util.concurrent.CyclicBarrier barrier = new java.util.concurrent.CyclicBarrier(threadCount);
+        java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(threadCount);
+        java.util.concurrent.ExecutorService pool = java.util.concurrent.Executors.newFixedThreadPool(threadCount);
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                pool.submit(() -> {
+                    try {
+                        barrier.await(5, java.util.concurrent.TimeUnit.SECONDS);
+                        task.run();
+                    } catch (Exception e) {
+                        // ignore
+                    } finally {
+                        latch.countDown();
+                    }
+                });
+            }
+            assertTrue(latch.await(15, java.util.concurrent.TimeUnit.SECONDS));
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    private static void clearAllTokenCaches() {
+        ZTSClient.ROLE_TOKEN_CACHE.clear();
+        ZTSClient.ACCESS_TOKEN_CACHE.clear();
+        ZTSClient.AWS_CREDS_CACHE.clear();
+        ZTSClient.ID_TOKEN_CACHE.clear();
+    }
+
+    @Test
+    public void testGetRoleTokenSingleFlight() throws InterruptedException {
+        clearAllTokenCaches();
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "auth_creds", PRINCIPAL_AUTHORITY);
+        CountingZTSRDLClientMock mock = new CountingZTSRDLClientMock(200);
+        mock.setRoleName("role1");
+        ZTSClient client = new ZTSClient("http://localhost:4080", principal);
+        client.setZTSRDLGeneratedClient(mock);
+
+        runConcurrently(10, () -> {
+            RoleToken token = client.getRoleToken("sf-roletoken-domain");
+            assertNotNull(token);
+        });
+
+        assertEquals(mock.getRoleTokenCalls.get(), 1,
+                "Concurrent getRoleToken should collapse into a single upstream call");
+        client.close();
+    }
+
+    @Test
+    public void testGetAccessTokenSingleFlight() throws InterruptedException {
+        clearAllTokenCaches();
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "auth_creds", PRINCIPAL_AUTHORITY);
+        CountingZTSRDLClientMock mock = new CountingZTSRDLClientMock(200);
+        ZTSClient client = new ZTSClient("http://localhost:4080", principal);
+        client.setZTSRDLGeneratedClient(mock);
+
+        runConcurrently(10, () -> {
+            AccessTokenResponse response = client.getAccessToken("coretech", null, 3600);
+            assertNotNull(response);
+        });
+
+        assertEquals(mock.postAccessTokenCalls.get(), 1,
+                "Concurrent getAccessToken should collapse into a single upstream call");
+        client.close();
+    }
+
+    @Test
+    public void testGetIDTokenSingleFlight() throws InterruptedException {
+        clearAllTokenCaches();
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "auth_creds", PRINCIPAL_AUTHORITY);
+        CountingZTSRDLClientMock mock = new CountingZTSRDLClientMock(200);
+        ZTSClient client = new ZTSClient("http://localhost:4080", principal);
+        client.setZTSRDLGeneratedClient(mock);
+
+        runConcurrently(10, () -> {
+            OIDCResponse response = client.getIDToken("sf-idtoken", "readers", "sys.auth.gcp",
+                    "gcp.athenz.io", true, null);
+            assertNotNull(response);
+        });
+
+        assertEquals(mock.getOIDCResponseCalls.get(), 1,
+                "Concurrent getIDToken should collapse into a single upstream call");
+        client.close();
+    }
+
+    @Test
+    public void testGetAWSCredsSingleFlight() throws InterruptedException {
+        clearAllTokenCaches();
+        Timestamp expiry = Timestamp.fromCurrentTime();
+        CountingZTSRDLClientMock mock = new CountingZTSRDLClientMock(200);
+        mock.setAwsCreds(expiry, "sf-aws-domain", "role", "session", "secret", "keyid");
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "v=S1;d=user_domain;n=user;s=sig", PRINCIPAL_AUTHORITY);
+        ZTSClient client = new ZTSClient("http://localhost:4080", principal);
+        client.setZTSRDLGeneratedClient(mock);
+
+        runConcurrently(10, () -> {
+            AWSTemporaryCredentials creds = client.getAWSTemporaryCredentials("sf-aws-domain", "role");
+            assertNotNull(creds);
+        });
+
+        assertEquals(mock.getAWSCredsCalls.get(), 1,
+                "Concurrent getAWSTemporaryCredentials should collapse into a single upstream call");
+        client.close();
+    }
+
+    @Test
+    public void testGetRoleTokenSingleFlightDisabledWhenCacheDisabled() throws InterruptedException {
+        clearAllTokenCaches();
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "auth_creds", PRINCIPAL_AUTHORITY);
+        CountingZTSRDLClientMock mock = new CountingZTSRDLClientMock(50);
+        mock.setRoleName("role1");
+        ZTSClient client = new ZTSClient("http://localhost:4080", principal);
+        client.setZTSRDLGeneratedClient(mock);
+
+        ZTSClient.setCacheDisable(true);
+        try {
+            runConcurrently(10, () -> {
+                RoleToken token = client.getRoleToken("sf-cachedis-domain");
+                assertNotNull(token);
+            });
+            assertEquals(mock.getRoleTokenCalls.get(), 10,
+                    "With cache disabled each concurrent call must hit ZTS independently");
+        } finally {
+            ZTSClient.setCacheDisable(false);
+            client.close();
+        }
+    }
 }


### PR DESCRIPTION
# Description
<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->
this PR adds a small `SingleFlightCache<T>` utility that collapses concurrent fetches for the same cache key into a single upstream call. the first thread to miss does the actual fetch; the rest wait on its `CompletableFuture` and share the result. exceptions propagate to all waiters in their original type so the existing stale-cache fallback keeps working.

applied to all four token fetch paths: `getRoleToken`, `getAccessToken`, `getIDToken`, `getAWSTemporaryCredentials`. single flight is gated on `cacheKey != null`, so when the client cache is disabled (`athenz.zts.client.disable_cache=true`) each thread fetches independently as before.

new system property `athenz.zts.client.single_flight_timeout` (default 30000ms) bounds how long a waiter blocks for the in-flight fetch. on timeout the waiter receives `ZTSClientException(SERVICE_UNAVAILABLE)` and falls through to the existing stale-cache logic.

Fixes https://github.com/AthenZ/athenz/issues/3329

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

