### PR TITLE
add validation for user principals after auth

### DIFF
--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -467,6 +467,14 @@ athenz.zms.no_auth_uri_list=/zms/v1/schema
 # zms will validate that the referenced role does exist in the domain.
 #athenz.zms.validate_policy_assertion_roles=false
 
+# Boolean value indicating whether the ZMS server should validate
+# user principals against the configured user authority during
+# API calls. When enabled, each request from a user principal will
+# be validated with the user authority to ensure the user is active.
+# When disabled (default), user authority principal validation is
+# skipped for all API calls.
+#athenz.zms.validate_user_authority_principals=false
+
 # Specify the number of days that the server will use to expunge
 # any expired members from roles and groups when the expunge expired
 # member api is called. If the value is 0, then no members are purged.

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
@@ -28,6 +28,8 @@ import com.yahoo.athenz.auth.Principal;
 import com.yahoo.athenz.common.ServerCommonConsts;
 import com.yahoo.athenz.common.messaging.DomainChangeMessage;
 import com.yahoo.athenz.common.server.rest.Http;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -35,20 +37,27 @@ import java.util.List;
 
 public class RsrcCtxWrapper implements ResourceContext {
 
+    private static final Logger LOG = LoggerFactory.getLogger(RsrcCtxWrapper.class);
+
     private final ServerResourceContext ctx;
     private final Object timerMetric;
     private final boolean optionalAuth;
     private final String apiName;
     private final boolean eventPublishersEnabled;
+    private final Authority userAuthority;
+    private final String userDomain;
     private List<DomainChangeMessage> domainChangeMessages;
-    
+
     RsrcCtxWrapper(ServletContext servletContext, HttpServletRequest request, HttpServletResponse response,
                    Http.AuthorityList authList, boolean optionalAuth, Authorizer authorizer, Object timerMetric,
-                   final String apiName, boolean eventPublishersEnabled) {
+                   final String apiName, boolean eventPublishersEnabled,
+                   Authority userAuthority, String userDomain) {
         this.optionalAuth = optionalAuth;
         this.timerMetric = timerMetric;
         this.apiName = apiName.toLowerCase();
         this.eventPublishersEnabled = eventPublishersEnabled;
+        this.userAuthority = userAuthority;
+        this.userDomain = userDomain;
         ctx = new ServerResourceContext(servletContext, request,
                 response, authList, authorizer);
     }
@@ -102,6 +111,7 @@ public class RsrcCtxWrapper implements ResourceContext {
     public void authenticate() {
         try {
             ctx.authenticate(optionalAuth);
+            validateUserPrincipal(principal());
         } catch (ServerResourceException restExc) {
             throwZmsException(restExc);
         }
@@ -111,9 +121,23 @@ public class RsrcCtxWrapper implements ResourceContext {
     public void authorize(String action, String resource, String trustedDomain) {
         try {
             ctx.authorize(action, resource, trustedDomain);
+            validateUserPrincipal(principal());
         } catch (ServerResourceException restExc) {
             logPrincipal();
             throwZmsException(restExc);
+        }
+    }
+
+    void validateUserPrincipal(final Principal principal) throws ServerResourceException {
+        if (principal == null || userAuthority == null || userDomain == null) {
+            return;
+        }
+        if (!userDomain.equals(principal.getDomain())) {
+            return;
+        }
+        if (userAuthority.getUserType(principal.getFullName()) != Authority.UserType.USER_ACTIVE) {
+            LOG.error("validateUserPrincipal: user {} is not valid", principal.getFullName());
+            throw new ServerResourceException(ServerResourceException.UNAUTHORIZED, "user is not valid");
         }
     }
 

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
@@ -130,7 +130,7 @@ public class RsrcCtxWrapper implements ResourceContext {
     }
 
     void validateUserPrincipal(final Principal principal) throws ServerResourceException {
-        if (principalValidated ||principal == null || userAuthority == null || userDomain == null) {
+        if (principalValidated || principal == null || userAuthority == null || userDomain == null) {
             return;
         }
         principalValidated = true;

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/RsrcCtxWrapper.java
@@ -46,6 +46,7 @@ public class RsrcCtxWrapper implements ResourceContext {
     private final boolean eventPublishersEnabled;
     private final Authority userAuthority;
     private final String userDomain;
+    private boolean principalValidated = false;
     private List<DomainChangeMessage> domainChangeMessages;
 
     RsrcCtxWrapper(ServletContext servletContext, HttpServletRequest request, HttpServletResponse response,
@@ -129,9 +130,10 @@ public class RsrcCtxWrapper implements ResourceContext {
     }
 
     void validateUserPrincipal(final Principal principal) throws ServerResourceException {
-        if (principal == null || userAuthority == null || userDomain == null) {
+        if (principalValidated ||principal == null || userAuthority == null || userDomain == null) {
             return;
         }
+        principalValidated = true;
         if (!userDomain.equals(principal.getDomain())) {
             return;
         }

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -85,9 +85,10 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_DEFAULT_MAX_SERVICE_EXPIRY  = "athenz.zms.default_max_service_expiry_days";
     public static final String ZMS_PROP_DEFAULT_MAX_GROUP_EXPIRY  = "athenz.zms.default_max_group_expiry_days";
 
-    public static final String ZMS_PROP_VALIDATE_USER_MEMBERS    = "athenz.zms.validate_user_members";
-    public static final String ZMS_PROP_VALIDATE_SERVICE_MEMBERS = "athenz.zms.validate_service_members";
-    public static final String ZMS_PROP_VALIDATE_ASSERTION_ROLES = "athenz.zms.validate_policy_assertion_roles";
+    public static final String ZMS_PROP_VALIDATE_USER_MEMBERS              = "athenz.zms.validate_user_members";
+    public static final String ZMS_PROP_VALIDATE_SERVICE_MEMBERS           = "athenz.zms.validate_service_members";
+    public static final String ZMS_PROP_VALIDATE_ASSERTION_ROLES           = "athenz.zms.validate_policy_assertion_roles";
+    public static final String ZMS_PROP_VALIDATE_USER_AUTHORITY_PRINCIPALS = "athenz.zms.validate_user_authority_principals";
 
     public static final String ZMS_PROP_VALIDATE_SERVICE_MEMBERS_SKIP_DOMAINS = "athenz.zms.validate_service_members_skip_domains";
     public static final String ZMS_PROP_MASTER_COPY_FOR_SIGNED_DOMAINS        = "athenz.zms.master_copy_for_signed_domains";
@@ -123,7 +124,7 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_DOMAIN_META_STORE_FACTORY_CLASS = "athenz.zms.domain_meta_store_factory_class";
     public static final String ZMS_DOMAIN_META_STORE_FACTORY_CLASS      = "com.yahoo.athenz.common.server.metastore.impl.NoOpDomainMetaStoreFactory";
 
-    public static final String ZMS_PROP_AUTH_HISTORY_STORE_FACTORY_CLASS    = "athenz.zms.auth_history_store_factory_class";
+    public static final String ZMS_PROP_AUTH_HISTORY_STORE_FACTORY_CLASS = "athenz.zms.auth_history_store_factory_class";
 
     public static final String ZMS_PROP_AWS_ASSUME_ROLE_ACTION    = "athenz.zms.aws_assume_role_action";
     public static final String ZMS_PROP_GCP_ASSUME_ROLE_ACTION    = "athenz.zms.gcp_assume_role_action";

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -184,6 +184,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     protected DynamicConfigBoolean validateServiceRoleMembers;
     protected DynamicConfigBoolean validateUserRoleMembers;
     protected DynamicConfigBoolean validatePolicyAssertionRoles;
+    protected DynamicConfigBoolean validateUserAuthorityPrincipals;
     protected DynamicConfigBoolean allowUnderscoreInServiceNames;
     protected boolean useMasterCopyForSignedDomains = false;
     protected List<String> validateServiceMemberSkipDomains;
@@ -883,6 +884,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         validateServiceRoleMembers = new DynamicConfigBoolean(CONFIG_MANAGER, ZMSConsts.ZMS_PROP_VALIDATE_SERVICE_MEMBERS, false);
         validateUserRoleMembers = new DynamicConfigBoolean(CONFIG_MANAGER, ZMSConsts.ZMS_PROP_VALIDATE_USER_MEMBERS, false);
         validatePolicyAssertionRoles = new DynamicConfigBoolean(CONFIG_MANAGER, ZMSConsts.ZMS_PROP_VALIDATE_ASSERTION_ROLES, false);
+        validateUserAuthorityPrincipals = new DynamicConfigBoolean(CONFIG_MANAGER, ZMSConsts.ZMS_PROP_VALIDATE_USER_AUTHORITY_PRINCIPALS, false);
 
         // there are going to be domains like our ci/cd dynamic project domain
         // where we can't verify the service role members so for those we're
@@ -10422,8 +10424,9 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         boolean optionalAuth = StringUtils.requestUriMatch(request.getRequestURI(),
                 authFreeUriSet, authFreeUriList);
         boolean eventPublishersEnabled = !domainChangePublishers.isEmpty();
+        Authority reqUserAuthority = validateUserAuthorityPrincipals.get() ? userAuthority : null;
         return new RsrcCtxWrapper(servletContext, request, response, authorities, optionalAuth, this,
-                timerMetric, apiName, eventPublishersEnabled, userAuthority, userDomain);
+                timerMetric, apiName, eventPublishersEnabled, reqUserAuthority, userDomain);
     }
 
     @Override

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -10423,7 +10423,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
                 authFreeUriSet, authFreeUriList);
         boolean eventPublishersEnabled = !domainChangePublishers.isEmpty();
         return new RsrcCtxWrapper(servletContext, request, response, authorities, optionalAuth, this,
-                timerMetric, apiName, eventPublishersEnabled);
+                timerMetric, apiName, eventPublishersEnabled, userAuthority, userDomain);
     }
 
     @Override

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/RsrcCtxWrapperTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/RsrcCtxWrapperTest.java
@@ -62,7 +62,7 @@ public class RsrcCtxWrapperTest {
         authListMock.add(authMock);
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, timerMetric, "apiName", false);
+                authorizerMock, timerMetric, "apiName", false, null, null);
 
         assertNotNull(wrapper.context());
 
@@ -102,7 +102,7 @@ public class RsrcCtxWrapperTest {
 
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, timerMetric, "apiName", false);
+                authorizerMock, timerMetric, "apiName", false, null, null);
 
         try {
             wrapper.authenticate();
@@ -137,7 +137,7 @@ public class RsrcCtxWrapperTest {
 
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, timerMetric, "apiName", false);
+                authorizerMock, timerMetric, "apiName", false, null, null);
 
         wrapper.authorize("add-domain", "test", "test");
 
@@ -164,7 +164,7 @@ public class RsrcCtxWrapperTest {
 
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, timerMetric, "apiName", false);
+                authorizerMock, timerMetric, "apiName", false, null, null);
 
         // when not set authority
         wrapper.authorize("add-domain", "test", "test");
@@ -182,7 +182,7 @@ public class RsrcCtxWrapperTest {
 
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, servletRequest, servletResponse,
-                authListMock, false, authorizerMock, timerMetric, "apiName", false);
+                authListMock, false, authorizerMock, timerMetric, "apiName", false, null, null);
 
         wrapper.logPrincipal();
         assertNull(servletRequest.getAttribute("com.yahoo.athenz.auth.principal"));
@@ -214,7 +214,7 @@ public class RsrcCtxWrapperTest {
         authListMock.add(authMock);
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, timerMetric, "apiName", false);
+                authorizerMock, timerMetric, "apiName", false, null, null);
 
         wrapper.authenticate();
         wrapper.logPrincipal();
@@ -236,7 +236,7 @@ public class RsrcCtxWrapperTest {
 
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, servletRequest, servletResponse,
-                authListMock, false, authorizerMock, timerMetric, "apiName", false);
+                authListMock, false, authorizerMock, timerMetric, "apiName", false, null, null);
 
         ServerResourceException restExc =
                 new ServerResourceException(503, null);
@@ -261,7 +261,7 @@ public class RsrcCtxWrapperTest {
 
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, servletRequest, servletResponse,
-                authListMock, false, authorizerMock, timerMetric, "apiName", false);
+                authListMock, false, authorizerMock, timerMetric, "apiName", false, null, null);
 
         wrapper.logAuthorityId(null);
         assertNull(servletRequest.getAttribute("com.yahoo.athenz.auth.authority_id"));
@@ -282,7 +282,7 @@ public class RsrcCtxWrapperTest {
 
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, servletRequest, servletResponse,
-            authListMock, false, authorizerMock, timerMetric, "apiName", true);
+            authListMock, false, authorizerMock, timerMetric, "apiName", true, null, null);
 
         assertNull(wrapper.getDomainChangeMessages());
 
@@ -339,7 +339,7 @@ public class RsrcCtxWrapperTest {
 
         Object timerMetric = new Object();
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, servletRequest, servletResponse,
-                authListMock, false, authorizerMock, timerMetric, "apiName", false);
+                authListMock, false, authorizerMock, timerMetric, "apiName", false, null, null);
 
         assertNull(wrapper.getDomainChangeMessages());
 
@@ -356,5 +356,260 @@ public class RsrcCtxWrapperTest {
                 .setObjectType(ROLE));
 
         assertNull(wrapper.getDomainChangeMessages());
+    }
+
+    @Test
+    public void testAuthenticateUserPrincipalValid() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_ACTIVE);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        Object timerMetric = new Object();
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, timerMetric, "apiName", false, userAuthority, "user");
+
+        wrapper.authenticate();
+        assertEquals(wrapper.principal(), prin);
+    }
+
+    @Test
+    public void testAuthenticateUserPrincipalInvalid() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_INVALID);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        Object timerMetric = new Object();
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, timerMetric, "apiName", false, userAuthority, "user");
+
+        try {
+            wrapper.authenticate();
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 401);
+            assertEquals(ex.getMessage(), "ResourceException (401): {code: 401, message: \"user is not valid\"}");
+        }
+    }
+
+    @Test
+    public void testAuthenticateUserPrincipalSuspended() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_SUSPENDED);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        Object timerMetric = new Object();
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, timerMetric, "apiName", false, userAuthority, "user");
+
+        try {
+            wrapper.authenticate();
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 401);
+        }
+    }
+
+    @Test
+    public void testAuthenticateNonUserDomainSkipsValidation() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("sports");
+        Mockito.when(prin.getFullName()).thenReturn("sports.api");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        Object timerMetric = new Object();
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, timerMetric, "apiName", false, userAuthority, "user");
+
+        wrapper.authenticate();
+        assertEquals(wrapper.principal(), prin);
+        Mockito.verify(userAuthority, Mockito.never()).getUserType(Mockito.anyString());
+    }
+
+    @Test
+    public void testAuthorizeUserPrincipalValid() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_ACTIVE);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        Mockito.when(authorizerMock.access(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(true);
+
+        Object timerMetric = new Object();
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, timerMetric, "apiName", false, userAuthority, "user");
+
+        wrapper.authorize("add-domain", "test", "test");
+        assertEquals(wrapper.principal(), prin);
+    }
+
+    @Test
+    public void testAuthorizeUserPrincipalInvalid() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_INVALID);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        Mockito.when(authorizerMock.access(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(true);
+
+        Object timerMetric = new Object();
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, timerMetric, "apiName", false, userAuthority, "user");
+
+        try {
+            wrapper.authorize("add-domain", "test", "test");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 401);
+            assertEquals(ex.getMessage(), "ResourceException (401): {code: 401, message: \"user is not valid\"}");
+        }
+    }
+
+    @Test
+    public void testAuthenticateNullUserAuthoritySkipsValidation() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        Object timerMetric = new Object();
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, timerMetric, "apiName", false, null, "user");
+
+        wrapper.authenticate();
+        assertEquals(wrapper.principal(), prin);
     }
 }

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -15285,6 +15285,80 @@ public class ZMSImplTest {
     }
 
     @Test
+    public void testNewResourceContextValidateUserAuthorityPrincipalsDefault() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+
+        // by default validateUserAuthorityPrincipals is false so the userAuthority
+        // should not be passed to the RsrcCtxWrapper
+
+        DynamicConfigBoolean savedConfig = zmsImpl.validateUserAuthorityPrincipals;
+        Authority savedAuthority = zmsImpl.userAuthority;
+
+        Authority authority = Mockito.mock(Authority.class);
+        zmsImpl.userAuthority = authority;
+
+        DynamicConfigBoolean dynamicConfigBoolean = Mockito.mock(DynamicConfigBoolean.class);
+        when(dynamicConfigBoolean.get()).thenReturn(false);
+        zmsImpl.validateUserAuthorityPrincipals = dynamicConfigBoolean;
+
+        RsrcCtxWrapper ctx = (RsrcCtxWrapper) zmsImpl.newResourceContext(zmsTestInitializer.getMockServletContext(),
+                zmsTestInitializer.getMockServletRequest(), zmsTestInitializer.getMockServletResponse(), "apiName");
+        assertNotNull(ctx);
+
+        // the wrapper should have null userAuthority since the config is disabled
+        // which means the validateUserPrincipal check will be skipped
+
+        try {
+            ctx.validateUserPrincipal(null);
+        } catch (Exception ex) {
+            fail();
+        }
+
+        zmsImpl.validateUserAuthorityPrincipals = savedConfig;
+        zmsImpl.userAuthority = savedAuthority;
+    }
+
+    @Test
+    public void testNewResourceContextValidateUserAuthorityPrincipalsEnabled() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+
+        DynamicConfigBoolean savedConfig = zmsImpl.validateUserAuthorityPrincipals;
+        Authority savedAuthority = zmsImpl.userAuthority;
+
+        Authority authority = Mockito.mock(Authority.class);
+        when(authority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_INVALID);
+        zmsImpl.userAuthority = authority;
+
+        DynamicConfigBoolean dynamicConfigBoolean = Mockito.mock(DynamicConfigBoolean.class);
+        when(dynamicConfigBoolean.get()).thenReturn(true);
+        zmsImpl.validateUserAuthorityPrincipals = dynamicConfigBoolean;
+
+        RsrcCtxWrapper ctx = (RsrcCtxWrapper) zmsImpl.newResourceContext(zmsTestInitializer.getMockServletContext(),
+                zmsTestInitializer.getMockServletRequest(), zmsTestInitializer.getMockServletResponse(), "apiName");
+        assertNotNull(ctx);
+
+        // the wrapper should have a non-null userAuthority since the config is enabled
+        // so the validateUserPrincipal check will be active - an invalid user should
+        // throw an exception
+
+        Principal principal = Mockito.mock(Principal.class);
+        when(principal.getDomain()).thenReturn("user");
+        when(principal.getFullName()).thenReturn("user.joe");
+
+        try {
+            ctx.validateUserPrincipal(principal);
+            fail();
+        } catch (ServerResourceException ex) {
+            assertEquals(ex.getCode(), 401);
+        }
+
+        zmsImpl.validateUserAuthorityPrincipals = savedConfig;
+        zmsImpl.userAuthority = savedAuthority;
+    }
+
+    @Test
     public void testAssertionMatchAuthenticatedRoles() {
         ZMSImpl zmsImpl = zmsTestInitializer.getZms();
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -14140,7 +14140,7 @@ public class ZMSImplTest {
         HttpServletRequest servletRequest = new MockHttpServletRequest();
         HttpServletResponse servletResponse = new MockHttpServletResponse();
         ResourceContext ctx = new RsrcCtxWrapper(null, servletRequest, servletResponse, null, false,
-                null, new Object(), "apiName", false);
+                null, new Object(), "apiName", false, null, null);
 
         zmsImpl.optionsUserToken(ctx, "user", "coretech.storage");
         assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_METHODS), "GET");
@@ -14161,7 +14161,7 @@ public class ZMSImplTest {
         MockHttpServletRequest servletRequest = new MockHttpServletRequest();
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
         ResourceContext ctx = new RsrcCtxWrapper(null, servletRequest, servletResponse, null, false,
-                null, new Object(), "apiName", false);
+                null, new Object(), "apiName", false, null, null);
 
         String origin = "https://zms.origin.athenzcompany.com";
         String requestHeaders = "X-Forwarded-For,Content-Type";
@@ -14199,7 +14199,7 @@ public class ZMSImplTest {
         HttpServletRequest servletRequest = new MockHttpServletRequest();
         HttpServletResponse servletResponse = new MockHttpServletResponse();
         ResourceContext ctx = new RsrcCtxWrapper(null, servletRequest, servletResponse, null, false,
-                null, new Object(), "apiName", false);
+                null, new Object(), "apiName", false, null, null);
 
         zmsImpl.setStandardCORSHeaders(ctx);
         assertEquals(servletResponse.getHeader(ZMSConsts.HTTP_ACCESS_CONTROL_ALLOW_CREDENTIALS), "true");
@@ -14217,7 +14217,7 @@ public class ZMSImplTest {
         MockHttpServletRequest servletRequest = new MockHttpServletRequest();
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
         ResourceContext ctx = new RsrcCtxWrapper(null, servletRequest, servletResponse, null, false,
-                null, new Object(), "apiName", true);
+                null, new Object(), "apiName", true, null, null);
 
         String origin = "https://zms.origin.athenzcompany.com";
         String requestHeaders = "X-Forwarded-For,Content-Type";

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestInitializer.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestInitializer.java
@@ -759,7 +759,7 @@ public class ZMSTestInitializer {
         MockHttpServletRequest servletRequest = new MockHttpServletRequest();
         MockHttpServletResponse servletResponse = new MockHttpServletResponse();
         RsrcCtxWrapper wrapperCtx = new RsrcCtxWrapper(null, servletRequest, servletResponse, null, false,
-                null, new Object(), apiName, true);
+                null, new Object(), apiName, true, null, null);
         ServerResourceContext ctx = wrapperCtx.context();
 
         Authority adminPrincipalAuthority = new com.yahoo.athenz.common.server.debug.DebugPrincipalAuthority();

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -617,6 +617,14 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # an identity certificate is issued
 #athenz.zts.validate_service_identity=true
 
+# Boolean value indicating whether the ZTS server should validate
+# user principals against the configured user authority during
+# API calls. When enabled, each request from a user principal will
+# be validated with the user authority to ensure the user is active.
+# When disabled (default), user authority principal validation is
+# skipped for all API calls.
+#athenz.zts.validate_user_authority_principals=false
+
 # Max size of allowable rich authorization details claim that will be included
 # in signed jwt access tokens
 #athenz.zts.max_authz_details_length=1024

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/InstanceExternalCredentialsProvider.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/InstanceExternalCredentialsProvider.java
@@ -56,7 +56,8 @@ public class InstanceExternalCredentialsProvider implements ExternalCredentialsP
         public ProviderResourceContext(ServletContext servletContext, HttpServletRequest request,
                 HttpServletResponse response, Http.AuthorityList authList, boolean optionalAuth,
                 Authorizer authorizer, Metric metric, Object timerMetric, String apiName) {
-            super(servletContext, request, response, authList, optionalAuth, authorizer, metric, timerMetric, apiName);
+            super(servletContext, request, response, authList, optionalAuth, authorizer, metric, timerMetric,
+                    apiName, null, null);
         }
 
         public void setPrincipal(Principal principal) {

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
@@ -44,14 +44,19 @@ public class RsrcCtxWrapper implements ResourceContext {
     Metric metric;
     private final Object timerMetric;
     private final String apiName;
+    private final Authority userAuthority;
+    private final String userDomain;
 
     public RsrcCtxWrapper(ServletContext servletContext, HttpServletRequest request, HttpServletResponse response,
                           Http.AuthorityList authList, boolean optionalAuth, Authorizer authorizer,
-                          Metric metric, Object timerMetric, String apiName) {
+                          Metric metric, Object timerMetric, String apiName,
+                          Authority userAuthority, String userDomain) {
         this.optionalAuth = optionalAuth;
         this.metric = metric;
         this.timerMetric = timerMetric;
         this.apiName = apiName.toLowerCase();
+        this.userAuthority = userAuthority;
+        this.userDomain = userDomain;
         ctx = new ServerResourceContext(servletContext, request, response,
                 authList, authorizer);
     }
@@ -111,18 +116,33 @@ public class RsrcCtxWrapper implements ResourceContext {
                 LOG.error("authenticate: certificate is mTLS restricted");
                 throw new ServerResourceException(ServerResourceException.UNAUTHORIZED, "certificate is mTLS restricted");
             }
+            validateUserPrincipal(principal);
         } catch (ServerResourceException restExc) {
             throwZtsException(restExc);
         }
     }
-    
+
     @Override
     public void authorize(String action, String resource, String trustedDomain) {
         try {
             ctx.authorize(action, resource, trustedDomain);
+            validateUserPrincipal(principal());
         } catch (ServerResourceException restExc) {
             logPrincipal();
             throwZtsException(restExc);
+        }
+    }
+
+    void validateUserPrincipal(final Principal principal) throws ServerResourceException {
+        if (principal == null || userAuthority == null || userDomain == null) {
+            return;
+        }
+        if (!userDomain.equals(principal.getDomain())) {
+            return;
+        }
+        if (userAuthority.getUserType(principal.getFullName()) != Authority.UserType.USER_ACTIVE) {
+            LOG.error("validateUserPrincipal: user {} is not valid", principal.getFullName());
+            throw new ServerResourceException(ServerResourceException.UNAUTHORIZED, "user is not valid");
         }
     }
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/RsrcCtxWrapper.java
@@ -46,6 +46,7 @@ public class RsrcCtxWrapper implements ResourceContext {
     private final String apiName;
     private final Authority userAuthority;
     private final String userDomain;
+    private boolean principalValidated = false;
 
     public RsrcCtxWrapper(ServletContext servletContext, HttpServletRequest request, HttpServletResponse response,
                           Http.AuthorityList authList, boolean optionalAuth, Authorizer authorizer,
@@ -134,9 +135,10 @@ public class RsrcCtxWrapper implements ResourceContext {
     }
 
     void validateUserPrincipal(final Principal principal) throws ServerResourceException {
-        if (principal == null || userAuthority == null || userDomain == null) {
+        if (principalValidated || principal == null || userAuthority == null || userDomain == null) {
             return;
         }
+        principalValidated = true;
         if (!userDomain.equals(principal.getDomain())) {
             return;
         }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -197,10 +197,12 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_HOSTNAME_RESOLVER_FACTORY_CLASS  = "athenz.zts.hostname_resolver_factory_class";
     public static final String ZTS_PROP_SSH_RECORD_STORE_FACTORY_CLASS   = "athenz.zts.ssh_record_store_factory_class";
     public static final String ZTS_PROP_VALIDATE_SERVICE_SKIP_DOMAINS    = "athenz.zts.validate_service_skip_domains";
-    public static final String ZTS_PROP_VALIDATE_SERVICE_IDENTITY        = "athenz.zts.validate_service_identity";
     public static final String ZTS_PROP_MAX_AUTHZ_DETAILS_LENGTH         = "athenz.zts.max_authz_details_length";
     public static final String ZTS_PROP_ROLE_BASED_AUTHZ_SUPPORT         = "athenz.zts.role_based_authz_support";
     public static final String ZTS_PROP_VALIDATE_ROLE_CERT_DNS_NAMES     = "athenz.zts.validate_role_cert_dns_names";
+
+    public static final String ZTS_PROP_VALIDATE_SERVICE_IDENTITY             = "athenz.zts.validate_service_identity";
+    public static final String ZTS_PROP_VALIDATE_USER_AUTHORITY_PRINCIPALS    = "athenz.zts.validate_user_authority_principals";
     public static final String ZTS_PROP_WORKLOAD_RECORD_STORE_FACTORY_CLASS   = "athenz.zts.workload_record_store_factory_class";
 
     public static final String ZTS_CHANGE_LOG_STORE_FACTORY_CLASS  = "com.yahoo.athenz.common.server.store.impl.ZMSFileChangeLogStoreFactory";
@@ -228,11 +230,11 @@ public final class ZTSConsts {
     public static final String ZTS_USER_CERT_TIMEOUT_TAG = "zts.UserCertTimeout";
     public static final String ZTS_USER_TOKEN_TIMEOUT_TAG = "zts.UserTokenTimeout";
 
-    public static final String ZTS_PROP_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY = "athenz.zts.cert_priority_min_percent_low_priority";
-    public static final String ZTS_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY_DEFAULT = "75";
-    public static final String ZTS_PROP_CERT_PRIORITY_MAX_PERCENT_HIGH_PRIORITY = "athenz.zts.cert_priority_max_percent_high_priority";
+    public static final String ZTS_PROP_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY     = "athenz.zts.cert_priority_min_percent_low_priority";
+    public static final String ZTS_CERT_PRIORITY_MIN_PERCENT_LOW_PRIORITY_DEFAULT  = "75";
+    public static final String ZTS_PROP_CERT_PRIORITY_MAX_PERCENT_HIGH_PRIORITY    = "athenz.zts.cert_priority_max_percent_high_priority";
     public static final String ZTS_CERT_PRIORITY_MAX_PERCENT_HIGH_PRIORITY_DEFAULT = "25";
-    public static final String ZTS_PROP_PRINCIPAL_IDENTITY_ISSUER_MAP_FNAME = "athenz.zts.principal_identity_issuer_map_fname";
+    public static final String ZTS_PROP_PRINCIPAL_IDENTITY_ISSUER_MAP_FNAME        = "athenz.zts.principal_identity_issuer_map_fname";
 
     public static final String ZTS_OPENID_RESPONSE_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:";
     public static final String ZTS_OPENID_RESPONSE_AT_ONLY    = "token";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -6895,7 +6895,7 @@ public class ZTSImpl implements ZTSHandler {
         boolean optionalAuth = StringUtils.requestUriMatch(request.getRequestURI(),
                 authFreeUriSet, authFreeUriList);
         return new RsrcCtxWrapper(servletContext, request, response, authorities, optionalAuth, authorizer,
-                metric, timerMetric, apiName);
+                metric, timerMetric, apiName, userAuthority, userDomain);
     }
 
     String getExceptionMsg(String prefix, ResourceContext ctx, Exception ex, String hostname) {

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -169,6 +169,7 @@ public class ZTSImpl implements ZTSHandler {
     protected boolean verifyCertRequestIP = false;
     protected boolean verifyCertSubjectOU = false;
     protected DynamicConfigBoolean validateInstanceServiceIdentity;
+    protected DynamicConfigBoolean validateUserAuthorityPrincipals;
     protected String ztsOAuthIssuer;
     protected File healthCheckFile = null;
     protected int maxAuthzDetailsLength;
@@ -768,6 +769,7 @@ public class ZTSImpl implements ZTSHandler {
         validateServiceSkipDomains = Arrays.asList(skipDomains.split(","));
 
         validateInstanceServiceIdentity = new DynamicConfigBoolean(CONFIG_MANAGER, ZTSConsts.ZTS_PROP_VALIDATE_SERVICE_IDENTITY, true);
+        validateUserAuthorityPrincipals = new DynamicConfigBoolean(CONFIG_MANAGER, ZTSConsts.ZTS_PROP_VALIDATE_USER_AUTHORITY_PRINCIPALS, false);
 
         // configured max length for authz details claims
 
@@ -6894,8 +6896,9 @@ public class ZTSImpl implements ZTSHandler {
 
         boolean optionalAuth = StringUtils.requestUriMatch(request.getRequestURI(),
                 authFreeUriSet, authFreeUriList);
+        Authority reqUserAuthority = validateUserAuthorityPrincipals.get() ? userAuthority : null;
         return new RsrcCtxWrapper(servletContext, request, response, authorities, optionalAuth, authorizer,
-                metric, timerMetric, apiName, userAuthority, userDomain);
+                metric, timerMetric, apiName, reqUserAuthority, userDomain);
     }
 
     String getExceptionMsg(String prefix, ResourceContext ctx, Exception ex, String hostname) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/RsrcCtxWrapperTest.java
@@ -65,7 +65,7 @@ public class RsrcCtxWrapperTest {
         authListMock.add(authMock);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, metricMock, timerMetricMock, "apiName");
+                authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         assertNotNull(wrapper.context());
 
@@ -113,7 +113,7 @@ public class RsrcCtxWrapperTest {
         authListMock.add(authMock);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, metricMock, timerMetricMock, "apiName");
+                authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         assertNotNull(wrapper.context());
 
@@ -156,7 +156,7 @@ public class RsrcCtxWrapperTest {
         authListMock.add(authMock);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, metricMock, timerMetricMock, "apiName");
+                authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         try {
             wrapper.authenticate();
@@ -192,7 +192,7 @@ public class RsrcCtxWrapperTest {
                 .thenReturn(true);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, metricMock, timerMetricMock, "apiName");
+                authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         wrapper.authorize("add-domain", "test", "test");
 
@@ -228,7 +228,7 @@ public class RsrcCtxWrapperTest {
                 .thenReturn(true);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, metricMock, timerMetricMock, "apiName");
+                authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         try {
             wrapper.authorize("add-domain", "test", "test");
@@ -259,7 +259,7 @@ public class RsrcCtxWrapperTest {
                 .thenReturn(true);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, metricMock, timerMetricMock, "apiName");
+                authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         // when not set authority
         wrapper.authorize("add-domain", "test", "test");
@@ -278,7 +278,7 @@ public class RsrcCtxWrapperTest {
         Object timerMetricMock = Mockito.mock(Object.class);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, servletRequest, servletResponse,
-                authListMock, false, authorizerMock, metricMock, timerMetricMock, "apiName");
+                authListMock, false, authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         wrapper.logPrincipal();
         assertNull(servletRequest.getAttribute("com.yahoo.athenz.auth.principal"));
@@ -316,7 +316,7 @@ public class RsrcCtxWrapperTest {
         authListMock.add(authMock);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, metricMock, timerMetricMock, "apiName");
+                authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         wrapper.authenticate();
         wrapper.logPrincipal();
@@ -353,7 +353,7 @@ public class RsrcCtxWrapperTest {
         authListMock.add(authMock);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
-                authorizerMock, metricMock, timerMetricMock, "apiName");
+                authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         wrapper.authenticate();
         assertEquals(wrapper.logPrincipal(), "athenz.role");
@@ -373,7 +373,7 @@ public class RsrcCtxWrapperTest {
         Object timerMetricMock = Mockito.mock(Object.class);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, servletRequest, servletResponse,
-                authListMock, false, authorizerMock, metricMock, timerMetricMock, "apiName");
+                authListMock, false, authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
 
         ServerResourceException restExc =
                 new ServerResourceException(503, null);
@@ -399,10 +399,272 @@ public class RsrcCtxWrapperTest {
         Object timerMetricMock = Mockito.mock(Object.class);
 
         RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, servletRequest, servletResponse,
-            authListMock, false, authorizerMock, metricMock, timerMetricMock, "apiName");
-        
+            authListMock, false, authorizerMock, metricMock, timerMetricMock, "apiName", null, null);
+
         wrapper.addDomainChangeMessage(new DomainChangeMessage());
-        
+
         assertNull(wrapper.getDomainChangeMessages());
+    }
+
+    @Test
+    public void testAuthenticateUserPrincipalValid() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+        Metric metricMock = Mockito.mock(Metric.class);
+        Object timerMetricMock = Mockito.mock(Object.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_ACTIVE);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, metricMock, timerMetricMock, "apiName", userAuthority, "user");
+
+        wrapper.authenticate();
+        assertEquals(wrapper.principal(), prin);
+    }
+
+    @Test
+    public void testAuthenticateUserPrincipalInvalid() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+        Metric metricMock = Mockito.mock(Metric.class);
+        Object timerMetricMock = Mockito.mock(Object.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_INVALID);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, metricMock, timerMetricMock, "apiName", userAuthority, "user");
+
+        try {
+            wrapper.authenticate();
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 401);
+            assertEquals(ex.getMessage(), "ResourceException (401): {code: 401, message: \"user is not valid\"}");
+        }
+    }
+
+    @Test
+    public void testAuthenticateUserPrincipalSuspended() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+        Metric metricMock = Mockito.mock(Metric.class);
+        Object timerMetricMock = Mockito.mock(Object.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_SUSPENDED);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, metricMock, timerMetricMock, "apiName", userAuthority, "user");
+
+        try {
+            wrapper.authenticate();
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 401);
+        }
+    }
+
+    @Test
+    public void testAuthenticateNonUserDomainSkipsValidation() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+        Metric metricMock = Mockito.mock(Metric.class);
+        Object timerMetricMock = Mockito.mock(Object.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("sports");
+        Mockito.when(prin.getFullName()).thenReturn("sports.api");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, metricMock, timerMetricMock, "apiName", userAuthority, "user");
+
+        wrapper.authenticate();
+        assertEquals(wrapper.principal(), prin);
+        Mockito.verify(userAuthority, Mockito.never()).getUserType(Mockito.anyString());
+    }
+
+    @Test
+    public void testAuthorizeUserPrincipalValid() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+        Metric metricMock = Mockito.mock(Metric.class);
+        Object timerMetricMock = Mockito.mock(Object.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_ACTIVE);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        Mockito.when(authorizerMock.access(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(true);
+
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, metricMock, timerMetricMock, "apiName", userAuthority, "user");
+
+        wrapper.authorize("add-domain", "test", "test");
+        assertEquals(wrapper.principal(), prin);
+    }
+
+    @Test
+    public void testAuthorizeUserPrincipalInvalid() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+        Metric metricMock = Mockito.mock(Metric.class);
+        Object timerMetricMock = Mockito.mock(Object.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Authority userAuthority = Mockito.mock(Authority.class);
+        Mockito.when(userAuthority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_INVALID);
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        Mockito.when(authorizerMock.access(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(true);
+
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, metricMock, timerMetricMock, "apiName", userAuthority, "user");
+
+        try {
+            wrapper.authorize("add-domain", "test", "test");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 401);
+            assertEquals(ex.getMessage(), "ResourceException (401): {code: 401, message: \"user is not valid\"}");
+        }
+    }
+
+    @Test
+    public void testAuthenticateNullUserAuthoritySkipsValidation() {
+        HttpServletRequest reqMock = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse resMock = Mockito.mock(HttpServletResponse.class);
+        ServletContext servletContext = Mockito.mock(ServletContext.class);
+
+        AuthorityList authListMock = new AuthorityList();
+        Authorizer authorizerMock = Mockito.mock(Authorizer.class);
+        Authority authMock = Mockito.mock(Authority.class);
+        Metric metricMock = Mockito.mock(Metric.class);
+        Object timerMetricMock = Mockito.mock(Object.class);
+
+        Principal prin = Mockito.mock(Principal.class);
+        Mockito.when(prin.getDomain()).thenReturn("user");
+        Mockito.when(prin.getFullName()).thenReturn("user.joe");
+
+        Mockito.when(authMock.getHeader()).thenReturn("testheader");
+        Mockito.when(reqMock.getHeader("testheader")).thenReturn("testcred");
+        Mockito.when(authMock.getCredSource()).thenReturn(Authority.CredSource.HEADER);
+        Mockito.when(authMock.authenticate(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(prin);
+        Mockito.when(reqMock.getRemoteAddr()).thenReturn("1.1.1.1");
+        Mockito.when(reqMock.getMethod()).thenReturn("POST");
+        authListMock.add(authMock);
+
+        RsrcCtxWrapper wrapper = new RsrcCtxWrapper(servletContext, reqMock, resMock, authListMock, false,
+                authorizerMock, metricMock, timerMetricMock, "apiName", null, "user");
+
+        wrapper.authenticate();
+        assertEquals(wrapper.principal(), prin);
     }
 }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -1769,7 +1769,7 @@ public class ZTSImplAccessTokenTest {
         HttpServletRequest servletRequest = Mockito.mock(HttpServletRequest.class);
         Mockito.when(servletRequest.isSecure()).thenReturn(true);
         ResourceContext context = new RsrcCtxWrapper(null, servletRequest, null, null, true,
-                null, null, null, "postaccesstoken");
+                null, null, null, "postaccesstoken", null, null);
 
         // first let's try without any client assertions which should
         // return the request at not authenticated

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -3168,6 +3168,66 @@ public class ZTSImplTest {
     }
 
     @Test
+    public void testNewResourceContextValidateUserAuthorityPrincipalsDefault() {
+
+        DynamicConfigBoolean savedConfig = zts.validateUserAuthorityPrincipals;
+        Authority savedAuthority = zts.userAuthority;
+
+        Authority authority = Mockito.mock(Authority.class);
+        zts.userAuthority = authority;
+
+        DynamicConfigBoolean dynamicConfigBoolean = Mockito.mock(DynamicConfigBoolean.class);
+        when(dynamicConfigBoolean.get()).thenReturn(false);
+        zts.validateUserAuthorityPrincipals = dynamicConfigBoolean;
+
+        RsrcCtxWrapper ctx = (RsrcCtxWrapper) zts.newResourceContext(mockServletContext,
+                mockServletRequest, mockServletResponse, "apiName");
+        assertNotNull(ctx);
+
+        try {
+            ctx.validateUserPrincipal(null);
+        } catch (Exception ex) {
+            fail();
+        }
+
+        zts.validateUserAuthorityPrincipals = savedConfig;
+        zts.userAuthority = savedAuthority;
+    }
+
+    @Test
+    public void testNewResourceContextValidateUserAuthorityPrincipalsEnabled() {
+
+        DynamicConfigBoolean savedConfig = zts.validateUserAuthorityPrincipals;
+        Authority savedAuthority = zts.userAuthority;
+
+        Authority authority = Mockito.mock(Authority.class);
+        when(authority.getUserType("user.joe")).thenReturn(Authority.UserType.USER_INVALID);
+        zts.userAuthority = authority;
+
+        DynamicConfigBoolean dynamicConfigBoolean = Mockito.mock(DynamicConfigBoolean.class);
+        when(dynamicConfigBoolean.get()).thenReturn(true);
+        zts.validateUserAuthorityPrincipals = dynamicConfigBoolean;
+
+        RsrcCtxWrapper ctx = (RsrcCtxWrapper) zts.newResourceContext(mockServletContext,
+                mockServletRequest, mockServletResponse, "apiName");
+        assertNotNull(ctx);
+
+        Principal principal = Mockito.mock(Principal.class);
+        when(principal.getDomain()).thenReturn("user");
+        when(principal.getFullName()).thenReturn("user.joe");
+
+        try {
+            ctx.validateUserPrincipal(principal);
+            fail();
+        } catch (ServerResourceException ex) {
+            assertEquals(ex.getCode(), 401);
+        }
+
+        zts.validateUserAuthorityPrincipals = savedConfig;
+        zts.userAuthority = savedAuthority;
+    }
+
+    @Test
     public void testVerifyAWSAssumeRoleInvalidDomain() {
         assertFalse(zts.verifyAWSAssumeRole("unknown-domain", "role", "user_domain.user"));
     }


### PR DESCRIPTION
# Description

Scenario:
a) user is issued a 24 hour user certificate at 8am
b) use is terminated at 10am and the user account is disabled in Athenz

With option (b), the user is no longer part of any role and/or group. However, the user still has a valid certificate for another 22 hours. If there are any roles that have "user.*" or "*" members, then the user can still use its x.509 certificate to get an access token which should not be allowed. While we take the risk that the user's certificate will be valid for another 22 hours while connecting to other services, ZMS and ZTS themselves should not honor that certificate.

So now after every authenticate call, if the principal identity is the user domain, ZMS/ZTS validate the user with the configured user authority to make sure the user is still valid before processing the request.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

