### PR TITLE
fix POC and security POC not loading on non role/group domain tabs

### DIFF
--- a/ui/src/components/header/DomainDetails.js
+++ b/ui/src/components/header/DomainDetails.js
@@ -44,6 +44,7 @@ import { makePoliciesExpires } from '../../redux/actions/policies';
 import Icon from '../denali/icons/Icon';
 import AddPoc from '../member/AddPoc';
 import { selectAllUsers } from '../../redux/selectors/user';
+import { getAllUsers } from '../../redux/thunks/user';
 import AddEnvironmentModal from '../modal/AddEnvironmentModal';
 import AddSlackChannelModal from '../modal/AddSlackChannelModal';
 import OnCallTeamModal from '../modal/OnCallTeamModal';
@@ -135,6 +136,12 @@ class DomainDetails extends React.Component {
         this.onClickOnboardToAWS = this.onClickOnboardToAWS.bind(this);
         this.toggleOnboardToAWSModal = this.toggleOnboardToAWSModal.bind(this);
         this.saveJustification = this.saveJustification.bind(this);
+    }
+
+    componentDidMount() {
+        if (this.props.getAllUsers) {
+            Promise.resolve(this.props.getAllUsers()).catch(() => {});
+        }
     }
 
     showError(errorMessage) {
@@ -744,6 +751,7 @@ const mapDispatchToProps = (dispatch) => ({
         dispatch(makeRolesExpires());
         dispatch(makePoliciesExpires());
     },
+    getAllUsers: () => dispatch(getAllUsers()),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(DomainDetails);

--- a/ui/src/components/header/DomainDetails.js
+++ b/ui/src/components/header/DomainDetails.js
@@ -139,9 +139,9 @@ class DomainDetails extends React.Component {
     }
 
     componentDidMount() {
-        if (this.props.getAllUsers) {
-            Promise.resolve(this.props.getAllUsers()).catch(() => {});
-        }
+        this.props.getAllUsers().catch((err) => {
+            this.showError(RequestUtils.xhrErrorCheckHelper(err));
+        });
     }
 
     showError(errorMessage) {

--- a/ui/src/pages/domain/[domain]/group.js
+++ b/ui/src/pages/domain/[domain]/group.js
@@ -34,8 +34,6 @@ import Alert from '../../../components/denali/Alert';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import { ReduxPageLoader } from '../../../components/denali/ReduxPageLoader';
-import { getAllUsers } from '../../../redux/thunks/user';
-import { selectAllUsers } from '../../../redux/selectors/user';
 import { withRouter } from 'next/router';
 
 const AppContainerDiv = styled.div`
@@ -108,15 +106,9 @@ class GroupPage extends React.Component {
     }
 
     componentDidMount() {
-        const {
-            getAllUsers,
-            getDomainData,
-            getGroupsList,
-            domainName,
-            userName,
-        } = this.props;
+        const { getDomainData, getGroupsList, domainName, userName } =
+            this.props;
         Promise.all([
-            getAllUsers(),
             getDomainData(domainName, userName),
             getGroupsList(domainName),
         ]).catch((err) => {
@@ -212,12 +204,10 @@ const mapStateToProps = (state, props) => {
         ...props,
         domainData: selectDomainData(state),
         isLoading: selectIsLoading(state),
-        userList: selectAllUsers(state),
     };
 };
 
 const mapDispatchToProps = (dispatch) => ({
-    getAllUsers: () => dispatch(getAllUsers()),
     getDomainData: (domainName, userName) =>
         dispatch(getDomainData(domainName, userName)),
     getGroupsList: (domainName) => dispatch(getGroups(domainName)),

--- a/ui/src/pages/domain/[domain]/role.js
+++ b/ui/src/pages/domain/[domain]/role.js
@@ -34,8 +34,6 @@ import Alert from '../../../components/denali/Alert';
 import createCache from '@emotion/cache';
 import { CacheProvider } from '@emotion/react';
 import { ReduxPageLoader } from '../../../components/denali/ReduxPageLoader';
-import { getAllUsers } from '../../../redux/thunks/user';
-import { selectAllUsers } from '../../../redux/selectors/user';
 import { withRouter } from 'next/router';
 
 const AppContainerDiv = styled.div`
@@ -114,10 +112,8 @@ class RolePage extends React.Component {
     }
 
     componentDidMount() {
-        const { getAllUsers, getRoles, domainName, getDomainData, userName } =
-            this.props;
+        const { getRoles, domainName, getDomainData, userName } = this.props;
         Promise.all([
-            getAllUsers(),
             getDomainData(domainName, userName),
             getRoles(domainName),
         ]).catch((err) => {
@@ -236,12 +232,10 @@ const mapStateToProps = (state, props) => {
         ...props,
         isLoading: selectIsLoading(state),
         domainData: selectDomainData(state),
-        userList: selectAllUsers(state),
     };
 };
 
 const mapDispatchToProps = (dispatch) => ({
-    getAllUsers: () => dispatch(getAllUsers()),
     getRoles: (domainName) => dispatch(getRoles(domainName)),
     getDomainData: (domainName, userName) =>
         dispatch(getDomainData(domainName, userName)),


### PR DESCRIPTION
# Description

  - `DomainDetails` resolves POC / Security POC display names by looking up `user.login` in `state.user.userList`. Only `role.js` and `group.js` dispatched `getAllUsers()` in `componentDidMount`, so on a hard refresh of any other tab that renders `DomainDetails` (service, policy, history, microsegmentation, tags,
  template, domain-settings, visibility) the user list was empty and both fields fell back to "add".
  - Move the `getAllUsers` dispatch into `DomainDetails.componentDidMount` so every tab that mounts the component gets the user list. The thunk is idempotent — it skips the API call if the list is already in the store — so this does not introduce extra fetches.
  - Remove the now-redundant `getAllUsers` wiring and unused `userList` prop from `role.js` and `group.js`.

  ## Test plan

  - [x] `npx jest src/__tests__/components/header/DomainDetails.test.js` — 7/7 pass
  - [x] `npx jest "src/__tests__/pages/domain/[domain]/"` — 34/34 pass
  - [ ] Verify in deployed UI: hard refresh non-role/group tabs and confirm POC / Security POC render correctly
 

<!-- Explain here the changes your PR introduces and text to help us understand the context of this change. -->

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

