### PR TITLE
extend role cert san-dns validation check

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -4078,7 +4078,7 @@ public class ZTSImpl implements ZTSHandler {
     boolean validateRoleCertificateRequest(X509RoleCertRequest certReq, final String principal,
             final String proxyUser, X509Certificate cert, final String ip) {
 
-        if (!certReq.validate(principal, proxyUser, validCertSubjectOrgValues, validateRoleCertDnsNames)) {
+        if (!certReq.validate(principal, proxyUser, cert, validCertSubjectOrgValues, validateRoleCertDnsNames)) {
             return false;
         }
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509RoleCertRequest.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509RoleCertRequest.java
@@ -168,8 +168,8 @@ public class X509RoleCertRequest extends X509CertRequest {
         return true;
     }
 
-    public boolean validate(final String principal, final String proxyUser, Set<String> validCertSubjectOrgValues,
-            boolean validateRoleCertDnsNames) {
+    public boolean validate(final String principal, final String proxyUser, final X509Certificate cert,
+            final Set<String> validCertSubjectOrgValues, final boolean validateRoleCertDnsNames) {
 
         // now let's check if we have a valid role principal
 
@@ -180,7 +180,7 @@ public class X509RoleCertRequest extends X509CertRequest {
         // validate that the dnsSuffix used in the dnsName attribute has
             // been authorized to be used by the given provider
 
-        if (!validateDnsNames(principal, validateRoleCertDnsNames)) {
+        if (!validateDnsNames(principal, cert, validateRoleCertDnsNames)) {
             return false;
         }
 
@@ -201,7 +201,19 @@ public class X509RoleCertRequest extends X509CertRequest {
         return validateSpiffeURI(reqRoleDomain, reqRoleName);
     }
 
-    boolean validateDnsNames(final String principal, boolean validateRoleCertDnsNames) {
+    private boolean serviceIdentityDnsNameMatch(final String prefix, final String dnsName) {
+
+        // the suffix values already start with a dot so we don't need to add it here
+
+        for (String suffix : ZTSUtils.ZTS_CERT_DNS_SUFFIX) {
+            if (dnsName.equals(prefix + suffix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    boolean validateDnsNames(final String principal, final X509Certificate principalCert, final boolean validateRoleCertDnsNames) {
 
         // if no dns names in the CSR then we're ok
 
@@ -217,47 +229,33 @@ public class X509RoleCertRequest extends X509CertRequest {
         final String domain = principal.substring(0, idx);
         final String service = principal.substring(idx + 1);
 
-        // the only format we're allowed to have in the CSR is:
+        List<String> principalCertDnsNames = (principalCert != null) ?
+            Crypto.extractX509CertDnsNames(principalCert) : Collections.emptyList();
+
+        // the dns names in the role certificate can inherit any of the dns names in
+        // the principal certificate or they must be in the format of
         // <service>.<domain-with-dashes>.<provider-dns-suffix>
-        // so we'll check if we have exactly one dns name if
-        // we're configured to validate dns names
-
-        if (validateRoleCertDnsNames && dnsNames.size() != 1) {
-            LOGGER.error("csr has incorrect number of dns names: {}/{}",
-                dnsNames.size(), String.join(", ", dnsNames));
-            return false;
-        }
-
-        // otherwise we'll go through and report any invalid dns names
-        // our dns suffix names already start with . so we don't need to add it again
 
         final String prefix = service + "." + domain.replace('.', '-');
         for (String dnsName : dnsNames) {
 
-            boolean match = false;
-            for (String suffix : ZTSUtils.ZTS_CERT_DNS_SUFFIX) {
-                if (dnsName.equals(prefix + suffix)) {
-                    match = true;
-                    break;
-                }
-            }
+            // if the dns name is in the principal certificate, then we're good
+            // and we can continue with the next dns name
 
-            if (match) {
-                if (validateRoleCertDnsNames) {
-                    return true;
-                }
+            if (principalCertDnsNames.contains(dnsName)) {
                 continue;
             }
 
-            LOGGER.error("Role Certificate sanDNS Validation - invalid entry: {}", dnsName);
+            if (serviceIdentityDnsNameMatch(prefix, dnsName)) {
+                continue;
+            }
+
+            LOGGER.error("Role Certificate sanDNS Validation - invalid entry: {}, principal: {}",
+                dnsName, principal);
             if (validateRoleCertDnsNames) {
                 return false;
             }
         }
-
-        // if our validation was turned on, then we would have
-        // already returned so at this point we're assuming the
-        // validation was turned off so we'll return true
 
         return true;
     }

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509RoleCertRequest.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/cert/X509RoleCertRequest.java
@@ -229,8 +229,8 @@ public class X509RoleCertRequest extends X509CertRequest {
         final String domain = principal.substring(0, idx);
         final String service = principal.substring(idx + 1);
 
-        List<String> principalCertDnsNames = (principalCert != null) ?
-            Crypto.extractX509CertDnsNames(principalCert) : Collections.emptyList();
+Set<String> principalCertDnsNames = (principalCert != null) ?
+    new HashSet<>(Crypto.extractX509CertDnsNames(principalCert)) : Collections.emptySet();
 
         // the dns names in the role certificate can inherit any of the dns names in
         // the principal certificate or they must be in the format of

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/X509RoleCertRequestTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/cert/X509RoleCertRequestTest.java
@@ -63,8 +63,8 @@ public class X509RoleCertRequestTest {
         Set<String> orgValues = new HashSet<>();
         orgValues.add("Athenz");
 
-        assertTrue(certReq.validate("sports.api", null, orgValues, false));
-        assertTrue(certReq.validate("sports.api", null, orgValues, true));
+        assertTrue(certReq.validate("sports.api", null, null, orgValues, false));
+        assertTrue(certReq.validate("sports.api", null, null, orgValues, true));
     }
 
     @Test
@@ -152,7 +152,7 @@ public class X509RoleCertRequestTest {
         Set<String> orgValues = new HashSet<>();
         orgValues.add("Athenz");
 
-        assertFalse(certReq.validate("sports.api", "proxy.user", orgValues, false));
+        assertFalse(certReq.validate("sports.api", "proxy.user", null, orgValues, false));
     }
 
     @Test
@@ -166,7 +166,7 @@ public class X509RoleCertRequestTest {
         Set<String> orgValues = new HashSet<>();
         orgValues.add("Athenz");
 
-        assertFalse(certReq.validate("athenz.production", "proxy.user", orgValues, false));
+        assertFalse(certReq.validate("athenz.production", "proxy.user", null, orgValues, false));
     }
 
     @Test
@@ -180,7 +180,7 @@ public class X509RoleCertRequestTest {
         Set<String> orgValues = new HashSet<>();
         orgValues.add("Athenz");
 
-        assertFalse(certReq.validate("sports.api", "proxy.user", orgValues, false));
+        assertFalse(certReq.validate("sports.api", "proxy.user", null, orgValues, false));
     }
 
     @Test
@@ -195,10 +195,10 @@ public class X509RoleCertRequestTest {
         orgValues.add("Athenz");
 
         // valid proxy user
-        assertTrue(certReq.validate("sports.api", "proxy.user", orgValues, false));
+        assertTrue(certReq.validate("sports.api", "proxy.user", null, orgValues, false));
 
         // mismatch proxy user
-        assertFalse(certReq.validate("sports.api", "proxy2.user", orgValues, false));
+        assertFalse(certReq.validate("sports.api", "proxy2.user", null, orgValues, false));
     }
 
     @Test
@@ -208,8 +208,8 @@ public class X509RoleCertRequestTest {
         String csr = new String(Files.readAllBytes(path));
 
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
-        assertTrue(certReq.validate("athenz.production", null, null, false));
-        assertFalse(certReq.validate("athenz.api", null, null, false));
+        assertTrue(certReq.validate("athenz.production", null, null, null, false));
+        assertFalse(certReq.validate("athenz.api", null, null, null, false));
     }
 
     @Test
@@ -219,8 +219,8 @@ public class X509RoleCertRequestTest {
         String csr = new String(Files.readAllBytes(path));
 
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
-        assertTrue(certReq.validate("athenz.production", null, null, false));
-        assertFalse(certReq.validate("athenz.api", null, null, false));
+        assertTrue(certReq.validate("athenz.production", null, null, null, false));
+        assertFalse(certReq.validate("athenz.api", null, null, null, false));
     }
 
     @Test
@@ -230,8 +230,8 @@ public class X509RoleCertRequestTest {
         String csr = new String(Files.readAllBytes(path));
 
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
-        assertFalse(certReq.validate("athenz.production", null, null, false));
-        assertFalse(certReq.validate("athenz.api", null, null, false));
+        assertFalse(certReq.validate("athenz.production", null, null, null, false));
+        assertFalse(certReq.validate("athenz.api", null, null, null, false));
     }
 
     @Test
@@ -263,7 +263,7 @@ public class X509RoleCertRequestTest {
         String csr = new String(Files.readAllBytes(path));
 
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
-        assertTrue(certReq.validateDnsNames("sports.api", false));
+        assertTrue(certReq.validateDnsNames("sports.api", null, false));
     }
 
     @Test
@@ -273,7 +273,7 @@ public class X509RoleCertRequestTest {
         String csr = new String(Files.readAllBytes(path));
 
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
-        assertFalse(certReq.validateDnsNames("nodotprincipal", false));
+        assertFalse(certReq.validateDnsNames("nodotprincipal", null, false));
     }
 
     @Test
@@ -285,7 +285,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Collections.singletonList("api.sports.athenz.cloud");
 
-        assertTrue(certReq.validateDnsNames("sports.api", false));
+        assertTrue(certReq.validateDnsNames("sports.api", null, false));
     }
 
     @Test
@@ -297,7 +297,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Collections.singletonList("invalid.dns.name");
 
-        assertTrue(certReq.validateDnsNames("sports.api", false));
+        assertTrue(certReq.validateDnsNames("sports.api", null, false));
     }
 
     @Test
@@ -309,7 +309,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Arrays.asList("invalid1.dns.name", "invalid2.dns.name");
 
-        assertTrue(certReq.validateDnsNames("sports.api", false));
+        assertTrue(certReq.validateDnsNames("sports.api", null, false));
     }
 
     @Test
@@ -321,7 +321,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Arrays.asList("api.sports.athenz.cloud", "invalid.dns.name");
 
-        assertTrue(certReq.validateDnsNames("sports.api", false));
+        assertTrue(certReq.validateDnsNames("sports.api", null, false));
     }
 
     @Test
@@ -333,7 +333,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Collections.singletonList("api.sports.athenz.cloud");
 
-        assertTrue(certReq.validateDnsNames("sports.api", true));
+        assertTrue(certReq.validateDnsNames("sports.api", null, true));
     }
 
     @Test
@@ -345,7 +345,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Collections.singletonList("invalid.dns.name");
 
-        assertFalse(certReq.validateDnsNames("sports.api", true));
+        assertFalse(certReq.validateDnsNames("sports.api", null, true));
     }
 
     @Test
@@ -357,7 +357,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Arrays.asList("api.sports.athenz.cloud", "extra.dns.athenz.cloud");
 
-        assertFalse(certReq.validateDnsNames("sports.api", true));
+        assertFalse(certReq.validateDnsNames("sports.api", null, true));
     }
 
     @Test
@@ -369,7 +369,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Arrays.asList("api.sports.athenz.cloud", "api.sports.athenz.cloud");
 
-        assertFalse(certReq.validateDnsNames("sports.api", true));
+        assertTrue(certReq.validateDnsNames("sports.api", null, true));
     }
 
     @Test
@@ -381,7 +381,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Collections.singletonList("api.athenz-sub.athenz.cloud");
 
-        assertTrue(certReq.validateDnsNames("athenz.sub.api", true));
+        assertTrue(certReq.validateDnsNames("athenz.sub.api", null, true));
     }
 
     @Test
@@ -393,7 +393,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Collections.singletonList("api.athenz-wrong.athenz.cloud");
 
-        assertFalse(certReq.validateDnsNames("athenz.sub.api", true));
+        assertFalse(certReq.validateDnsNames("athenz.sub.api", null, true));
     }
 
     @Test
@@ -406,7 +406,7 @@ public class X509RoleCertRequestTest {
 
         // role_single_ip.csr has DNS names that don't match the default suffix pattern
         // with validation off, should still return true
-        assertTrue(certReq.validateDnsNames("athenz.production", false));
+        assertTrue(certReq.validateDnsNames("athenz.production", null, false));
     }
 
     @Test
@@ -418,7 +418,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
 
         // role_single_ip.csr has 2 DNS names, with validation on and size != 1, should fail
-        assertFalse(certReq.validateDnsNames("athenz.production", true));
+        assertFalse(certReq.validateDnsNames("athenz.production", null, true));
     }
 
     @Test
@@ -430,7 +430,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Collections.singletonList("api.sports.wrong.suffix");
 
-        assertFalse(certReq.validateDnsNames("sports.api", true));
+        assertFalse(certReq.validateDnsNames("sports.api", null, true));
     }
 
     @Test
@@ -442,7 +442,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Collections.singletonList("wrongservice.sports.athenz.cloud");
 
-        assertFalse(certReq.validateDnsNames("sports.api", true));
+        assertFalse(certReq.validateDnsNames("sports.api", null, true));
     }
 
     @Test
@@ -454,7 +454,7 @@ public class X509RoleCertRequestTest {
         X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
         certReq.dnsNames = Collections.singletonList("api.wrongdomain.athenz.cloud");
 
-        assertFalse(certReq.validateDnsNames("sports.api", true));
+        assertFalse(certReq.validateDnsNames("sports.api", null, true));
     }
 
     @Test
@@ -469,6 +469,104 @@ public class X509RoleCertRequestTest {
         Set<String> orgValues = new HashSet<>();
         orgValues.add("Athenz");
 
-        assertFalse(certReq.validate("sports.api", null, orgValues, true));
+        assertFalse(certReq.validate("sports.api", null, null, orgValues, true));
+    }
+
+    @Test
+    public void testValidateDnsNamesWithCertDnsMatch() throws IOException {
+
+        Path path = Paths.get("src/test/resources/spiffe_role.csr");
+        String csr = new String(Files.readAllBytes(path));
+
+        path = Paths.get("src/test/resources/athenz.instanceid.pem");
+        String pem = new String(Files.readAllBytes(path));
+        X509Certificate cert = Crypto.loadX509Certificate(pem);
+
+        X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
+        certReq.dnsNames = Collections.singletonList("production.athenz.ostk.athenz.cloud");
+
+        assertTrue(certReq.validateDnsNames("athenz.production", cert, true));
+    }
+
+    @Test
+    public void testValidateDnsNamesWithCertDnsMatchMultiple() throws IOException {
+
+        Path path = Paths.get("src/test/resources/spiffe_role.csr");
+        String csr = new String(Files.readAllBytes(path));
+
+        path = Paths.get("src/test/resources/athenz.instanceid.pem");
+        String pem = new String(Files.readAllBytes(path));
+        X509Certificate cert = Crypto.loadX509Certificate(pem);
+
+        X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
+        certReq.dnsNames = Arrays.asList("production.athenz.ostk.athenz.cloud",
+                "1001.instanceid.athenz.ostk.athenz.cloud");
+
+        assertTrue(certReq.validateDnsNames("athenz.production", cert, true));
+    }
+
+    @Test
+    public void testValidateDnsNamesWithCertDnsAndSuffixMatch() throws IOException {
+
+        Path path = Paths.get("src/test/resources/spiffe_role.csr");
+        String csr = new String(Files.readAllBytes(path));
+
+        path = Paths.get("src/test/resources/athenz.instanceid.pem");
+        String pem = new String(Files.readAllBytes(path));
+        X509Certificate cert = Crypto.loadX509Certificate(pem);
+
+        X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
+        certReq.dnsNames = Arrays.asList("production.athenz.ostk.athenz.cloud",
+                "production.athenz.athenz.cloud");
+
+        assertTrue(certReq.validateDnsNames("athenz.production", cert, true));
+    }
+
+    @Test
+    public void testValidateDnsNamesWithCertDnsNoMatch() throws IOException {
+
+        Path path = Paths.get("src/test/resources/spiffe_role.csr");
+        String csr = new String(Files.readAllBytes(path));
+
+        path = Paths.get("src/test/resources/athenz.instanceid.pem");
+        String pem = new String(Files.readAllBytes(path));
+        X509Certificate cert = Crypto.loadX509Certificate(pem);
+
+        X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
+        certReq.dnsNames = Collections.singletonList("unknown.dns.name");
+
+        assertFalse(certReq.validateDnsNames("athenz.production", cert, true));
+    }
+
+    @Test
+    public void testValidateDnsNamesWithCertDnsPartialMatchValidationOn() throws IOException {
+
+        Path path = Paths.get("src/test/resources/spiffe_role.csr");
+        String csr = new String(Files.readAllBytes(path));
+
+        path = Paths.get("src/test/resources/athenz.instanceid.pem");
+        String pem = new String(Files.readAllBytes(path));
+        X509Certificate cert = Crypto.loadX509Certificate(pem);
+
+        X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
+        certReq.dnsNames = Arrays.asList("production.athenz.ostk.athenz.cloud", "unknown.dns.name");
+
+        assertFalse(certReq.validateDnsNames("athenz.production", cert, true));
+    }
+
+    @Test
+    public void testValidateDnsNamesWithCertDnsPartialMatchValidationOff() throws IOException {
+
+        Path path = Paths.get("src/test/resources/spiffe_role.csr");
+        String csr = new String(Files.readAllBytes(path));
+
+        path = Paths.get("src/test/resources/athenz.instanceid.pem");
+        String pem = new String(Files.readAllBytes(path));
+        X509Certificate cert = Crypto.loadX509Certificate(pem);
+
+        X509RoleCertRequest certReq = new X509RoleCertRequest(csr, spiffeUriManager);
+        certReq.dnsNames = Arrays.asList("production.athenz.ostk.athenz.cloud", "unknown.dns.name");
+
+        assertTrue(certReq.validateDnsNames("athenz.production", cert, false));
     }
 }


### PR DESCRIPTION
# Description

role certificates should be allowed to inherit any of the san dns values from the principal certificate that was used to request the role certificate. the san dns validation logic was updated to allow this.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

