### PR TITLE
fix tls protocol/cipher log with jetty 1.12.x

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLog.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLog.java
@@ -19,18 +19,17 @@ import java.util.Locale;
 
 import com.yahoo.athenz.common.ServerCommonConsts;
 import org.apache.hc.core5.net.InetAddressUtils;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.CustomRequestLog;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.RequestLog;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.DateCache;
-import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.net.ssl.SSLSession;
 
 public class AthenzRequestLog extends CustomRequestLog {
 
@@ -93,10 +92,12 @@ public class AthenzRequestLog extends CustomRequestLog {
     }
 
     private void logTLSProtocol(StringBuilder buf, Request request) {
-        SSLSession sslSession = (SSLSession) request.getAttribute(ServerCommonConsts.REQUEST_SSL_SESSION);
-        append(buf, (sslSession == null) ? null : sslSession.getProtocol());
+        EndPoint.SslSessionData sslData = (EndPoint.SslSessionData) request.getAttribute(EndPoint.SslSessionData.ATTRIBUTE);
+
+        append(buf, (sslData == null) ? null : sslData.sslSession() != null
+            ? sslData.sslSession().getProtocol() : null);
         buf.append(' ');
-        append(buf, (sslSession == null) ? null : sslSession.getCipherSuite());
+        append(buf, (sslData == null) ? null : sslData.cipherSuite());
     }
 
     private void append(StringBuilder buf, String str) {

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLogTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/log/jetty/AthenzRequestLogTest.java
@@ -18,6 +18,7 @@ package com.yahoo.athenz.common.server.log.jetty;
 import com.yahoo.athenz.common.ServerCommonConsts;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.server.*;
 import org.eclipse.jetty.server.internal.HttpChannelState;
 import org.mockito.Mockito;
@@ -299,9 +300,11 @@ public class AthenzRequestLogTest {
         Mockito.when(response.getStatus()).thenReturn(200);
 
         SSLSession sslSession = Mockito.mock(SSLSession.class);
-        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_SSL_SESSION)).thenReturn(sslSession);
         Mockito.when(sslSession.getProtocol()).thenReturn("TLSv1.2");
-        Mockito.when(sslSession.getCipherSuite()).thenReturn("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        EndPoint.SslSessionData sslData = Mockito.mock(EndPoint.SslSessionData.class);
+        Mockito.when(sslData.sslSession()).thenReturn(sslSession);
+        Mockito.when(sslData.cipherSuite()).thenReturn("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        Mockito.when(request.getAttribute(EndPoint.SslSessionData.ATTRIBUTE)).thenReturn(sslData);
 
         athenzRequestLog.log(request, response);
         athenzRequestLog.stop();
@@ -357,9 +360,11 @@ public class AthenzRequestLogTest {
         Mockito.when(response.getStatus()).thenReturn(200);
 
         SSLSession sslSession = Mockito.mock(SSLSession.class);
-        Mockito.when(request.getAttribute(ServerCommonConsts.REQUEST_SSL_SESSION)).thenReturn(sslSession);
         Mockito.when(sslSession.getProtocol()).thenReturn("TLSv1.2");
-        Mockito.when(sslSession.getCipherSuite()).thenReturn("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        EndPoint.SslSessionData sslData = Mockito.mock(EndPoint.SslSessionData.class);
+        Mockito.when(sslData.sslSession()).thenReturn(sslSession);
+        Mockito.when(sslData.cipherSuite()).thenReturn("TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256");
+        Mockito.when(request.getAttribute(EndPoint.SslSessionData.ATTRIBUTE)).thenReturn(sslData);
 
         athenzRequestLog.log(request, response);
         athenzRequestLog.stop();


### PR DESCRIPTION
# Description

since the migration to jetty 1.12.x we lost the capability to log tls protocol version and cipher used in connections because the attribute that jetty used in previous versions was changed and the code wasn't updated accordingly

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

