### PR TITLE
Add support for IAM role path for SIA EC2, Fargate, EKS

### DIFF
--- a/libs/go/sia/agent/agent.go
+++ b/libs/go/sia/agent/agent.go
@@ -408,6 +408,7 @@ func setUpAttestationRequest(opts *sc.Options, service, ztsUrl string) *provider
 		UseRegionalSTS: opts.UseRegionalSTS,
 		EC2Document:    opts.EC2Document,
 		EC2Signature:   opts.EC2Signature,
+		RolePath:       opts.RolePath,
 	}
 }
 

--- a/libs/go/sia/aws/attestation/attestation.go
+++ b/libs/go/sia/aws/attestation/attestation.go
@@ -69,7 +69,7 @@ func New(domain, service, region, account, ec2Document, ec2Signature string, use
 	return string(data), nil
 }
 
-func getSTSToken(useRegionalSTS bool, region, account, role string) (*sts.AssumeRoleOutput, error) {
+func getSTSToken(useRegionalSTS bool, region, account, role, rolePath string) (*sts.AssumeRoleOutput, error) {
 	// Attempt STS AssumeRole
 	stsClient, err := stssession.New(useRegionalSTS, region)
 	if err != nil {

--- a/libs/go/sia/aws/attestation/attestation.go
+++ b/libs/go/sia/aws/attestation/attestation.go
@@ -41,7 +41,7 @@ type AttestationData struct {
 // New creates a new AttestationData with values fed to it and from the result of STS Assume Role.
 // This requires an identity document along with its signature. The aws account and region will
 // be extracted from the identity document.
-func New(domain, service, region, account, ec2Document, ec2Signature string, useRegionalSTS, omitDomain bool) (string, error) {
+func New(domain, service, region, account, ec2Document, ec2Signature string, useRegionalSTS, omitDomain bool, rolePath string) (string, error) {
 	commonName := fmt.Sprintf("%s.%s", domain, service)
 	var role string
 	if omitDomain {
@@ -49,7 +49,7 @@ func New(domain, service, region, account, ec2Document, ec2Signature string, use
 	} else {
 		role = commonName
 	}
-	tok, err := getSTSToken(useRegionalSTS, region, account, role)
+	tok, err := getSTSToken(useRegionalSTS, region, account, role, rolePath)
 	if err != nil {
 		return "", err
 	}
@@ -76,7 +76,12 @@ func getSTSToken(useRegionalSTS bool, region, account, role string) (*sts.Assume
 		log.Printf("unable to create new session: %v\n", err)
 		return nil, err
 	}
-	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", account, role)
+	var roleArn string
+	if rolePath != "" {
+	    roleArn = fmt.Sprintf("arn:aws:iam::%s:role/%s/%s", account, rolePath, role)
+    } else {
+        roleArn = fmt.Sprintf("arn:aws:iam::%s:role/%s", account, role)
+    }
 	log.Printf("Trying to assume role: %v\n", roleArn)
 	return stsClient.AssumeRole(context.TODO(), &sts.AssumeRoleInput{
 		RoleArn:         &roleArn,

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -272,6 +272,9 @@ func InitEnvConfig(config *sc.Config) (*sc.Config, *sc.ConfigAccount, error) {
 	if !config.RunAfterFailExit {
 		config.RunAfterFailExit = util.ParseEnvBooleanFlag("ATHENZ_SIA_RUN_AFTER_FAIL_EXIT")
 	}
+    if config.RolePath == "" {
+        config.RolePath = os.Getenv("ATHENZ_SIA_ROLE_PATH")
+    }
 
 	roleArn := os.Getenv("ATHENZ_SIA_IAM_ROLE_ARN")
 	if roleArn == "" {

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -398,6 +398,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 	runAfterFailExit := false
 	roleCertsRequired := false
 	httpPort := 0
+	rolePath := ""
 
 	var storeTokenOption *int
 	if config != nil {
@@ -416,6 +417,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		runAfterFailExit = config.RunAfterFailExit
 		roleCertsRequired = config.RoleCertsRequired
 		httpPort = config.HttpPort
+		rolePath = config.RolePath
 
 		if config.RefreshInterval > 0 {
 			refreshInterval = config.RefreshInterval
@@ -669,6 +671,7 @@ func setOptions(config *sc.Config, account *sc.ConfigAccount, profileConfig *sc.
 		RoleCertsRequired:      roleCertsRequired,
 		OTel:                   oTelCfg,
 		HttpPort:               httpPort,
+		RolePath:               rolePath,
 	}, nil
 }
 

--- a/libs/go/sia/config/config.go
+++ b/libs/go/sia/config/config.go
@@ -113,6 +113,7 @@ type Config struct {
 	RoleCertsRequired bool                     `json:"role_certs_required,omitempty"`        //role certs are required for system operations, fail if not successful
 	OTel              OTel                     `json:"otel"`                                 //OpenTelemetry configuration
 	HttpPort          int                      `json:"http_port,omitempty"`                  //HTTP port for health check
+	RolePath          string                    `json:"role_path,omitempty"`                 //IAM role path prefix
 }
 
 type AccessProfileConfig struct {
@@ -225,6 +226,7 @@ type Options struct {
 	RoleCertsRequired      bool              //role certs are required for system operations, fail if not successful
 	OTel                   OTel              //openTelemetry configuration
 	HttpPort               int               //HTTP port for health check
+	RolePath               string            //IAM role path prefix
 }
 
 // OTel stores the configuration for OpenTelemetry.

--- a/libs/go/sia/host/provider/provider.go
+++ b/libs/go/sia/host/provider/provider.go
@@ -38,6 +38,7 @@ type AttestationRequest struct {
 	Region         string //region name
 	EC2Document    string //EC2 instance identity document (for AWS only)
 	EC2Signature   string //EC2 instance identity document pkcs7 signature (for AWS only)
+	RolePath       string // IAM role path prefix
 }
 
 // Provider is the interface which wraps various Providers known to ZTS

--- a/provider/aws/sia-ec2/provider.go
+++ b/provider/aws/sia-ec2/provider.go
@@ -84,7 +84,7 @@ func (ec2 EC2Provider) GetSuffixes() []string {
 }
 
 func (ec2 EC2Provider) CloudAttestationData(request *provider.AttestationRequest) (string, error) {
-	return attestation.New(request.Domain, request.Service, request.Region, request.Account, request.EC2Document, request.EC2Signature, request.UseRegionalSTS, request.OmitDomain)
+	return attestation.New(request.Domain, request.Service, request.Region, request.Account, request.EC2Document, request.EC2Signature, request.UseRegionalSTS, request.OmitDomain, request.RolePath)
 }
 
 func (ec2 EC2Provider) GetAccountDomainServiceFromMeta(_ string) (string, string, string, error) {

--- a/provider/aws/sia-eks/provider.go
+++ b/provider/aws/sia-eks/provider.go
@@ -82,7 +82,7 @@ func (eks EKSProvider) GetSuffixes() []string {
 }
 
 func (eks EKSProvider) CloudAttestationData(request *provider.AttestationRequest) (string, error) {
-	return attestation.New(request.Domain, request.Service, request.Region, request.Account, request.EC2Document, request.EC2Signature, request.UseRegionalSTS, request.OmitDomain)
+	return attestation.New(request.Domain, request.Service, request.Region, request.Account, request.EC2Document, request.EC2Signature, request.UseRegionalSTS, request.OmitDomain, request.RolePath)
 }
 
 func (eks EKSProvider) GetAccountDomainServiceFromMeta(_ string) (string, string, string, error) {

--- a/provider/aws/sia-fargate/provider.go
+++ b/provider/aws/sia-fargate/provider.go
@@ -81,7 +81,7 @@ func (fargate FargateProvider) GetSuffixes() []string {
 }
 
 func (fargate FargateProvider) CloudAttestationData(request *provider.AttestationRequest) (string, error) {
-	return attestation.New(request.Domain, request.Service, request.Region, request.Account, request.EC2Document, request.EC2Signature, request.UseRegionalSTS, request.OmitDomain)
+	return attestation.New(request.Domain, request.Service, request.Region, request.Account, request.EC2Document, request.EC2Signature, request.UseRegionalSTS, request.OmitDomain, request.RolePath)
 }
 
 func (fargate FargateProvider) GetAccountDomainServiceFromMeta(_ string) (string, string, string, error) {


### PR DESCRIPTION
# Description
SIA EC2, Fargate and EKS currently construct the IAM role ARN for attestation without support for IAM role paths. Organizations that use IAM role paths (e.g., for organizational scoping) cannot use SIA EC2 without modification.

[Link to issue](https://github.com/AthenZ/athenz/issues/3344)

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

