### PR TITLE
add validation for selfRenew in ZMS

### DIFF
--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -2937,6 +2937,12 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         validateIntegerValue(role.getMaxMembers(), "maxMembers");
         validateIntegerValue(role.getSelfRenewMins(), "selfRenewMins");
 
+        if (role.getSelfRenew() == Boolean.TRUE
+                && (role.getSelfRenewMins() == null || role.getSelfRenewMins() <= 0)) {
+            throw ZMSUtils.requestError(
+                    "Role cannot enable self-renew without a positive selfRenewMins value", caller);
+        }
+
         validateString(role.getNotifyRoles(), TYPE_RESOURCE_NAMES, caller);
         validateString(role.getUserAuthorityFilter(), TYPE_AUTHORITY_KEYWORDS, caller);
         validateString(role.getUserAuthorityExpiration(), TYPE_AUTHORITY_KEYWORD, caller);
@@ -2952,6 +2958,12 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
         validateIntegerValue(group.getServiceExpiryDays(), "serviceExpiryDays");
         validateIntegerValue(group.getMaxMembers(), "maxMembers");
         validateIntegerValue(group.getSelfRenewMins(), "selfRenewMins");
+
+        if (group.getSelfRenew() == Boolean.TRUE
+                && (group.getSelfRenewMins() == null || group.getSelfRenewMins() <= 0)) {
+            throw ZMSUtils.requestError(
+                    "Group cannot enable self-renew without a positive selfRenewMins value", caller);
+        }
 
         validateString(group.getNotifyRoles(), TYPE_RESOURCE_NAMES, caller);
         validateString(group.getUserAuthorityFilter(), TYPE_AUTHORITY_KEYWORDS, caller);
@@ -10590,6 +10602,10 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         validateRoleMetaAuditEnabledFlag(meta, role, domain.getDomain(), caller);
 
+        // validate self-renew settings for the given role
+
+        validateRoleMetaSelfRenewFlag(meta, role, caller);
+
         // authorization check since we have 2 actions: update and update_meta
         // that allow access callers to manage metadata in a role
 
@@ -10633,6 +10649,29 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             }
         } else {
             meta.setAuditEnabled(role.getAuditEnabled());
+        }
+    }
+
+    void validateRoleMetaSelfRenewFlag(RoleMeta meta, Role role, final String caller) {
+
+        // only validate if the caller is touching either of the self-renew fields;
+        // pre-existing inconsistent rows can continue to receive unrelated meta updates
+
+        if (meta.getSelfRenew() == null && meta.getSelfRenewMins() == null) {
+            return;
+        }
+
+        Boolean effectiveSelfRenew = meta.getSelfRenew() != null
+                ? meta.getSelfRenew() : role.getSelfRenew();
+        if (effectiveSelfRenew != Boolean.TRUE) {
+            return;
+        }
+
+        Integer effectiveSelfRenewMins = meta.getSelfRenewMins() != null
+                ? meta.getSelfRenewMins() : role.getSelfRenewMins();
+        if (effectiveSelfRenewMins == null || effectiveSelfRenewMins <= 0) {
+            throw ZMSUtils.requestError(
+                    "Role cannot enable self-renew without a positive selfRenewMins value", caller);
         }
     }
 
@@ -12332,6 +12371,10 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         validateGroupMetaAuditEnabledFlag(meta, group, domain.getDomain(), caller);
 
+        // validate self-renew settings for the given group
+
+        validateGroupMetaSelfRenewFlag(meta, group, caller);
+
         // verify resource ownership for the request. If the object returned
         // is not null then it indicates that the object must be modified
         // with the given resource ownership details
@@ -12361,6 +12404,29 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
             }
         } else {
             meta.setAuditEnabled(group.getAuditEnabled());
+        }
+    }
+
+    void validateGroupMetaSelfRenewFlag(GroupMeta meta, Group group, final String caller) {
+
+        // only validate if the caller is touching either of the self-renew fields;
+        // pre-existing inconsistent rows can continue to receive unrelated meta updates
+
+        if (meta.getSelfRenew() == null && meta.getSelfRenewMins() == null) {
+            return;
+        }
+
+        Boolean effectiveSelfRenew = meta.getSelfRenew() != null
+                ? meta.getSelfRenew() : group.getSelfRenew();
+        if (effectiveSelfRenew != Boolean.TRUE) {
+            return;
+        }
+
+        Integer effectiveSelfRenewMins = meta.getSelfRenewMins() != null
+                ? meta.getSelfRenewMins() : group.getSelfRenewMins();
+        if (effectiveSelfRenewMins == null || effectiveSelfRenewMins <= 0) {
+            throw ZMSUtils.requestError(
+                    "Group cannot enable self-renew without a positive selfRenewMins value", caller);
         }
     }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/SelfRenewTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/SelfRenewTest.java
@@ -384,4 +384,340 @@ public class SelfRenewTest {
         assertTrue(membershipRes.getExpiration().millis() >= currentTime + 9 * 60 * 1000);
         assertTrue(membershipRes.getExpiration().millis() <= currentTime + 11 * 60 * 1000);
     }
+
+    @Test
+    public void testValidateRoleSelfRenewFlag() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+
+        // meta does not touch either field - no validation should happen
+        // even if the stored role would be inconsistent
+
+        RoleMeta meta = new RoleMeta();
+        Role role = new Role().setSelfRenew(Boolean.TRUE).setSelfRenewMins(null);
+        zmsImpl.validateRoleMetaSelfRenewFlag(meta, role, "validateRoleSelfRenewFlag");
+
+        // meta sets selfRenew=true with no mins, stored role also has no mins -> reject
+
+        meta.setSelfRenew(Boolean.TRUE);
+        role = new Role().setSelfRenew(null).setSelfRenewMins(null);
+        try {
+            zmsImpl.validateRoleMetaSelfRenewFlag(meta, role, "validateRoleSelfRenewFlag");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Role cannot enable self-renew without a positive selfRenewMins value"));
+        }
+
+        // meta sets selfRenew=true and stored role has a valid mins -> ok
+
+        role = new Role().setSelfRenew(null).setSelfRenewMins(15);
+        zmsImpl.validateRoleMetaSelfRenewFlag(meta, role, "validateRoleSelfRenewFlag");
+
+        // meta sets selfRenew=true and mins=0 -> reject regardless of stored
+
+        meta.setSelfRenewMins(0);
+        try {
+            zmsImpl.validateRoleMetaSelfRenewFlag(meta, role, "validateRoleSelfRenewFlag");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+
+        // meta sets mins=0 while stored selfRenew=true -> reject
+
+        meta = new RoleMeta().setSelfRenewMins(0);
+        role = new Role().setSelfRenew(Boolean.TRUE).setSelfRenewMins(10);
+        try {
+            zmsImpl.validateRoleMetaSelfRenewFlag(meta, role, "validateRoleSelfRenewFlag");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+
+        // meta sets mins=0 while stored selfRenew=false -> ok
+
+        role = new Role().setSelfRenew(Boolean.FALSE).setSelfRenewMins(10);
+        zmsImpl.validateRoleMetaSelfRenewFlag(meta, role, "validateRoleSelfRenewFlag");
+
+        // meta disables selfRenew while leaving mins null -> ok regardless of stored mins
+
+        meta = new RoleMeta().setSelfRenew(Boolean.FALSE);
+        role = new Role().setSelfRenew(Boolean.TRUE).setSelfRenewMins(null);
+        zmsImpl.validateRoleMetaSelfRenewFlag(meta, role, "validateRoleSelfRenewFlag");
+
+        // meta provides both, valid -> ok
+
+        meta = new RoleMeta().setSelfRenew(Boolean.TRUE).setSelfRenewMins(20);
+        role = new Role().setSelfRenew(null).setSelfRenewMins(null);
+        zmsImpl.validateRoleMetaSelfRenewFlag(meta, role, "validateRoleSelfRenewFlag");
+    }
+
+    @Test
+    public void testValidateGroupSelfRenewFlag() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+
+        // meta does not touch either field - no validation should happen
+
+        GroupMeta meta = new GroupMeta();
+        Group group = new Group().setSelfRenew(Boolean.TRUE).setSelfRenewMins(null);
+        zmsImpl.validateGroupMetaSelfRenewFlag(meta, group, "validateGroupSelfRenewFlag");
+
+        // meta sets selfRenew=true with no mins, stored group also has no mins -> reject
+
+        meta.setSelfRenew(Boolean.TRUE);
+        group = new Group().setSelfRenew(null).setSelfRenewMins(null);
+        try {
+            zmsImpl.validateGroupMetaSelfRenewFlag(meta, group, "validateGroupSelfRenewFlag");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Group cannot enable self-renew without a positive selfRenewMins value"));
+        }
+
+        // meta sets selfRenew=true and stored group has a valid mins -> ok
+
+        group = new Group().setSelfRenew(null).setSelfRenewMins(15);
+        zmsImpl.validateGroupMetaSelfRenewFlag(meta, group, "validateGroupSelfRenewFlag");
+
+        // meta sets mins=0 while stored selfRenew=true -> reject
+
+        meta = new GroupMeta().setSelfRenewMins(0);
+        group = new Group().setSelfRenew(Boolean.TRUE).setSelfRenewMins(10);
+        try {
+            zmsImpl.validateGroupMetaSelfRenewFlag(meta, group, "validateGroupSelfRenewFlag");
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+
+        // meta sets mins=0 while stored selfRenew=false -> ok
+
+        group = new Group().setSelfRenew(Boolean.FALSE).setSelfRenewMins(10);
+        zmsImpl.validateGroupMetaSelfRenewFlag(meta, group, "validateGroupSelfRenewFlag");
+
+        // meta provides both, valid -> ok
+
+        meta = new GroupMeta().setSelfRenew(Boolean.TRUE).setSelfRenewMins(20);
+        group = new Group().setSelfRenew(null).setSelfRenewMins(null);
+        zmsImpl.validateGroupMetaSelfRenewFlag(meta, group, "validateGroupSelfRenewFlag");
+    }
+
+    @Test
+    public void testPutRoleSelfRenewWithoutMinsRejected() {
+
+        final String domainName = "role-self-renew-bad-put";
+        final String roleName = "role1";
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain", "testOrg", "user.user1");
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        List<RoleMember> members = new ArrayList<>();
+        members.add(new RoleMember().setMemberName("user.jack"));
+
+        Role role = zmsTestInitializer.createRoleObject(domainName, roleName, null, members);
+        role.setSelfRenew(Boolean.TRUE);
+        role.setSelfRenewMins(null);
+
+        try {
+            zmsImpl.putRole(ctx, domainName, roleName, auditRef, false, null, role);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Role cannot enable self-renew without a positive selfRenewMins value"));
+        }
+
+        role.setSelfRenewMins(0);
+        try {
+            zmsImpl.putRole(ctx, domainName, roleName, auditRef, false, null, role);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+
+        // a valid pair is accepted
+
+        role.setSelfRenewMins(10);
+        zmsImpl.putRole(ctx, domainName, roleName, auditRef, false, null, role);
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
+    }
+
+    @Test
+    public void testPutGroupSelfRenewWithoutMinsRejected() {
+
+        final String domainName = "group-self-renew-bad-put";
+        final String groupName = "group1";
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain", "testOrg", "user.user1");
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        List<GroupMember> members = new ArrayList<>();
+        members.add(new GroupMember().setMemberName("user.jack"));
+
+        Group group = zmsTestInitializer.createGroupObject(domainName, groupName, members);
+        group.setSelfRenew(Boolean.TRUE);
+        group.setSelfRenewMins(null);
+
+        try {
+            zmsImpl.putGroup(ctx, domainName, groupName, auditRef, false, null, group);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Group cannot enable self-renew without a positive selfRenewMins value"));
+        }
+
+        group.setSelfRenewMins(0);
+        try {
+            zmsImpl.putGroup(ctx, domainName, groupName, auditRef, false, null, group);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+
+        // a valid pair is accepted
+
+        group.setSelfRenewMins(10);
+        zmsImpl.putGroup(ctx, domainName, groupName, auditRef, false, null, group);
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
+    }
+
+    @Test
+    public void testPutRoleMetaSelfRenewMergeAware() {
+
+        final String domainName = "role-self-renew-meta";
+        final String roleName = "role1";
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain", "testOrg", "user.user1");
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        List<RoleMember> members = new ArrayList<>();
+        members.add(new RoleMember().setMemberName("user.jack"));
+        Role role = zmsTestInitializer.createRoleObject(domainName, roleName, null, members);
+        zmsImpl.putRole(ctx, domainName, roleName, auditRef, false, null, role);
+
+        // PATCH selfRenew=true while stored selfRenewMins is null -> reject
+
+        RoleMeta rm = new RoleMeta().setSelfRenew(Boolean.TRUE);
+        try {
+            zmsImpl.putRoleMeta(ctx, domainName, roleName, auditRef, null, rm);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Role cannot enable self-renew without a positive selfRenewMins value"));
+        }
+
+        // PATCH a valid pair together -> accepted
+
+        rm = new RoleMeta().setSelfRenew(Boolean.TRUE).setSelfRenewMins(10);
+        zmsImpl.putRoleMeta(ctx, domainName, roleName, auditRef, null, rm);
+
+        // PATCH selfRenew=true alone now that stored mins is valid -> accepted (no-op semantically)
+
+        rm = new RoleMeta().setSelfRenew(Boolean.TRUE);
+        zmsImpl.putRoleMeta(ctx, domainName, roleName, auditRef, null, rm);
+
+        // PATCH mins=0 while stored selfRenew=true -> reject
+
+        rm = new RoleMeta().setSelfRenewMins(0);
+        try {
+            zmsImpl.putRoleMeta(ctx, domainName, roleName, auditRef, null, rm);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+
+        // PATCH unrelated meta (description) does not touch self-renew fields -> always accepted
+
+        rm = new RoleMeta().setDescription("just a description");
+        zmsImpl.putRoleMeta(ctx, domainName, roleName, auditRef, null, rm);
+
+        // PATCH that disables selfRenew first, then mins=0 -> both accepted
+
+        rm = new RoleMeta().setSelfRenew(Boolean.FALSE);
+        zmsImpl.putRoleMeta(ctx, domainName, roleName, auditRef, null, rm);
+
+        rm = new RoleMeta().setSelfRenewMins(0);
+        zmsImpl.putRoleMeta(ctx, domainName, roleName, auditRef, null, rm);
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
+    }
+
+    @Test
+    public void testPutGroupMetaSelfRenewMergeAware() {
+
+        final String domainName = "group-self-renew-meta";
+        final String groupName = "group1";
+
+        ZMSImpl zmsImpl = zmsTestInitializer.getZms();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        final String auditRef = zmsTestInitializer.getAuditRef();
+
+        TopLevelDomain dom1 = zmsTestInitializer.createTopLevelDomainObject(domainName,
+                "Test Domain", "testOrg", "user.user1");
+        zmsImpl.postTopLevelDomain(ctx, auditRef, null, dom1);
+
+        List<GroupMember> members = new ArrayList<>();
+        members.add(new GroupMember().setMemberName("user.jack"));
+        Group group = zmsTestInitializer.createGroupObject(domainName, groupName, members);
+        zmsImpl.putGroup(ctx, domainName, groupName, auditRef, false, null, group);
+
+        // PATCH selfRenew=true while stored selfRenewMins is null -> reject
+
+        GroupMeta gm = new GroupMeta().setSelfRenew(Boolean.TRUE);
+        try {
+            zmsImpl.putGroupMeta(ctx, domainName, groupName, auditRef, null, gm);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+            assertTrue(ex.getMessage().contains("Group cannot enable self-renew without a positive selfRenewMins value"));
+        }
+
+        // PATCH a valid pair together -> accepted
+
+        gm = new GroupMeta().setSelfRenew(Boolean.TRUE).setSelfRenewMins(10);
+        zmsImpl.putGroupMeta(ctx, domainName, groupName, auditRef, null, gm);
+
+        // PATCH selfRenew=true alone now that stored mins is valid -> accepted
+
+        gm = new GroupMeta().setSelfRenew(Boolean.TRUE);
+        zmsImpl.putGroupMeta(ctx, domainName, groupName, auditRef, null, gm);
+
+        // PATCH mins=0 while stored selfRenew=true -> reject
+
+        gm = new GroupMeta().setSelfRenewMins(0);
+        try {
+            zmsImpl.putGroupMeta(ctx, domainName, groupName, auditRef, null, gm);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 400);
+        }
+
+        // PATCH that disables selfRenew first, then mins=0 -> both accepted
+
+        gm = new GroupMeta().setSelfRenew(Boolean.FALSE);
+        zmsImpl.putGroupMeta(ctx, domainName, groupName, auditRef, null, gm);
+
+        gm = new GroupMeta().setSelfRenewMins(0);
+        zmsImpl.putGroupMeta(ctx, domainName, groupName, auditRef, null, gm);
+
+        zmsImpl.deleteTopLevelDomain(ctx, domainName, auditRef, null);
+    }
 }


### PR DESCRIPTION
# Description
  reject self-renew without positive selfRenewMins in ZMS

  Enabling selfRenew on a role/group while leaving selfRenewMins null or 0
  silently produced an unusable configuration: isRoleSelfRenewAllowed /
  isGroupSelfRenewAllowed required both fields, so members hit 403 when
  trying to renew.

  Adds a cross-field validation that rejects the broken combination at the
  API boundary, mirroring the existing validateRoleMetaAuditEnabledFlag
  pattern:

  - validateRoleValues / validateGroupValues: inline check on the full PUT
    path.
  - validateRoleMetaSelfRenewFlag / validateGroupMetaSelfRenewFlag: new
    merge-aware validators called from putRoleMeta / putGroupMeta after
    the DB fetch. Validate only when the meta touches one of the self-
    renew fields, so existing inconsistent rows can still receive
    unrelated meta updates.

# Contribution Checklist:
- [ ] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

