### PR TITLE
Add automated schema migration runner

### DIFF
--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AWSCertRecordStoreFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/cert/impl/AWSCertRecordStoreFactory.java
@@ -29,8 +29,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.common.server.cert.impl.JDBCCertRecordStoreFactory;
 import com.yahoo.athenz.common.server.db.DataSourceFactory;
 import com.yahoo.athenz.common.server.db.PoolableDataSource;
+import com.yahoo.athenz.common.server.db.SchemaMigrationRunner;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.rds.RdsClient;
@@ -78,7 +80,10 @@ public class AWSCertRecordStoreFactory implements CertRecordStoreFactory {
         mysqlConnectionProperties.setProperty(ServerCommonConsts.DB_PROP_PASSWORD, rdsToken);
         
         PoolableDataSource dataSource = DataSourceFactory.create(jdbcStore, mysqlConnectionProperties);
-        
+
+        SchemaMigrationRunner.migrateIfConfigured(dataSource,
+                JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR, "athenz_schema_migration_zts");
+
         long credsRefreshTime = Integer.parseInt(System.getProperty(ZTS_PROP_AWS_RDS_CREDS_REFRESH_TIME, "300"));
 
         ScheduledExecutorService scheduledThreadPool = Executors.newScheduledThreadPool(1);

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/AWSObjectStoreFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/AWSObjectStoreFactory.java
@@ -34,8 +34,10 @@ import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequ
 import com.yahoo.athenz.auth.PrivateKeyStore;
 import com.yahoo.athenz.common.server.db.DataSourceFactory;
 import com.yahoo.athenz.common.server.db.PoolableDataSource;
+import com.yahoo.athenz.common.server.db.SchemaMigrationRunner;
 import com.yahoo.athenz.common.server.store.ObjectStore;
 import com.yahoo.athenz.common.server.store.ObjectStoreFactory;
+import com.yahoo.athenz.common.server.store.impl.JDBCConsts;
 import com.yahoo.athenz.common.server.store.impl.JDBCObjectStore;
 
 public class AWSObjectStoreFactory implements ObjectStoreFactory {
@@ -91,7 +93,10 @@ public class AWSObjectStoreFactory implements ObjectStoreFactory {
 
         setConnectionProperties(MYSQL_PRIMARY_CONNECTION_PROPERTIES, rdsPrimaryToken);
         PoolableDataSource dataPrimarySource = DataSourceFactory.create(jdbcPrimaryStore, MYSQL_PRIMARY_CONNECTION_PROPERTIES);
-        
+
+        SchemaMigrationRunner.migrateIfConfigured(dataPrimarySource,
+                JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR, "athenz_schema_migration_zms");
+
         // now check to see if we also have a read-only replica jdbc store configured
 
         PoolableDataSource dataReplicaSource = null;

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/AWSCertRecordStoreFactoryTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/cert/impl/AWSCertRecordStoreFactoryTest.java
@@ -16,6 +16,11 @@
 package io.athenz.server.aws.common.cert.impl;
 
 import com.yahoo.athenz.common.server.cert.CertRecordStore;
+import com.yahoo.athenz.common.server.cert.impl.JDBCCertRecordStoreFactory;
+import com.yahoo.athenz.common.server.db.PoolableDataSource;
+import com.yahoo.athenz.common.server.db.SchemaMigrationRunner;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -134,5 +139,27 @@ public class AWSCertRecordStoreFactoryTest {
         System.clearProperty(AWSCertRecordStoreFactory.ZTS_PROP_AWS_RDS_PRIMARY_INSTANCE);
         System.clearProperty(AWSCertRecordStoreFactory.ZTS_PROP_AWS_RDS_USER);
         System.clearProperty(AWSCertRecordStoreFactory.ZTS_PROP_AWS_RDS_CREDS_REFRESH_TIME);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        System.clearProperty(JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR);
+    }
+
+    @Test
+    public void testSchemaMigrationNotConfigured() {
+        System.clearProperty(JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR);
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+        SchemaMigrationRunner.migrateIfConfigured(mockDs,
+                JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR, "athenz_schema_migration_zts");
+        Mockito.verifyNoInteractions(mockDs);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSchemaMigrationInvalidDirectory() {
+        System.setProperty(JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR, "/non/existent/dir");
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+        SchemaMigrationRunner.migrateIfConfigured(mockDs,
+                JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR, "athenz_schema_migration_zts");
     }
 }

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/AWSObjectStoreFactoryTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/AWSObjectStoreFactoryTest.java
@@ -15,7 +15,12 @@
  */
 package io.athenz.server.aws.common.store.impl;
 
+import com.yahoo.athenz.common.server.db.PoolableDataSource;
+import com.yahoo.athenz.common.server.db.SchemaMigrationRunner;
 import com.yahoo.athenz.common.server.store.ObjectStore;
+import com.yahoo.athenz.common.server.store.impl.JDBCConsts;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;
@@ -109,5 +114,27 @@ public class AWSObjectStoreFactoryTest {
         System.clearProperty(AWSObjectStoreFactory.ZMS_PROP_AWS_RDS_REPLICA_INSTANCE);
         System.clearProperty(AWSObjectStoreFactory.ZMS_PROP_AWS_RDS_USER);
         System.clearProperty(AWSObjectStoreFactory.ZMS_PROP_AWS_RDS_CREDS_REFRESH_TIME);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        System.clearProperty(JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR);
+    }
+
+    @Test
+    public void testSchemaMigrationNotConfigured() {
+        System.clearProperty(JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR);
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+        SchemaMigrationRunner.migrateIfConfigured(mockDs,
+                JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR, "athenz_schema_migration_zms");
+        Mockito.verifyNoInteractions(mockDs);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testSchemaMigrationInvalidDirectory() {
+        System.setProperty(JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR, "/non/existent/dir");
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+        SchemaMigrationRunner.migrateIfConfigured(mockDs,
+                JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR, "athenz_schema_migration_zms");
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreFactory.java
@@ -23,6 +23,7 @@ import com.yahoo.athenz.common.server.cert.CertRecordStore;
 import com.yahoo.athenz.common.server.cert.CertRecordStoreFactory;
 import com.yahoo.athenz.common.server.db.DataSourceFactory;
 import com.yahoo.athenz.common.server.db.PoolableDataSource;
+import com.yahoo.athenz.common.server.db.SchemaMigrationRunner;
 import com.yahoo.athenz.common.server.ServerResourceException;
 
 public class JDBCCertRecordStoreFactory implements CertRecordStoreFactory {
@@ -36,7 +37,8 @@ public class JDBCCertRecordStoreFactory implements CertRecordStoreFactory {
     public static final String ZTS_PROP_CERT_JDBC_USE_SSL                       = "athenz.zts.cert_jdbc_use_ssl";
     public static final String ZTS_PROP_CERT_OP_TIMEOUT                         = "athenz.zts.cert_op_timeout";
     public static final String ZTS_PROP_CERT_FILE_STORE_PATH                    = "athenz.zts.cert_file_store_path";
-    
+    public static final String ZTS_PROP_SCHEMA_MIGRATION_DIR                    = "athenz.zts.schema_migration_dir";
+
     private static final String JDBC = "jdbc";
     
     @Override
@@ -58,6 +60,8 @@ public class JDBCCertRecordStoreFactory implements CertRecordStoreFactory {
 
         PoolableDataSource src = DataSourceFactory.create(jdbcStore, props);
 
+        runSchemaMigrations(src);
+
         // set default timeout for our connections
 
         JDBCCertRecordStore certStore = new JDBCCertRecordStore(src);
@@ -65,5 +69,10 @@ public class JDBCCertRecordStoreFactory implements CertRecordStoreFactory {
         certStore.setOperationTimeout(opTimeout);
 
         return certStore;
+    }
+
+    void runSchemaMigrations(PoolableDataSource dataSource) {
+        SchemaMigrationRunner.migrateIfConfigured(dataSource,
+                ZTS_PROP_SCHEMA_MIGRATION_DIR, "athenz_schema_migration_zts");
     }
 }

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunner.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunner.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.common.server.db;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.sql.DataSource;
+
+import org.eclipse.jetty.util.StringUtil;
+
+public class SchemaMigrationRunner {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SchemaMigrationRunner.class);
+
+    static final String MIGRATION_FILE_PATTERN = "update-*.sql";
+    static final Pattern VERSION_PATTERN = Pattern.compile("update-(\\d{8})\\.sql");
+    static final String DEFAULT_LOCK_NAME = "athenz_schema_migration";
+    static final int LOCK_TIMEOUT_SECONDS = 30;
+
+    static final int MYSQL_ER_DUP_FIELDNAME = 1060;
+    static final int MYSQL_ER_DUP_KEYNAME = 1061;
+    static final int MYSQL_ER_TABLE_EXISTS = 1050;
+    static final int MYSQL_ER_DUP_ENTRY = 1062;
+
+    static final String CREATE_SCHEMA_VERSION_TABLE =
+            "CREATE TABLE IF NOT EXISTS `schema_version` (" +
+            "  `version` VARCHAR(64) NOT NULL," +
+            "  `script` VARCHAR(256) NOT NULL," +
+            "  `installed_on` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)," +
+            "  `execution_time_ms` INT UNSIGNED NOT NULL DEFAULT 0," +
+            "  `success` TINYINT(1) NOT NULL DEFAULT 1," +
+            "  PRIMARY KEY (`version`)" +
+            ") ENGINE = InnoDB";
+
+    static final String SELECT_APPLIED_VERSIONS =
+            "SELECT `version` FROM `schema_version` WHERE `success` = 1";
+
+    static final String INSERT_SCHEMA_VERSION =
+            "INSERT INTO `schema_version` (`version`, `script`, `execution_time_ms`, `success`) " +
+            "VALUES (?, ?, ?, ?) " +
+            "ON DUPLICATE KEY UPDATE `script` = VALUES(`script`), " +
+            "`execution_time_ms` = VALUES(`execution_time_ms`), " +
+            "`success` = VALUES(`success`), " +
+            "`installed_on` = CURRENT_TIMESTAMP(3)";
+
+    private final DataSource dataSource;
+    private final String lockName;
+
+    public SchemaMigrationRunner(DataSource dataSource) {
+        this(dataSource, DEFAULT_LOCK_NAME);
+    }
+
+    public SchemaMigrationRunner(DataSource dataSource, String lockName) {
+        this.dataSource = dataSource;
+        this.lockName = lockName;
+    }
+
+    public static void migrateIfConfigured(DataSource dataSource, String propertyName, String lockName) {
+        final String migrationDir = System.getProperty(propertyName);
+        if (StringUtil.isEmpty(migrationDir)) {
+            return;
+        }
+        LOGGER.info("Running schema migrations from: {}", migrationDir);
+        new SchemaMigrationRunner(dataSource, lockName).migrate(migrationDir);
+    }
+
+    public void migrate(String migrationDirPath) {
+
+        Path migrationDir = Paths.get(migrationDirPath);
+        if (!Files.isDirectory(migrationDir)) {
+            LOGGER.error("Schema migration directory does not exist: {}", migrationDirPath);
+            throw new IllegalArgumentException("Schema migration directory does not exist: " + migrationDirPath);
+        }
+
+        List<Path> migrationFiles = findMigrationFiles(migrationDir);
+        if (migrationFiles.isEmpty()) {
+            LOGGER.info("No migration files found in: {}", migrationDirPath);
+            return;
+        }
+
+        LOGGER.info("Found {} migration file(s) in: {}", migrationFiles.size(), migrationDirPath);
+
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+
+            acquireLock(conn);
+            try {
+                createSchemaVersionTable(conn);
+                Set<String> appliedVersions = getAppliedVersions(conn);
+                LOGGER.info("Schema version table has {} previously applied migration(s)", appliedVersions.size());
+
+                int applied = 0;
+                for (Path file : migrationFiles) {
+                    String version = extractVersion(file.getFileName().toString());
+                    if (appliedVersions.contains(version)) {
+                        continue;
+                    }
+                    applyMigration(conn, file, version);
+                    applied++;
+                }
+
+                if (applied > 0) {
+                    LOGGER.info("Applied {} new migration(s)", applied);
+                } else {
+                    LOGGER.info("Schema is up to date, no new migrations to apply");
+                }
+            } finally {
+                releaseLock(conn);
+            }
+        } catch (SQLException ex) {
+            LOGGER.error("Failed to run schema migrations", ex);
+            throw new RuntimeException("Failed to run schema migrations", ex);
+        }
+    }
+
+    List<Path> findMigrationFiles(Path migrationDir) {
+        List<Path> files = new ArrayList<>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(migrationDir, MIGRATION_FILE_PATTERN)) {
+            for (Path entry : stream) {
+                if (VERSION_PATTERN.matcher(entry.getFileName().toString()).matches()) {
+                    files.add(entry);
+                }
+            }
+        } catch (IOException ex) {
+            LOGGER.error("Failed to scan migration directory: {}", migrationDir, ex);
+            throw new RuntimeException("Failed to scan migration directory", ex);
+        }
+        Collections.sort(files);
+        return files;
+    }
+
+    static String extractVersion(String filename) {
+        Matcher matcher = VERSION_PATTERN.matcher(filename);
+        if (!matcher.matches()) {
+            throw new IllegalArgumentException("Invalid migration filename: " + filename);
+        }
+        return matcher.group(1);
+    }
+
+    void createSchemaVersionTable(Connection conn) throws SQLException {
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute(CREATE_SCHEMA_VERSION_TABLE);
+        }
+    }
+
+    Set<String> getAppliedVersions(Connection conn) throws SQLException {
+        Set<String> versions = new HashSet<>();
+        try (Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(SELECT_APPLIED_VERSIONS)) {
+            while (rs.next()) {
+                versions.add(rs.getString("version"));
+            }
+        }
+        return versions;
+    }
+
+    void applyMigration(Connection conn, Path file, String version) throws SQLException {
+
+        LOGGER.info("Applying migration: {} (version {})", file.getFileName(), version);
+
+        String content;
+        try {
+            content = Files.readString(file, StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            LOGGER.error("Failed to read migration file: {}", file, ex);
+            throw new RuntimeException("Failed to read migration file: " + file, ex);
+        }
+
+        List<String> statements = parseStatements(content);
+        long startTime = System.currentTimeMillis();
+
+        try (Statement stmt = conn.createStatement()) {
+            for (String sql : statements) {
+                try {
+                    stmt.execute(sql);
+                } catch (SQLException ex) {
+                    if (!isSafeError(ex)) {
+                        LOGGER.error("Migration {} failed on statement: {}", version, truncate(sql, 200), ex);
+                        recordMigration(conn, version, file.getFileName().toString(),
+                                System.currentTimeMillis() - startTime, false);
+                        throw ex;
+                    }
+                    LOGGER.info("Migration {} statement already applied ({}): {}",
+                            version, ex.getMessage(), truncate(sql, 100));
+                }
+            }
+        }
+
+        long duration = System.currentTimeMillis() - startTime;
+        recordMigration(conn, version, file.getFileName().toString(), duration, true);
+        LOGGER.info("Migration {} completed in {} ms", version, duration);
+    }
+
+    void recordMigration(Connection conn, String version, String script,
+                         long executionTimeMs, boolean success) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement(INSERT_SCHEMA_VERSION)) {
+            stmt.setString(1, version);
+            stmt.setString(2, script);
+            stmt.setLong(3, executionTimeMs);
+            stmt.setBoolean(4, success);
+            stmt.executeUpdate();
+        }
+    }
+
+    static List<String> parseStatements(String content) {
+        List<String> statements = new ArrayList<>();
+        StringBuilder current = new StringBuilder();
+
+        for (String line : content.split("\n")) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("--")) {
+                continue;
+            }
+            if (current.length() > 0) {
+                current.append('\n');
+            }
+            current.append(line);
+            if (trimmed.endsWith(";")) {
+                addStatement(statements, current.toString());
+                current.setLength(0);
+            }
+        }
+
+        addStatement(statements, current.toString());
+        return statements;
+    }
+
+    private static void addStatement(List<String> statements, String raw) {
+        String sql = raw.trim();
+        if (sql.endsWith(";")) {
+            sql = sql.substring(0, sql.length() - 1).trim();
+        }
+        if (!sql.isEmpty()) {
+            statements.add(sql);
+        }
+    }
+
+    static boolean isSafeError(SQLException ex) {
+        int errorCode = ex.getErrorCode();
+        return errorCode == MYSQL_ER_DUP_FIELDNAME ||
+               errorCode == MYSQL_ER_DUP_KEYNAME ||
+               errorCode == MYSQL_ER_TABLE_EXISTS ||
+               errorCode == MYSQL_ER_DUP_ENTRY;
+    }
+
+    void acquireLock(Connection conn) throws SQLException {
+        try (PreparedStatement stmt = conn.prepareStatement("SELECT GET_LOCK(?, ?)")) {
+            stmt.setString(1, lockName);
+            stmt.setInt(2, LOCK_TIMEOUT_SECONDS);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (!rs.next() || rs.getInt(1) != 1) {
+                    throw new SQLException("Failed to acquire migration lock '" + lockName +
+                            "' within " + LOCK_TIMEOUT_SECONDS + " seconds");
+                }
+            }
+        }
+        LOGGER.debug("Acquired migration lock: {}", lockName);
+    }
+
+    void releaseLock(Connection conn) {
+        try (PreparedStatement stmt = conn.prepareStatement("SELECT RELEASE_LOCK(?)")) {
+            stmt.setString(1, lockName);
+            stmt.executeQuery();
+            LOGGER.debug("Released migration lock: {}", lockName);
+        } catch (SQLException ex) {
+            LOGGER.warn("Failed to release migration lock: {}", lockName, ex);
+        }
+    }
+
+    static String truncate(String str, int maxLen) {
+        if (str.length() <= maxLen) {
+            return str;
+        }
+        return str.substring(0, maxLen) + "...";
+    }
+}

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunner.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunner.java
@@ -50,6 +50,7 @@ public class SchemaMigrationRunner {
     static final int MYSQL_ER_DUP_KEYNAME = 1061;
     static final int MYSQL_ER_TABLE_EXISTS = 1050;
     static final int MYSQL_ER_DUP_ENTRY = 1062;
+    static final int MYSQL_ER_MULTIPLE_PRI_KEY = 1068;
 
     static final String CREATE_SCHEMA_VERSION_TABLE =
             "CREATE TABLE IF NOT EXISTS `schema_version` (" +
@@ -269,7 +270,8 @@ public class SchemaMigrationRunner {
         return errorCode == MYSQL_ER_DUP_FIELDNAME ||
                errorCode == MYSQL_ER_DUP_KEYNAME ||
                errorCode == MYSQL_ER_TABLE_EXISTS ||
-               errorCode == MYSQL_ER_DUP_ENTRY;
+               errorCode == MYSQL_ER_DUP_ENTRY ||
+               errorCode == MYSQL_ER_MULTIPLE_PRI_KEY;
     }
 
     void acquireLock(Connection conn) throws SQLException {

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/JDBCConsts.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/JDBCConsts.java
@@ -32,6 +32,7 @@ public final class JDBCConsts {
     public static final String ZMS_PROP_JDBC_USE_SSL            = "athenz.zms.jdbc_use_ssl";
     public static final String ZMS_PROP_JDBC_TLS_VERSIONS       = "athenz.zms.jdbc_tls_versions";
     public static final String ZMS_PROP_JDBC_DRIVER_CLASS       = "athenz.db.driver.class";
+    public static final String ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR = "athenz.zms.schema_migration_dir";
 
     public static final String ZMS_PROP_MYSQL_SERVER_TIMEZONE = "athenz.zms.mysql_server_timezone";
     public static final String ZMS_PROP_MYSQL_SERVER_TRUST_ROLES_UPDATE_TIMEOUT = "athenz.zms.mysql_server_trust_roles_update_timeout";

--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/JDBCObjectStoreFactory.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/store/impl/JDBCObjectStoreFactory.java
@@ -21,6 +21,7 @@ import com.yahoo.athenz.auth.PrivateKeyStore;
 import com.yahoo.athenz.common.ServerCommonConsts;
 import com.yahoo.athenz.common.server.db.DataSourceFactory;
 import com.yahoo.athenz.common.server.db.PoolableDataSource;
+import com.yahoo.athenz.common.server.db.SchemaMigrationRunner;
 import com.yahoo.athenz.common.server.store.ObjectStore;
 import com.yahoo.athenz.common.server.store.ObjectStoreFactory;
 import org.eclipse.jetty.util.StringUtil;
@@ -54,7 +55,9 @@ public class JDBCObjectStoreFactory implements ObjectStoreFactory {
         final String jdbcKeygroupName = System.getProperty(JDBCConsts.ZMS_PROP_JDBC_KEYGROUP_NAME, "");
         Properties readWriteProperties = getProperties(jdbcUser, keyStore.getSecret(jdbcAppName, jdbcKeygroupName, password));
         PoolableDataSource readWriteSrc = DataSourceFactory.create(jdbcStore, readWriteProperties);
-        
+
+        runSchemaMigrations(readWriteSrc);
+
         // now check to see if we also have a read-only jdbc store configured
         // if no username and password are specified then we'll use the
         // read-write store credentials
@@ -68,6 +71,11 @@ public class JDBCObjectStoreFactory implements ObjectStoreFactory {
             readOnlySrc = DataSourceFactory.create(jdbcReadOnlyStore, readOnlyProperties);
         }
         return new JDBCObjectStore(readWriteSrc, readOnlySrc);
+    }
+
+    void runSchemaMigrations(PoolableDataSource dataSource) {
+        SchemaMigrationRunner.migrateIfConfigured(dataSource,
+                JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR, "athenz_schema_migration_zms");
     }
 
     String getDefaultSetting(final String propName, final String defaultValue) {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreFactoryTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreFactoryTest.java
@@ -16,7 +16,9 @@
 package com.yahoo.athenz.common.server.cert.impl;
 
 import com.yahoo.athenz.common.server.ServerResourceException;
+import com.yahoo.athenz.common.server.db.PoolableDataSource;
 import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import com.yahoo.athenz.auth.PrivateKeyStore;
@@ -39,5 +41,41 @@ public class JDBCCertRecordStoreFactoryTest {
         JDBCCertRecordStoreFactory factory = new JDBCCertRecordStoreFactory();
         CertRecordStore store = factory.create(keyStore);
         assertNotNull(store);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        System.clearProperty(JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR);
+    }
+
+    @Test
+    public void testRunSchemaMigrationsNotConfigured() {
+        System.clearProperty(JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR);
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+
+        JDBCCertRecordStoreFactory factory = new JDBCCertRecordStoreFactory();
+        factory.runSchemaMigrations(mockDs);
+
+        Mockito.verifyNoInteractions(mockDs);
+    }
+
+    @Test
+    public void testRunSchemaMigrationsEmptyProperty() {
+        System.setProperty(JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR, "");
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+
+        JDBCCertRecordStoreFactory factory = new JDBCCertRecordStoreFactory();
+        factory.runSchemaMigrations(mockDs);
+
+        Mockito.verifyNoInteractions(mockDs);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRunSchemaMigrationsInvalidDirectory() {
+        System.setProperty(JDBCCertRecordStoreFactory.ZTS_PROP_SCHEMA_MIGRATION_DIR, "/non/existent/dir");
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+
+        JDBCCertRecordStoreFactory factory = new JDBCCertRecordStoreFactory();
+        factory.runSchemaMigrations(mockDs);
     }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunnerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunnerTest.java
@@ -1,0 +1,447 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.common.server.db;
+
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.*;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.*;
+
+public class SchemaMigrationRunnerTest {
+
+    private Path tempDir;
+    private PoolableDataSource mockDataSource;
+    private Connection mockConnection;
+    private Statement mockStatement;
+    private PreparedStatement mockPreparedStatement;
+    private ResultSet mockResultSet;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        tempDir = Files.createTempDirectory("migration-test");
+        mockDataSource = Mockito.mock(PoolableDataSource.class);
+        mockConnection = Mockito.mock(Connection.class);
+        mockStatement = Mockito.mock(Statement.class);
+        mockPreparedStatement = Mockito.mock(PreparedStatement.class);
+        mockResultSet = Mockito.mock(ResultSet.class);
+
+        when(mockDataSource.getConnection()).thenReturn(mockConnection);
+        when(mockConnection.createStatement()).thenReturn(mockStatement);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(mockPreparedStatement);
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        if (tempDir != null) {
+            Files.walk(tempDir)
+                    .sorted(java.util.Comparator.reverseOrder())
+                    .forEach(p -> {
+                        try { Files.deleteIfExists(p); } catch (IOException ignored) {}
+                    });
+        }
+    }
+
+    @Test
+    public void testParseStatementsSingleStatement() {
+        List<String> stmts = SchemaMigrationRunner.parseStatements(
+                "ALTER TABLE `zms_server`.`domain` ADD `cert_dns_domain` VARCHAR(256) NOT NULL DEFAULT '';\n");
+        assertEquals(stmts.size(), 1);
+        assertEquals(stmts.get(0),
+                "ALTER TABLE `zms_server`.`domain` ADD `cert_dns_domain` VARCHAR(256) NOT NULL DEFAULT ''");
+    }
+
+    @Test
+    public void testParseStatementsMultipleStatements() {
+        String content = "ALTER TABLE `zms_server`.`quota` ADD `principal_group` INT;\n" +
+                "ALTER TABLE `zms_server`.`quota` ADD `principal_group_member` INT;\n";
+        List<String> stmts = SchemaMigrationRunner.parseStatements(content);
+        assertEquals(stmts.size(), 2);
+    }
+
+    @Test
+    public void testParseStatementsWithComments() {
+        String content = "-- This is a comment\n" +
+                "-- Another comment\n" +
+                "ALTER TABLE `zms_server`.`domain` ADD `test` VARCHAR(256);\n";
+        List<String> stmts = SchemaMigrationRunner.parseStatements(content);
+        assertEquals(stmts.size(), 1);
+        assertTrue(stmts.get(0).startsWith("ALTER TABLE"));
+    }
+
+    @Test
+    public void testParseStatementsMultiLineStatement() {
+        String content = "CREATE TABLE IF NOT EXISTS `zms_server`.`role_tags` (\n" +
+                "  `role_id` INT UNSIGNED NOT NULL,\n" +
+                "  `key` VARCHAR(64) NOT NULL,\n" +
+                "  PRIMARY KEY (`role_id`, `key`)\n" +
+                ") ENGINE = InnoDB;\n";
+        List<String> stmts = SchemaMigrationRunner.parseStatements(content);
+        assertEquals(stmts.size(), 1);
+        assertTrue(stmts.get(0).startsWith("CREATE TABLE"));
+        assertTrue(stmts.get(0).endsWith(") ENGINE = InnoDB"));
+    }
+
+    @Test
+    public void testParseStatementsEmpty() {
+        List<String> stmts = SchemaMigrationRunner.parseStatements("");
+        assertTrue(stmts.isEmpty());
+    }
+
+    @Test
+    public void testParseStatementsOnlyComments() {
+        List<String> stmts = SchemaMigrationRunner.parseStatements("-- comment\n-- another\n");
+        assertTrue(stmts.isEmpty());
+    }
+
+    @Test
+    public void testParseStatementsNoTrailingSemicolon() {
+        String content = "ALTER TABLE `zms_server`.`domain` ADD `test` VARCHAR(256)";
+        List<String> stmts = SchemaMigrationRunner.parseStatements(content);
+        assertEquals(stmts.size(), 1);
+        assertEquals(stmts.get(0), "ALTER TABLE `zms_server`.`domain` ADD `test` VARCHAR(256)");
+    }
+
+    @Test
+    public void testExtractVersion() {
+        assertEquals(SchemaMigrationRunner.extractVersion("update-20260421.sql"), "20260421");
+        assertEquals(SchemaMigrationRunner.extractVersion("update-20190107.sql"), "20190107");
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testExtractVersionInvalidFilename() {
+        SchemaMigrationRunner.extractVersion("not-a-migration.sql");
+    }
+
+    @Test
+    public void testIsSafeErrorDuplicateColumn() {
+        SQLException ex = new SQLException("Duplicate column name 'test'", "HY000", 1060);
+        assertTrue(SchemaMigrationRunner.isSafeError(ex));
+    }
+
+    @Test
+    public void testIsSafeErrorDuplicateKey() {
+        SQLException ex = new SQLException("Duplicate key name 'idx'", "HY000", 1061);
+        assertTrue(SchemaMigrationRunner.isSafeError(ex));
+    }
+
+    @Test
+    public void testIsSafeErrorTableExists() {
+        SQLException ex = new SQLException("Table already exists", "HY000", 1050);
+        assertTrue(SchemaMigrationRunner.isSafeError(ex));
+    }
+
+    @Test
+    public void testIsSafeErrorDuplicateEntry() {
+        SQLException ex = new SQLException("Duplicate entry", "HY000", 1062);
+        assertTrue(SchemaMigrationRunner.isSafeError(ex));
+    }
+
+    @Test
+    public void testIsSafeErrorUnsafeError() {
+        SQLException ex = new SQLException("Syntax error", "HY000", 1064);
+        assertFalse(SchemaMigrationRunner.isSafeError(ex));
+    }
+
+    @Test
+    public void testTruncate() {
+        assertEquals(SchemaMigrationRunner.truncate("short", 100), "short");
+        String longStr = "a".repeat(200);
+        String truncated = SchemaMigrationRunner.truncate(longStr, 10);
+        assertEquals(truncated.length(), 13); // 10 + "..."
+        assertTrue(truncated.endsWith("..."));
+    }
+
+    @Test
+    public void testFindMigrationFiles() throws Exception {
+        Files.writeString(tempDir.resolve("update-20190107.sql"), "SELECT 1;");
+        Files.writeString(tempDir.resolve("update-20260421.sql"), "SELECT 2;");
+        Files.writeString(tempDir.resolve("update-20200506.sql"), "SELECT 3;");
+        Files.writeString(tempDir.resolve("not-a-migration.txt"), "ignored");
+        Files.writeString(tempDir.resolve("update-bad.sql"), "also ignored");
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        List<Path> files = runner.findMigrationFiles(tempDir);
+
+        assertEquals(files.size(), 3);
+        assertTrue(files.get(0).getFileName().toString().contains("20190107"));
+        assertTrue(files.get(1).getFileName().toString().contains("20200506"));
+        assertTrue(files.get(2).getFileName().toString().contains("20260421"));
+    }
+
+    @Test
+    public void testFindMigrationFilesEmptyDir() throws Exception {
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        List<Path> files = runner.findMigrationFiles(tempDir);
+        assertTrue(files.isEmpty());
+    }
+
+    @Test
+    public void testMigrateNoMigrationFiles() throws Exception {
+        when(mockStatement.executeQuery(SchemaMigrationRunner.SELECT_APPLIED_VERSIONS))
+                .thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+        when(mockPreparedStatement.executeQuery()).thenReturn(mockResultSet);
+        when(mockResultSet.getInt(1)).thenReturn(1);
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.migrate(tempDir.toString());
+
+        verify(mockConnection, never()).prepareStatement(SchemaMigrationRunner.INSERT_SCHEMA_VERSION);
+    }
+
+    @Test
+    public void testMigrateAppliesPendingMigrations() throws Exception {
+        Files.writeString(tempDir.resolve("update-20190107.sql"),
+                "ALTER TABLE `test` ADD `col1` VARCHAR(256);\n");
+        Files.writeString(tempDir.resolve("update-20200506.sql"),
+                "ALTER TABLE `test` ADD `col2` VARCHAR(256);\n");
+
+        ResultSet lockResultSet = Mockito.mock(ResultSet.class);
+        when(lockResultSet.next()).thenReturn(true);
+        when(lockResultSet.getInt(1)).thenReturn(1);
+
+        PreparedStatement lockStmt = Mockito.mock(PreparedStatement.class);
+        when(lockStmt.executeQuery()).thenReturn(lockResultSet);
+
+        PreparedStatement releaseLockStmt = Mockito.mock(PreparedStatement.class);
+        ResultSet releaseLockRs = Mockito.mock(ResultSet.class);
+        when(releaseLockStmt.executeQuery()).thenReturn(releaseLockRs);
+
+        PreparedStatement insertStmt = Mockito.mock(PreparedStatement.class);
+
+        when(mockConnection.prepareStatement("SELECT GET_LOCK(?, ?)")).thenReturn(lockStmt);
+        when(mockConnection.prepareStatement("SELECT RELEASE_LOCK(?)")).thenReturn(releaseLockStmt);
+        when(mockConnection.prepareStatement(SchemaMigrationRunner.INSERT_SCHEMA_VERSION)).thenReturn(insertStmt);
+
+        when(mockStatement.executeQuery(SchemaMigrationRunner.SELECT_APPLIED_VERSIONS))
+                .thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.migrate(tempDir.toString());
+
+        verify(mockStatement, times(3)).execute(anyString());
+        verify(insertStmt, times(2)).executeUpdate();
+    }
+
+    @Test
+    public void testMigrateSkipsAlreadyApplied() throws Exception {
+        Files.writeString(tempDir.resolve("update-20190107.sql"),
+                "ALTER TABLE `test` ADD `col1` VARCHAR(256);\n");
+        Files.writeString(tempDir.resolve("update-20200506.sql"),
+                "ALTER TABLE `test` ADD `col2` VARCHAR(256);\n");
+
+        ResultSet lockResultSet = Mockito.mock(ResultSet.class);
+        when(lockResultSet.next()).thenReturn(true);
+        when(lockResultSet.getInt(1)).thenReturn(1);
+
+        PreparedStatement lockStmt = Mockito.mock(PreparedStatement.class);
+        when(lockStmt.executeQuery()).thenReturn(lockResultSet);
+
+        PreparedStatement releaseLockStmt = Mockito.mock(PreparedStatement.class);
+        ResultSet releaseLockRs = Mockito.mock(ResultSet.class);
+        when(releaseLockStmt.executeQuery()).thenReturn(releaseLockRs);
+
+        PreparedStatement insertStmt = Mockito.mock(PreparedStatement.class);
+
+        when(mockConnection.prepareStatement("SELECT GET_LOCK(?, ?)")).thenReturn(lockStmt);
+        when(mockConnection.prepareStatement("SELECT RELEASE_LOCK(?)")).thenReturn(releaseLockStmt);
+        when(mockConnection.prepareStatement(SchemaMigrationRunner.INSERT_SCHEMA_VERSION)).thenReturn(insertStmt);
+
+        ResultSet appliedRs = Mockito.mock(ResultSet.class);
+        when(mockStatement.executeQuery(SchemaMigrationRunner.SELECT_APPLIED_VERSIONS))
+                .thenReturn(appliedRs);
+        when(appliedRs.next()).thenReturn(true, false);
+        when(appliedRs.getString("version")).thenReturn("20190107");
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.migrate(tempDir.toString());
+
+        // schema_version table creation + 1 migration statement (only 20200506, not 20190107)
+        verify(mockStatement, times(2)).execute(anyString());
+        verify(insertStmt, times(1)).executeUpdate();
+    }
+
+    @Test
+    public void testMigrateHandlesSafeErrors() throws Exception {
+        Files.writeString(tempDir.resolve("update-20190107.sql"),
+                "ALTER TABLE `test` ADD `col1` VARCHAR(256);\n");
+
+        ResultSet lockResultSet = Mockito.mock(ResultSet.class);
+        when(lockResultSet.next()).thenReturn(true);
+        when(lockResultSet.getInt(1)).thenReturn(1);
+
+        PreparedStatement lockStmt = Mockito.mock(PreparedStatement.class);
+        when(lockStmt.executeQuery()).thenReturn(lockResultSet);
+
+        PreparedStatement releaseLockStmt = Mockito.mock(PreparedStatement.class);
+        ResultSet releaseLockRs = Mockito.mock(ResultSet.class);
+        when(releaseLockStmt.executeQuery()).thenReturn(releaseLockRs);
+
+        PreparedStatement insertStmt = Mockito.mock(PreparedStatement.class);
+
+        when(mockConnection.prepareStatement("SELECT GET_LOCK(?, ?)")).thenReturn(lockStmt);
+        when(mockConnection.prepareStatement("SELECT RELEASE_LOCK(?)")).thenReturn(releaseLockStmt);
+        when(mockConnection.prepareStatement(SchemaMigrationRunner.INSERT_SCHEMA_VERSION)).thenReturn(insertStmt);
+
+        when(mockStatement.executeQuery(SchemaMigrationRunner.SELECT_APPLIED_VERSIONS))
+                .thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        Statement migrationStmt = Mockito.mock(Statement.class);
+        // createStatement() is called for: schema_version table, getAppliedVersions, migration
+        when(mockConnection.createStatement()).thenReturn(mockStatement, mockStatement, migrationStmt);
+        doThrow(new SQLException("Duplicate column name 'col1'", "HY000", 1060))
+                .when(migrationStmt).execute(anyString());
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.migrate(tempDir.toString());
+
+        // Should still record the migration as successful
+        verify(insertStmt, times(1)).executeUpdate();
+        verify(insertStmt).setBoolean(4, true);
+    }
+
+    @Test(expectedExceptions = RuntimeException.class)
+    public void testMigrateThrowsOnUnsafeError() throws Exception {
+        Files.writeString(tempDir.resolve("update-20190107.sql"),
+                "ALTER TABLE `test` ADD `col1` VARCHAR(256);\n");
+
+        ResultSet lockResultSet = Mockito.mock(ResultSet.class);
+        when(lockResultSet.next()).thenReturn(true);
+        when(lockResultSet.getInt(1)).thenReturn(1);
+
+        PreparedStatement lockStmt = Mockito.mock(PreparedStatement.class);
+        when(lockStmt.executeQuery()).thenReturn(lockResultSet);
+
+        PreparedStatement releaseLockStmt = Mockito.mock(PreparedStatement.class);
+        ResultSet releaseLockRs = Mockito.mock(ResultSet.class);
+        when(releaseLockStmt.executeQuery()).thenReturn(releaseLockRs);
+
+        PreparedStatement insertStmt = Mockito.mock(PreparedStatement.class);
+
+        when(mockConnection.prepareStatement("SELECT GET_LOCK(?, ?)")).thenReturn(lockStmt);
+        when(mockConnection.prepareStatement("SELECT RELEASE_LOCK(?)")).thenReturn(releaseLockStmt);
+        when(mockConnection.prepareStatement(SchemaMigrationRunner.INSERT_SCHEMA_VERSION)).thenReturn(insertStmt);
+
+        when(mockStatement.executeQuery(SchemaMigrationRunner.SELECT_APPLIED_VERSIONS))
+                .thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        Statement migrationStmt = Mockito.mock(Statement.class);
+        when(mockConnection.createStatement()).thenReturn(mockStatement, mockStatement, migrationStmt);
+        doThrow(new SQLException("Syntax error", "HY000", 1064))
+                .when(migrationStmt).execute(anyString());
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.migrate(tempDir.toString());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testMigrateNonExistentDirectory() {
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.migrate("/non/existent/directory");
+    }
+
+    @Test(expectedExceptions = RuntimeException.class,
+            expectedExceptionsMessageRegExp = ".*Failed to run schema migrations.*")
+    public void testMigrateLockFailure() throws Exception {
+        Files.writeString(tempDir.resolve("update-20190107.sql"), "SELECT 1;\n");
+
+        ResultSet lockResultSet = Mockito.mock(ResultSet.class);
+        when(lockResultSet.next()).thenReturn(true);
+        when(lockResultSet.getInt(1)).thenReturn(0);
+
+        PreparedStatement lockStmt = Mockito.mock(PreparedStatement.class);
+        when(lockStmt.executeQuery()).thenReturn(lockResultSet);
+
+        PreparedStatement releaseLockStmt = Mockito.mock(PreparedStatement.class);
+        ResultSet releaseLockRs = Mockito.mock(ResultSet.class);
+        when(releaseLockStmt.executeQuery()).thenReturn(releaseLockRs);
+
+        when(mockConnection.prepareStatement("SELECT GET_LOCK(?, ?)")).thenReturn(lockStmt);
+        when(mockConnection.prepareStatement("SELECT RELEASE_LOCK(?)")).thenReturn(releaseLockStmt);
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.migrate(tempDir.toString());
+    }
+
+    @Test
+    public void testGetAppliedVersions() throws Exception {
+        ResultSet rs = Mockito.mock(ResultSet.class);
+        when(rs.next()).thenReturn(true, true, false);
+        when(rs.getString("version")).thenReturn("20190107", "20200506");
+        when(mockStatement.executeQuery(SchemaMigrationRunner.SELECT_APPLIED_VERSIONS)).thenReturn(rs);
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        Set<String> versions = runner.getAppliedVersions(mockConnection);
+
+        assertEquals(versions.size(), 2);
+        assertTrue(versions.contains("20190107"));
+        assertTrue(versions.contains("20200506"));
+    }
+
+    @Test
+    public void testCreateSchemaVersionTable() throws Exception {
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.createSchemaVersionTable(mockConnection);
+
+        verify(mockStatement).execute(SchemaMigrationRunner.CREATE_SCHEMA_VERSION_TABLE);
+    }
+
+    @Test
+    public void testCustomLockName() throws Exception {
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource, "custom_lock");
+
+        ResultSet lockResultSet = Mockito.mock(ResultSet.class);
+        when(lockResultSet.next()).thenReturn(true);
+        when(lockResultSet.getInt(1)).thenReturn(1);
+
+        PreparedStatement lockStmt = Mockito.mock(PreparedStatement.class);
+        when(lockStmt.executeQuery()).thenReturn(lockResultSet);
+        when(mockConnection.prepareStatement("SELECT GET_LOCK(?, ?)")).thenReturn(lockStmt);
+
+        runner.acquireLock(mockConnection);
+
+        verify(lockStmt).setString(1, "custom_lock");
+    }
+
+    @Test
+    public void testRecordMigrationUpsertOnRetry() throws Exception {
+        PreparedStatement insertStmt = Mockito.mock(PreparedStatement.class);
+        when(mockConnection.prepareStatement(SchemaMigrationRunner.INSERT_SCHEMA_VERSION)).thenReturn(insertStmt);
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+
+        runner.recordMigration(mockConnection, "20190107", "update-20190107.sql", 100, false);
+        verify(insertStmt).setBoolean(4, false);
+
+        runner.recordMigration(mockConnection, "20190107", "update-20190107.sql", 50, true);
+        verify(insertStmt).setBoolean(4, true);
+
+        verify(insertStmt, times(2)).executeUpdate();
+    }
+}

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunnerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunnerTest.java
@@ -450,4 +450,64 @@ public class SchemaMigrationRunnerTest {
 
         verify(insertStmt, times(2)).executeUpdate();
     }
+
+    @Test
+    public void testMigrateIfConfiguredWithValidDir() throws Exception {
+        Files.writeString(tempDir.resolve("update-20190107.sql"),
+                "ALTER TABLE `test` ADD `col1` VARCHAR(256);\n");
+
+        System.setProperty("test.migration.dir", tempDir.toString());
+
+        ResultSet lockResultSet = Mockito.mock(ResultSet.class);
+        when(lockResultSet.next()).thenReturn(true);
+        when(lockResultSet.getInt(1)).thenReturn(1);
+
+        PreparedStatement lockStmt = Mockito.mock(PreparedStatement.class);
+        when(lockStmt.executeQuery()).thenReturn(lockResultSet);
+
+        PreparedStatement releaseLockStmt = Mockito.mock(PreparedStatement.class);
+        ResultSet releaseLockRs = Mockito.mock(ResultSet.class);
+        when(releaseLockStmt.executeQuery()).thenReturn(releaseLockRs);
+
+        PreparedStatement insertStmt = Mockito.mock(PreparedStatement.class);
+
+        when(mockConnection.prepareStatement("SELECT GET_LOCK(?, ?)")).thenReturn(lockStmt);
+        when(mockConnection.prepareStatement("SELECT RELEASE_LOCK(?)")).thenReturn(releaseLockStmt);
+        when(mockConnection.prepareStatement(SchemaMigrationRunner.INSERT_SCHEMA_VERSION)).thenReturn(insertStmt);
+
+        when(mockStatement.executeQuery(SchemaMigrationRunner.SELECT_APPLIED_VERSIONS))
+                .thenReturn(mockResultSet);
+        when(mockResultSet.next()).thenReturn(false);
+
+        try {
+            SchemaMigrationRunner.migrateIfConfigured(mockDataSource,
+                    "test.migration.dir", "test_lock");
+            verify(insertStmt, times(1)).executeUpdate();
+        } finally {
+            System.clearProperty("test.migration.dir");
+        }
+    }
+
+    @Test
+    public void testReleaseLockSuccess() throws Exception {
+        PreparedStatement releaseLockStmt = Mockito.mock(PreparedStatement.class);
+        ResultSet releaseLockRs = Mockito.mock(ResultSet.class);
+        when(releaseLockStmt.executeQuery()).thenReturn(releaseLockRs);
+        when(mockConnection.prepareStatement("SELECT RELEASE_LOCK(?)")).thenReturn(releaseLockStmt);
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.releaseLock(mockConnection);
+
+        verify(releaseLockStmt).setString(1, SchemaMigrationRunner.DEFAULT_LOCK_NAME);
+        verify(releaseLockStmt).executeQuery();
+    }
+
+    @Test
+    public void testReleaseLockFailure() throws Exception {
+        when(mockConnection.prepareStatement("SELECT RELEASE_LOCK(?)"))
+                .thenThrow(new SQLException("connection closed"));
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(mockDataSource);
+        runner.releaseLock(mockConnection);
+    }
 }

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunnerTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/db/SchemaMigrationRunnerTest.java
@@ -160,6 +160,12 @@ public class SchemaMigrationRunnerTest {
     }
 
     @Test
+    public void testIsSafeErrorMultiplePrimaryKey() {
+        SQLException ex = new SQLException("Multiple primary key defined", "HY000", 1068);
+        assertTrue(SchemaMigrationRunner.isSafeError(ex));
+    }
+
+    @Test
     public void testIsSafeErrorUnsafeError() {
         SQLException ex = new SQLException("Syntax error", "HY000", 1064);
         assertFalse(SchemaMigrationRunner.isSafeError(ex));

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/JDBCObjectStoreFactoryTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/store/impl/JDBCObjectStoreFactoryTest.java
@@ -16,8 +16,10 @@
 package com.yahoo.athenz.common.server.store.impl;
 
 import com.yahoo.athenz.auth.PrivateKeyStore;
+import com.yahoo.athenz.common.server.db.PoolableDataSource;
 import com.yahoo.athenz.common.server.store.ObjectStore;
 import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;
@@ -68,5 +70,41 @@ public class JDBCObjectStoreFactoryTest {
         System.clearProperty(JDBCConsts.ZMS_PROP_JDBC_RO_STORE);
         System.clearProperty(JDBCConsts.ZMS_PROP_JDBC_RO_USER);
         System.clearProperty(JDBCConsts.ZMS_PROP_JDBC_RO_PASSWORD);
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        System.clearProperty(JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR);
+    }
+
+    @Test
+    public void testRunSchemaMigrationsNotConfigured() {
+        System.clearProperty(JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR);
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+
+        JDBCObjectStoreFactory factory = new JDBCObjectStoreFactory();
+        factory.runSchemaMigrations(mockDs);
+
+        Mockito.verifyNoInteractions(mockDs);
+    }
+
+    @Test
+    public void testRunSchemaMigrationsEmptyProperty() {
+        System.setProperty(JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR, "");
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+
+        JDBCObjectStoreFactory factory = new JDBCObjectStoreFactory();
+        factory.runSchemaMigrations(mockDs);
+
+        Mockito.verifyNoInteractions(mockDs);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testRunSchemaMigrationsInvalidDirectory() {
+        System.setProperty(JDBCConsts.ZMS_PROP_JDBC_SCHEMA_MIGRATION_DIR, "/non/existent/dir");
+        PoolableDataSource mockDs = Mockito.mock(PoolableDataSource.class);
+
+        JDBCObjectStoreFactory factory = new JDBCObjectStoreFactory();
+        factory.runSchemaMigrations(mockDs);
     }
 }

--- a/servers/zms/schema/schema_update.md
+++ b/servers/zms/schema/schema_update.md
@@ -23,4 +23,12 @@ and the corresponding SQL script is stored in the `servers/zms/schema/zms_server
 1. Create a new file in the updates directory with the name `update-<date>.sql` where `<date>` is
    the current date (e.g. update-20240523.sql).
 2. Include the necessary SQL statements in the file to update an existing schema (e.g. `ALTER TABLE`, etc.).
-3. Include the update file as part of your PR.
+3. Follow these formatting rules (required by the automated migration runner):
+   - Each SQL statement must end with a semicolon (`;`) as the last non-whitespace
+     character on its line.
+   - Do not place comments after a semicolon on the same line
+     (e.g., avoid `ALTER TABLE ...; -- comment`).
+   - Do not place multiple statements on the same line.
+   - Use `--` for line comments (not `#`).
+   - Statements may span multiple lines.
+4. Include the update file as part of your PR.

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/SchemaMigrationIntegrationTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/SchemaMigrationIntegrationTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms;
+
+import com.yahoo.athenz.common.server.db.DataSourceFactory;
+import com.yahoo.athenz.common.server.db.PoolableDataSource;
+import com.yahoo.athenz.common.server.db.SchemaMigrationRunner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.shaded.org.apache.commons.io.FileUtils;
+import org.testcontainers.utility.DockerImageName;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.*;
+import java.time.Duration;
+import java.util.Properties;
+
+import static org.testng.Assert.*;
+
+public class SchemaMigrationIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaMigrationIntegrationTest.class);
+
+    private static final String DB_USER = "admin";
+    private static final String DB_PASS = "unit-test";
+    private static final String MIGRATION_DIR = "schema/updates";
+
+    private static MySQLContainer<?> mysql;
+    private PoolableDataSource dataSource;
+
+    @BeforeClass
+    public void setUp() throws Exception {
+        String mysqlImage = System.getenv("ZMS_TEST_MYSQL_IMAGE");
+        if (mysqlImage == null || mysqlImage.isEmpty()) {
+            mysqlImage = "mysql/mysql-server:8.0";
+        }
+
+        FileUtils.copyFile(
+                new File("schema/zms_server.sql"),
+                new File("src/test/resources/mysql/zms_server.sql"));
+
+        mysql = new MySQLContainer<>(DockerImageName.parse(mysqlImage).asCompatibleSubstituteFor("mysql"))
+                .withDatabaseName("zms_server")
+                .withUsername(DB_USER)
+                .withPassword(DB_PASS)
+                .withEnv("MYSQL_ROOT_PASSWORD", DB_PASS)
+                .withInitScript("mysql/zms_server.sql")
+                .withStartupTimeout(Duration.ofMinutes(2));
+        mysql.start();
+        mysql.followOutput(new Slf4jLogConsumer(LOG));
+
+        Properties props = new Properties();
+        props.setProperty("user", DB_USER);
+        props.setProperty("password", DB_PASS);
+        dataSource = DataSourceFactory.create(mysql.getJdbcUrl(), props);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        if (mysql != null && mysql.isRunning()) {
+            mysql.stop();
+        }
+    }
+
+    @Test
+    public void testMigrateAppliesAllFiles() throws Exception {
+
+        assertTrue(Files.isDirectory(Path.of(MIGRATION_DIR)),
+                "Migration directory must exist: " + MIGRATION_DIR);
+        long fileCount;
+        try (var stream = Files.list(Path.of(MIGRATION_DIR))) {
+            fileCount = stream
+                    .filter(p -> p.getFileName().toString().matches("update-\\d{8}\\.sql"))
+                    .count();
+        }
+        assertTrue(fileCount > 0, "Expected migration files in " + MIGRATION_DIR);
+
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(dataSource, "test_migration_lock");
+        runner.migrate(MIGRATION_DIR);
+
+        // Verify schema_version table was created and populated
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(
+                     "SELECT COUNT(*) AS cnt FROM schema_version WHERE success = 1")) {
+            assertTrue(rs.next());
+            long appliedCount = rs.getLong("cnt");
+            assertEquals(appliedCount, fileCount,
+                    "All migration files should be recorded in schema_version");
+            LOG.info("Verified {} migrations recorded in schema_version", appliedCount);
+        }
+    }
+
+    @Test(dependsOnMethods = "testMigrateAppliesAllFiles")
+    public void testMigrateIsIdempotent() throws Exception {
+
+        // Count existing records
+        long countBefore;
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) AS cnt FROM schema_version")) {
+            assertTrue(rs.next());
+            countBefore = rs.getLong("cnt");
+        }
+
+        // Run migrations again
+        SchemaMigrationRunner runner = new SchemaMigrationRunner(dataSource, "test_migration_lock");
+        runner.migrate(MIGRATION_DIR);
+
+        // Verify no new records were added
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT COUNT(*) AS cnt FROM schema_version")) {
+            assertTrue(rs.next());
+            long countAfter = rs.getLong("cnt");
+            assertEquals(countAfter, countBefore,
+                    "Idempotent run should not add new records");
+        }
+    }
+
+    @Test(dependsOnMethods = "testMigrateAppliesAllFiles")
+    public void testSchemaVersionTableContents() throws Exception {
+
+        try (Connection conn = dataSource.getConnection();
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery(
+                     "SELECT version, script, execution_time_ms, success " +
+                     "FROM schema_version ORDER BY version")) {
+            int count = 0;
+            String previousVersion = "";
+            while (rs.next()) {
+                String version = rs.getString("version");
+                String script = rs.getString("script");
+                boolean success = rs.getBoolean("success");
+
+                assertTrue(version.matches("\\d{8}"), "Version should be YYYYMMDD: " + version);
+                assertTrue(script.startsWith("update-"), "Script should start with 'update-': " + script);
+                assertTrue(script.endsWith(".sql"), "Script should end with '.sql': " + script);
+                assertTrue(success, "All migrations should be successful");
+                assertTrue(version.compareTo(previousVersion) > 0,
+                        "Versions should be in order: " + previousVersion + " < " + version);
+                previousVersion = version;
+                count++;
+            }
+            assertTrue(count > 0, "Should have at least one migration record");
+            LOG.info("Verified {} schema_version records with correct format and ordering", count);
+        }
+    }
+}

--- a/servers/zts/schema/schema_update.md
+++ b/servers/zts/schema/schema_update.md
@@ -23,4 +23,12 @@ and the corresponding SQL script is stored in the `servers/zts/schema/zts_server
 1. Create a new file in the updates directory with the name `update-<date>.sql` where `<date>` is
    the current date (e.g. update-20240523.sql).
 2. Include the necessary SQL statements in the file to update an existing schema (e.g. `ALTER TABLE`, etc.).
-3. Include the update file as part of your PR.
+3. Follow these formatting rules (required by the automated migration runner):
+   - Each SQL statement must end with a semicolon (`;`) as the last non-whitespace
+     character on its line.
+   - Do not place comments after a semicolon on the same line
+     (e.g., avoid `ALTER TABLE ...; -- comment`).
+   - Do not place multiple statements on the same line.
+   - Use `--` for line comments (not `#`).
+   - Statements may span multiple lines.
+4. Include the update file as part of your PR.


### PR DESCRIPTION
# Description

Adds opt-in schema migration support that runs pending `update-YYYYMMDD.sql` files on server startup, eliminating the need to manually track and apply schema changes between Athenz versions.

Closes #2374

## How it works

A new `SchemaMigrationRunner` in `server_common` handles migrations for both ZMS and ZTS:

1. Scans the configured directory for `update-YYYYMMDD.sql` files
2. Creates a `schema_version` tracking table if it doesn't exist
3. Applies any files not yet recorded, in date order
4. Handles safe MySQL errors (duplicate column, table exists, etc.) gracefully, so it works on existing deployments where some migrations were already applied manually

Migrations are serialized across server instances using MySQL advisory locks.

## Configuration

Set the system property pointing to the schema updates directory. Migrations only run when the property is set.

- ZMS: `athenz.zms.schema_migration_dir=/path/to/servers/zms/schema/updates`
- ZTS: `athenz.zts.schema_migration_dir=/path/to/servers/zts/schema/updates`

## Safe for existing deployments

The runner is idempotent. On first run against an existing database, it attempts each migration file and treats "already applied" errors (duplicate column 1060, duplicate key 1061, table exists 1050, multiple primary key 1068) as success, recording them in `schema_version`. Subsequent startups skip all recorded versions.

## Testing

- 38 unit tests covering parsing, error handling, locking, and factory integration
- Integration test using Testcontainers MySQL: loads the base `zms_server.sql` schema, runs all 58 ZMS migration files, verifies idempotency on second run

## Changes

- `SchemaMigrationRunner` (new) - core migration logic in `server_common`
- `JDBCObjectStoreFactory` / `AWSObjectStoreFactory` - call runner for ZMS when configured
- `JDBCCertRecordStoreFactory` / `AWSCertRecordStoreFactory` - call runner for ZTS when configured
- `JDBCConsts` - new property constant

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request.**