### PR TITLE
correct callback port to be int instead of string

### DIFF
--- a/libs/go/usercert/idp.go
+++ b/libs/go/usercert/idp.go
@@ -49,7 +49,7 @@ func getIdpAuthURL(endPoint, clientId, scope, nonce, state string, callbackPort 
 		return "", fmt.Errorf("failed to parse auth endpoint: %v", err)
 	}
 
-	redirectURL := fmt.Sprintf("http://localhost:%d/oauth2/callback", callbackPort)
+	redirectURL := fmt.Sprintf("http://127.0.0.1:%d/oauth2/callback", callbackPort)
 
 	query := u.Query()
 	query.Set("client_id", clientId)
@@ -131,7 +131,7 @@ func getAuthCodeFromCallbackHandler(port, timeoutSeconds int, verbose bool) <-ch
 		log.Printf("Starting callback server on port %d", port)
 	}
 	server := &http.Server{
-		Addr:         fmt.Sprintf("localhost:%d", port),
+		Addr:         fmt.Sprintf("127.0.0.1:%d", port),
 		Handler:      mux,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,

--- a/libs/go/usercert/idp.go
+++ b/libs/go/usercert/idp.go
@@ -43,13 +43,13 @@ func computeCodeChallenge(verifier string) string {
 	return encode(h[:])
 }
 
-func getIdpAuthURL(endPoint, clientId, scope, nonce, state, callbackPort, codeChallenge string) (string, error) {
+func getIdpAuthURL(endPoint, clientId, scope, nonce, state string, callbackPort int, codeChallenge string) (string, error) {
 	u, err := url.Parse(endPoint)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse auth endpoint: %v", err)
 	}
 
-	redirectURL := fmt.Sprintf("http://localhost:%s/oauth2/callback", callbackPort)
+	redirectURL := fmt.Sprintf("http://localhost:%d/oauth2/callback", callbackPort)
 
 	query := u.Query()
 	query.Set("client_id", clientId)
@@ -83,7 +83,7 @@ func openBrowser(url string) error {
 	return cmd.Run()
 }
 
-func openIdpAuthURL(endPoint, clientId, scope, nonce, state, callbackPort, codeChallenge string, verbose bool) error {
+func openIdpAuthURL(endPoint, clientId, scope, nonce, state string, callbackPort int, codeChallenge string, verbose bool) error {
 	authURL, err := getIdpAuthURL(endPoint, clientId, scope, nonce, state, callbackPort, codeChallenge)
 	if err != nil {
 		return err
@@ -120,7 +120,7 @@ func registerHandlers(mux *http.ServeMux, code chan<- string) {
 	}))
 }
 
-func getAuthCodeFromCallbackHandler(port string, timeoutSeconds int, verbose bool) <-chan authResult {
+func getAuthCodeFromCallbackHandler(port, timeoutSeconds int, verbose bool) <-chan authResult {
 	result := make(chan authResult, 1)
 	code := make(chan string, 1)
 
@@ -128,10 +128,10 @@ func getAuthCodeFromCallbackHandler(port string, timeoutSeconds int, verbose boo
 	registerHandlers(mux, code)
 
 	if verbose {
-		log.Printf("Starting callback server on port %s", port)
+		log.Printf("Starting callback server on port %d", port)
 	}
 	server := &http.Server{
-		Addr:         fmt.Sprintf("localhost:%s", port),
+		Addr:         fmt.Sprintf("localhost:%d", port),
 		Handler:      mux,
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
@@ -173,7 +173,7 @@ func getAuthCodeFromCallbackHandler(port string, timeoutSeconds int, verbose boo
 // verifier is returned so the caller can include it in the token exchange.
 // Returns the raw query string containing the code and state, the PKCE code
 // verifier (empty when pkce is false), or an error if the process fails.
-func GetAuthCode(endPoint, clientId, scope, callbackPort string, timeoutSeconds int, pkce, verbose bool) (string, string, error) {
+func GetAuthCode(endPoint, clientId, scope string, callbackPort, timeoutSeconds int, pkce, verbose bool) (string, string, error) {
 	result := getAuthCodeFromCallbackHandler(callbackPort, timeoutSeconds, verbose)
 
 	nonce, err := newCodeVerifier(24)

--- a/libs/go/usercert/idp_test.go
+++ b/libs/go/usercert/idp_test.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -89,7 +90,7 @@ func TestNewNonceIsValidBase64URL(t *testing.T) {
 // --- getIdpAuthURL tests ---
 
 func TestGetIdpAuthURL(t *testing.T) {
-	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "test-state", "9213", "")
+	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "test-state", 9213, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -129,16 +130,16 @@ func TestGetIdpAuthURL(t *testing.T) {
 
 func TestGetIdpAuthURLDifferentPorts(t *testing.T) {
 	tests := []struct {
-		port        string
+		port        int
 		expectedURI string
 	}{
-		{"8080", "http://localhost:8080/oauth2/callback"},
-		{"3000", "http://localhost:3000/oauth2/callback"},
-		{"443", "http://localhost:443/oauth2/callback"},
+		{8080, "http://localhost:8080/oauth2/callback"},
+		{3000, "http://localhost:3000/oauth2/callback"},
+		{443, "http://localhost:443/oauth2/callback"},
 	}
 
 	for _, tt := range tests {
-		t.Run("port-"+tt.port, func(t *testing.T) {
+		t.Run("port-"+strconv.Itoa(tt.port), func(t *testing.T) {
 			authURL, err := getIdpAuthURL("https://idp.example.com/auth", "client", "openid", "nonce", "test-state", tt.port, "")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -152,14 +153,14 @@ func TestGetIdpAuthURLDifferentPorts(t *testing.T) {
 }
 
 func TestGetIdpAuthURLInvalidEndpoint(t *testing.T) {
-	_, err := getIdpAuthURL("://invalid", "client", "openid", "nonce", "test-state", "9213", "")
+	_, err := getIdpAuthURL("://invalid", "client", "openid", "nonce", "test-state", 9213, "")
 	if err == nil {
 		t.Fatal("expected error for invalid endpoint")
 	}
 }
 
 func TestGetIdpAuthURLPreservesExistingQueryParams(t *testing.T) {
-	authURL, err := getIdpAuthURL("https://idp.example.com/auth?extra=value", "client", "openid", "nonce", "test-state", "9213", "")
+	authURL, err := getIdpAuthURL("https://idp.example.com/auth?extra=value", "client", "openid", "nonce", "test-state", 9213, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -173,7 +174,7 @@ func TestGetIdpAuthURLPreservesExistingQueryParams(t *testing.T) {
 }
 
 func TestGetIdpAuthURLCustomScope(t *testing.T) {
-	authURL, err := getIdpAuthURL("https://idp.example.com/auth", "client", "openid profile email", "nonce", "test-state", "9213", "")
+	authURL, err := getIdpAuthURL("https://idp.example.com/auth", "client", "openid profile email", "nonce", "test-state", 9213, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -326,7 +327,7 @@ func TestRegisterHandlersCloseEndpoint(t *testing.T) {
 func TestGetAuthCodeFromCallbackHandlerTimeout(t *testing.T) {
 	// Use port 0 to let OS pick a free port - but the function takes a string port.
 	// Use a high port that's likely free.
-	result := getAuthCodeFromCallbackHandler("19994", 1, false)
+	result := getAuthCodeFromCallbackHandler(19994, 1, false)
 	select {
 	case r := <-result:
 		if r.Error == nil {
@@ -346,7 +347,7 @@ func TestGetAuthCodeFromCallbackHandlerSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
-	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	port := listener.Addr().(*net.TCPAddr).Port
 	listener.Close()
 
 	result := getAuthCodeFromCallbackHandler(port, 10, false)
@@ -355,7 +356,7 @@ func TestGetAuthCodeFromCallbackHandlerSuccess(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Simulate the IdP callback
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=auth-code-123&state=nonce", port))
+	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=auth-code-123&state=nonce", port))
 	if err != nil {
 		t.Fatalf("failed to call callback: %v", err)
 	}
@@ -381,7 +382,7 @@ func TestGetAuthCodeSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
-	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	port := listener.Addr().(*net.TCPAddr).Port
 	listener.Close()
 
 	origBrowserOpen := browserOpen
@@ -395,7 +396,7 @@ func TestGetAuthCodeSuccess(t *testing.T) {
 		state := u.Query().Get("state")
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=test-auth-code&state=%s", port, state))
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=test-auth-code&state=%s", port, state))
 			if err == nil {
 				resp.Body.Close()
 			}
@@ -425,7 +426,7 @@ func TestGetAuthCodeStateMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
-	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	port := listener.Addr().(*net.TCPAddr).Port
 	listener.Close()
 
 	origBrowserOpen := browserOpen
@@ -434,7 +435,7 @@ func TestGetAuthCodeStateMismatch(t *testing.T) {
 	browserOpen = func(authURL string) error {
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=test-auth-code&state=wrong-state", port))
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=test-auth-code&state=wrong-state", port))
 			if err == nil {
 				resp.Body.Close()
 			}
@@ -456,7 +457,7 @@ func TestGetAuthCodeMissingState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
-	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	port := listener.Addr().(*net.TCPAddr).Port
 	listener.Close()
 
 	origBrowserOpen := browserOpen
@@ -465,7 +466,7 @@ func TestGetAuthCodeMissingState(t *testing.T) {
 	browserOpen = func(authURL string) error {
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=test-auth-code", port))
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=test-auth-code", port))
 			if err == nil {
 				resp.Body.Close()
 			}
@@ -487,7 +488,7 @@ func TestGetAuthCodeBrowserOpenFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
-	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	port := listener.Addr().(*net.TCPAddr).Port
 	listener.Close()
 
 	origBrowserOpen := browserOpen
@@ -514,7 +515,7 @@ func TestGetAuthCodeInvalidEndpoint(t *testing.T) {
 		return nil
 	}
 
-	_, _, err := GetAuthCode("://invalid", "my-client", "openid", "19999", 5, false, false)
+	_, _, err := GetAuthCode("://invalid", "my-client", "openid", 19999, 5, false, false)
 	if err == nil {
 		t.Fatal("expected error for invalid endpoint")
 	}
@@ -626,7 +627,7 @@ func TestComputeCodeChallengeMatchesSHA256(t *testing.T) {
 
 func TestGetIdpAuthURLWithPKCE(t *testing.T) {
 	challenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
-	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "test-state", "9213", challenge)
+	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "test-state", 9213, challenge)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -646,7 +647,7 @@ func TestGetIdpAuthURLWithPKCE(t *testing.T) {
 }
 
 func TestGetIdpAuthURLWithoutPKCE(t *testing.T) {
-	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "test-state", "9213", "")
+	authURL, err := getIdpAuthURL("https://idp.example.com/oauth2/authorize", "my-client", "openid", "test-nonce", "test-state", 9213, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -670,7 +671,7 @@ func TestGetAuthCodeWithPKCESuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
-	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	port := listener.Addr().(*net.TCPAddr).Port
 	listener.Close()
 
 	origBrowserOpen := browserOpen
@@ -686,7 +687,7 @@ func TestGetAuthCodeWithPKCESuccess(t *testing.T) {
 		state := u.Query().Get("state")
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=pkce-code&state=%s", port, state))
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=pkce-code&state=%s", port, state))
 			if err == nil {
 				resp.Body.Close()
 			}
@@ -739,7 +740,7 @@ func TestGetAuthCodeWithPKCEDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
-	port := fmt.Sprintf("%d", listener.Addr().(*net.TCPAddr).Port)
+	port := listener.Addr().(*net.TCPAddr).Port
 	listener.Close()
 
 	origBrowserOpen := browserOpen
@@ -755,7 +756,7 @@ func TestGetAuthCodeWithPKCEDisabled(t *testing.T) {
 		state := u.Query().Get("state")
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%s/oauth2/callback?code=no-pkce-code&state=%s", port, state))
+			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=no-pkce-code&state=%s", port, state))
 			if err == nil {
 				resp.Body.Close()
 			}

--- a/libs/go/usercert/idp_test.go
+++ b/libs/go/usercert/idp_test.go
@@ -325,9 +325,8 @@ func TestRegisterHandlersCloseEndpoint(t *testing.T) {
 // --- getAuthCodeFromCallbackHandler tests ---
 
 func TestGetAuthCodeFromCallbackHandlerTimeout(t *testing.T) {
-	// Use port 0 to let OS pick a free port - but the function takes a string port.
-	// Use a high port that's likely free.
-	result := getAuthCodeFromCallbackHandler(19994, 1, false)
+	// Use port 0 to let OS pick a free port
+	result := getAuthCodeFromCallbackHandler(0, 1, false)
 	select {
 	case r := <-result:
 		if r.Error == nil {

--- a/libs/go/usercert/idp_test.go
+++ b/libs/go/usercert/idp_test.go
@@ -111,7 +111,7 @@ func TestGetIdpAuthURL(t *testing.T) {
 	if q.Get("client_id") != "my-client" {
 		t.Errorf("expected client_id=my-client, got %s", q.Get("client_id"))
 	}
-	if q.Get("redirect_uri") != "http://localhost:9213/oauth2/callback" {
+	if q.Get("redirect_uri") != "http://127.0.0.1:9213/oauth2/callback" {
 		t.Errorf("expected redirect_uri with port 9213, got %s", q.Get("redirect_uri"))
 	}
 	if q.Get("response_type") != "code" {
@@ -133,9 +133,9 @@ func TestGetIdpAuthURLDifferentPorts(t *testing.T) {
 		port        int
 		expectedURI string
 	}{
-		{8080, "http://localhost:8080/oauth2/callback"},
-		{3000, "http://localhost:3000/oauth2/callback"},
-		{443, "http://localhost:443/oauth2/callback"},
+		{8080, "http://127.0.0.1:8080/oauth2/callback"},
+		{3000, "http://127.0.0.1:3000/oauth2/callback"},
+		{443, "http://127.0.0.1:443/oauth2/callback"},
 	}
 
 	for _, tt := range tests {
@@ -192,7 +192,7 @@ func TestRegisterHandlersCallbackRedirect(t *testing.T) {
 	registerHandlers(mux, codeChan)
 
 	// Find a free port
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -200,7 +200,7 @@ func TestRegisterHandlersCallbackRedirect(t *testing.T) {
 	listener.Close()
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf("localhost:%d", port),
+		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
 		Handler: mux,
 	}
 	go server.ListenAndServe()
@@ -214,7 +214,7 @@ func TestRegisterHandlersCallbackRedirect(t *testing.T) {
 			return http.ErrUseLastResponse
 		},
 	}
-	resp, err := client.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=test123&state=nonce", port))
+	resp, err := client.Get(fmt.Sprintf("http://127.0.0.1:%d/oauth2/callback?code=test123&state=nonce", port))
 	if err != nil {
 		t.Fatalf("failed to call callback: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestRegisterHandlersCallbackFollowRedirect(t *testing.T) {
 	codeChan := make(chan string, 1)
 	registerHandlers(mux, codeChan)
 
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -243,7 +243,7 @@ func TestRegisterHandlersCallbackFollowRedirect(t *testing.T) {
 	listener.Close()
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf("localhost:%d", port),
+		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
 		Handler: mux,
 	}
 	go server.ListenAndServe()
@@ -262,7 +262,7 @@ func TestRegisterHandlersCallbackFollowRedirect(t *testing.T) {
 		}
 	}
 
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=test123&state=nonce", port))
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/oauth2/callback?code=test123&state=nonce", port))
 	if err != nil {
 		t.Fatalf("failed to call callback: %v", err)
 	}
@@ -291,7 +291,7 @@ func TestRegisterHandlersCloseEndpoint(t *testing.T) {
 	codeChan := make(chan string, 1)
 	registerHandlers(mux, codeChan)
 
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -299,7 +299,7 @@ func TestRegisterHandlersCloseEndpoint(t *testing.T) {
 	listener.Close()
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf("localhost:%d", port),
+		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
 		Handler: mux,
 	}
 	go server.ListenAndServe()
@@ -307,7 +307,7 @@ func TestRegisterHandlersCloseEndpoint(t *testing.T) {
 
 	time.Sleep(100 * time.Millisecond)
 
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/close", port))
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/close", port))
 	if err != nil {
 		t.Fatalf("failed to call /close: %v", err)
 	}
@@ -342,7 +342,7 @@ func TestGetAuthCodeFromCallbackHandlerTimeout(t *testing.T) {
 
 func TestGetAuthCodeFromCallbackHandlerSuccess(t *testing.T) {
 	// Find a free port first
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -355,7 +355,7 @@ func TestGetAuthCodeFromCallbackHandlerSuccess(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// Simulate the IdP callback
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=auth-code-123&state=nonce", port))
+	resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/oauth2/callback?code=auth-code-123&state=nonce", port))
 	if err != nil {
 		t.Fatalf("failed to call callback: %v", err)
 	}
@@ -377,7 +377,7 @@ func TestGetAuthCodeFromCallbackHandlerSuccess(t *testing.T) {
 // --- GetAuthCode tests ---
 
 func TestGetAuthCodeSuccess(t *testing.T) {
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -395,7 +395,7 @@ func TestGetAuthCodeSuccess(t *testing.T) {
 		state := u.Query().Get("state")
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=test-auth-code&state=%s", port, state))
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/oauth2/callback?code=test-auth-code&state=%s", port, state))
 			if err == nil {
 				resp.Body.Close()
 			}
@@ -421,7 +421,7 @@ func TestGetAuthCodeSuccess(t *testing.T) {
 }
 
 func TestGetAuthCodeStateMismatch(t *testing.T) {
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -434,7 +434,7 @@ func TestGetAuthCodeStateMismatch(t *testing.T) {
 	browserOpen = func(authURL string) error {
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=test-auth-code&state=wrong-state", port))
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/oauth2/callback?code=test-auth-code&state=wrong-state", port))
 			if err == nil {
 				resp.Body.Close()
 			}
@@ -452,7 +452,7 @@ func TestGetAuthCodeStateMismatch(t *testing.T) {
 }
 
 func TestGetAuthCodeMissingState(t *testing.T) {
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -465,7 +465,7 @@ func TestGetAuthCodeMissingState(t *testing.T) {
 	browserOpen = func(authURL string) error {
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=test-auth-code", port))
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/oauth2/callback?code=test-auth-code", port))
 			if err == nil {
 				resp.Body.Close()
 			}
@@ -483,7 +483,7 @@ func TestGetAuthCodeMissingState(t *testing.T) {
 }
 
 func TestGetAuthCodeBrowserOpenFailure(t *testing.T) {
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -666,7 +666,7 @@ func TestGetIdpAuthURLWithoutPKCE(t *testing.T) {
 }
 
 func TestGetAuthCodeWithPKCESuccess(t *testing.T) {
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -686,7 +686,7 @@ func TestGetAuthCodeWithPKCESuccess(t *testing.T) {
 		state := u.Query().Get("state")
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=pkce-code&state=%s", port, state))
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/oauth2/callback?code=pkce-code&state=%s", port, state))
 			if err == nil {
 				resp.Body.Close()
 			}
@@ -735,7 +735,7 @@ func TestGetAuthCodeWithPKCESuccess(t *testing.T) {
 }
 
 func TestGetAuthCodeWithPKCEDisabled(t *testing.T) {
-	listener, err := net.Listen("tcp", "localhost:0")
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to get free port: %v", err)
 	}
@@ -755,7 +755,7 @@ func TestGetAuthCodeWithPKCEDisabled(t *testing.T) {
 		state := u.Query().Get("state")
 		go func() {
 			time.Sleep(200 * time.Millisecond)
-			resp, err := http.Get(fmt.Sprintf("http://localhost:%d/oauth2/callback?code=no-pkce-code&state=%s", port, state))
+			resp, err := http.Get(fmt.Sprintf("http://127.0.0.1:%d/oauth2/callback?code=no-pkce-code&state=%s", port, state))
 			if err == nil {
 				resp.Body.Close()
 			}

--- a/libs/go/usercert/usercert.go
+++ b/libs/go/usercert/usercert.go
@@ -54,7 +54,7 @@ type Options struct {
 	SubjectOrgUnit    string // CSR subject OrganizationalUnit field
 	SpiffeTrustDomain string // SPIFFE trust domain for URI SAN
 	Scope             string // OIDC scope parameter (default: "openid")
-	CallbackPort      string // local port for OAuth2 callback server
+	CallbackPort      int    // local port for OAuth2 callback server
 	CallbackTimeout   int    // seconds to wait for IdP callback
 	ExpiryTime        int    // certificate expiry in minutes (0 = server default)
 	PKCE              bool   // enable PKCE for IdP auth flow

--- a/libs/go/usercert/usercert_test.go
+++ b/libs/go/usercert/usercert_test.go
@@ -400,7 +400,7 @@ func TestRequestCertificateWithMockZTS(t *testing.T) {
 		SubjectCountry:  "US",
 		SubjectOrg:      "Test",
 		SubjectOrgUnit:  "Test",
-		CallbackPort:    "19998",
+		CallbackPort:    19998,
 		CallbackTimeout: 1,
 	})
 	// We expect an error because the IdP auth flow won't complete in a test
@@ -429,7 +429,7 @@ func TestRequestCertificateInvalidCACertFile(t *testing.T) {
 		SubjectCountry:  "US",
 		SubjectOrg:      "Test",
 		SubjectOrgUnit:  "Test",
-		CallbackPort:    "19996",
+		CallbackPort:    19996,
 		CallbackTimeout: 1,
 	})
 	if err == nil {
@@ -453,7 +453,7 @@ func TestRequestCertificateVerboseMode(t *testing.T) {
 		SubjectCountry:  "US",
 		SubjectOrg:      "Test",
 		SubjectOrgUnit:  "Test",
-		CallbackPort:    "19992",
+		CallbackPort:    19992,
 		CallbackTimeout: 1,
 		Verbose:         true,
 	})
@@ -477,7 +477,7 @@ func TestRequestCertificateWithExpiryTime(t *testing.T) {
 		SubjectCountry:  "US",
 		SubjectOrg:      "Test",
 		SubjectOrgUnit:  "Test",
-		CallbackPort:    "19990",
+		CallbackPort:    19990,
 		CallbackTimeout: 1,
 		ExpiryTime:      60,
 	})
@@ -501,7 +501,7 @@ func TestRequestCertificateWithSpiffeDomain(t *testing.T) {
 		SubjectOrg:        "Test",
 		SubjectOrgUnit:    "Test",
 		SpiffeTrustDomain: "athenz.io",
-		CallbackPort:      "19988",
+		CallbackPort:      19988,
 		CallbackTimeout:   1,
 	})
 	if err == nil {

--- a/libs/go/usercert/usercert_test.go
+++ b/libs/go/usercert/usercert_test.go
@@ -395,7 +395,7 @@ func TestRequestCertificateWithMockZTS(t *testing.T) {
 		ZtsURL:          server.URL,
 		PrivateKeyFile:  tmpKeyFile,
 		UserName:        "johndoe",
-		IdpEndpoint:     "http://localhost:19999/auth",
+		IdpEndpoint:     "http://127.0.0.1:19999/auth",
 		IdpClientId:     "test-client",
 		SubjectCountry:  "US",
 		SubjectOrg:      "Test",
@@ -424,7 +424,7 @@ func TestRequestCertificateInvalidCACertFile(t *testing.T) {
 	_, err := RequestCertificate(Options{
 		PrivateKeyFile:  tmpKeyFile,
 		UserName:        "johndoe",
-		IdpEndpoint:     "http://localhost:19997/auth",
+		IdpEndpoint:     "http://127.0.0.1:19997/auth",
 		IdpClientId:     "test-client",
 		SubjectCountry:  "US",
 		SubjectOrg:      "Test",
@@ -448,7 +448,7 @@ func TestRequestCertificateVerboseMode(t *testing.T) {
 	_, err := RequestCertificate(Options{
 		PrivateKeyFile:  tmpKeyFile,
 		UserName:        "johndoe",
-		IdpEndpoint:     "http://localhost:19993/auth",
+		IdpEndpoint:     "http://127.0.0.1:19993/auth",
 		IdpClientId:     "test-client",
 		SubjectCountry:  "US",
 		SubjectOrg:      "Test",
@@ -472,7 +472,7 @@ func TestRequestCertificateWithExpiryTime(t *testing.T) {
 	_, err := RequestCertificate(Options{
 		PrivateKeyFile:  tmpKeyFile,
 		UserName:        "johndoe",
-		IdpEndpoint:     "http://localhost:19991/auth",
+		IdpEndpoint:     "http://127.0.0.1:19991/auth",
 		IdpClientId:     "test-client",
 		SubjectCountry:  "US",
 		SubjectOrg:      "Test",
@@ -495,7 +495,7 @@ func TestRequestCertificateWithSpiffeDomain(t *testing.T) {
 	_, err := RequestCertificate(Options{
 		PrivateKeyFile:    tmpKeyFile,
 		UserName:          "johndoe",
-		IdpEndpoint:       "http://localhost:19989/auth",
+		IdpEndpoint:       "http://127.0.0.1:19989/auth",
 		IdpClientId:       "test-client",
 		SubjectCountry:    "US",
 		SubjectOrg:        "Test",

--- a/utils/zts-usercert/zts-usercert.go
+++ b/utils/zts-usercert/zts-usercert.go
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	DefaultCallbackPort    = "9213"
+	DefaultCallbackPort    = 9213
 	DefaultCallbackTimeout = 45
 	DefaultSubjectOrgUnit  = "Athenz"
 )
@@ -43,8 +43,8 @@ func main() {
 	var ztsURL, privateKeyFile, userName, certFile string
 	var idpEndpoint, idpClientId, caCertFile string
 	var subjC, subjO, subjOU, spiffeTrustDomain string
-	var scope, callbackPort string
-	var callbackTimeout, expiryTime int
+	var scope string
+	var callbackPort, callbackTimeout, expiryTime int
 	var pkce, proxy, verbose, showVersion bool
 
 	flag.StringVar(&ztsURL, "zts", "", "url of the ZTS Service")
@@ -58,7 +58,7 @@ func main() {
 	flag.StringVar(&subjOU, "subj-ou", DefaultSubjectOrgUnit, "Subject OU/OrganizationalUnit field")
 	flag.StringVar(&spiffeTrustDomain, "spiffe-trust-domain", "", "trust domain value for SPIFFE URI")
 	flag.StringVar(&scope, "scope", "openid", "OIDC scope parameter")
-	flag.StringVar(&callbackPort, "callback-port", DefaultCallbackPort, "local port for IdP OAuth2 callback")
+	flag.IntVar(&callbackPort, "callback-port", DefaultCallbackPort, "local port for IdP OAuth2 callback")
 	flag.IntVar(&callbackTimeout, "callback-timeout", DefaultCallbackTimeout, "timeout in seconds for IdP auth flow")
 	flag.IntVar(&expiryTime, "expiry-time", 0, "expiry time in minutes for the certificate")
 	flag.StringVar(&caCertFile, "cacert", "", "CA certificate file")


### PR DESCRIPTION
# Description

rfc8252 recommends the use of 127.0.0.1 instead of localhost.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

