### PR TITLE
uplift next.js to version 16.2.6

### DIFF
--- a/ui/next.config.js
+++ b/ui/next.config.js
@@ -1,8 +1,8 @@
 const appConfig = require('./src/config/config')();
 
 module.exports = {
-    publicRuntimeConfig: {
-        onCallUrl: appConfig.onCallUrl || appConfig.serverURL,
-        organizationDomain: appConfig?.organizationDomain,
+    env: {
+        NEXT_PUBLIC_ONCALL_URL: appConfig?.onCallUrl || appConfig.serverURL,
+        NEXT_PUBLIC_ORGANIZATION_DOMAIN: appConfig?.organizationDomain,
     },
 };

--- a/ui/package.json
+++ b/ui/package.json
@@ -95,7 +95,7 @@
         "moment": "2.29.4",
         "moment-timezone": "0.5.37",
         "multer": "2.1.1",
-        "next": "14.2.35",
+        "next": "16.2.6",
         "next-redux-wrapper": "8.0.0",
         "passport": "0.6.0",
         "passport-strategy": "1.0.0",

--- a/ui/src/config/client-config.js
+++ b/ui/src/config/client-config.js
@@ -1,8 +1,5 @@
-import getConfig from 'next/config';
-const { publicRuntimeConfig } = getConfig() || {};
-
 // Exposes values from config files that depend on Node.js APIs (not accessible client-side)
 export const CLIENT_CONFIG = {
-    onCallUrl: publicRuntimeConfig?.onCallUrl,
-    organizationDomain: publicRuntimeConfig?.organizationDomain,
+    onCallUrl: process.env.NEXT_PUBLIC_ONCALL_URL,
+    organizationDomain: process.env.NEXT_PUBLIC_ORGANIZATION_DOMAIN,
 };

--- a/ui/src/redux/actions/policies.js
+++ b/ui/src/redux/actions/policies.js
@@ -63,6 +63,17 @@ export const addAssertionPolicyVersionToStore = (
     },
 });
 
+export const ADD_ASSERTION_CONDITIONS = 'ADD_ASSERTION_CONDITIONS';
+export const addAssertionConditionsToStore = (
+    policyName,
+    version,
+    assertionId,
+    conditionsList
+) => ({
+    type: ADD_ASSERTION_CONDITIONS,
+    payload: { policyName, version, assertionId, conditionsList },
+});
+
 export const DELETE_ASSERTION_POLICY_VERSION =
     'DELETE_ASSERTION_POLICY_VERSION';
 export const deleteAssertionPolicyVersionFromStore = (
@@ -83,6 +94,16 @@ export const deleteAssertionConditionFromStore = (
 ) => ({
     type: DELETE_ASSERTION_CONDITION,
     payload: { policyName, version, assertionId, conditionId },
+});
+
+export const DELETE_ASSERTION_CONDITIONS = 'DELETE_ASSERTION_CONDITIONS';
+export const deleteAssertionConditionsFromStore = (
+    policyName,
+    version,
+    assertionId
+) => ({
+    type: DELETE_ASSERTION_CONDITIONS,
+    payload: { policyName, version, assertionId },
 });
 
 export const MAKE_POLICIES_EXPIRES = 'MAKE_POLICIES_EXPIRES';


### PR DESCRIPTION
# Description
* uplift next.js version to 16.2.6
* export missing redux actions (next.js 16 has stricter ESM analysis)
* use `NEXT_PUBLIC` env vars since we can no longer read in nextjs config (deprecated)

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

