### PR TITLE
jag token integration changes with okta tests

### DIFF
--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -174,6 +174,18 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # server will automatically replace the value with this one
 #athenz.zts.id_token_max_timeout=43200
 
+# Specifies the maximum expiry timeout that a client can ask for when
+# requesting an token based on ID-JAG exchange request and the principal
+# is a user. If the client asks for a longer timeout, the server will
+# automatically replace the value with this one
+#athenz.zts.jag_token_user_max_timeout=3600
+
+# Specifies the maximum expiry timeout that a client can ask for when
+# requesting an token based on ID-JAG exchange request and the principal
+# is a service. If the client asks for a longer timeout, the server will
+# automatically replace the value with this one
+#athenz.zts.jag_token_service_max_timeout=21600
+
 # Specifies the expiry timeout for signed policy documents that
 # ZTS Server signs and returns to ZPU clients
 #athenz.zts.signed_policy_timeout=604800

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSConsts.java
@@ -108,6 +108,9 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_USER_CERT_SIGNER_KEY_ID_LIST = "athenz.zts.user_cert_signer_key_id_list";
     public static final String ZTS_PROP_USER_IDENTITY_TIMEOUT_REFRESH_INTERVAL = "athenz.zts.user_identity_timeout_refresh_interval";
 
+    public static final String ZTS_PROP_JAG_TOKEN_USER_MAX_TIMEOUT    = "athenz.zts.jag_token_user_max_timeout";
+    public static final String ZTS_PROP_JAG_TOKEN_SERVICE_MAX_TIMEOUT = "athenz.zts.jag_token_service_max_timeout";
+
     public static final String ZTS_PROP_SELF_SIGNER_PRIVATE_KEY_FNAME    = "athenz.zts.self_signer_private_key_fname";
     public static final String ZTS_PROP_SELF_SIGNER_PRIVATE_KEY_PASSWORD = "athenz.zts.self_signer_private_key_password";
     public static final String ZTS_PROP_SELF_SIGNER_CERT_DN              = "athenz.zts.self_signer_cert_dn";
@@ -116,13 +119,13 @@ public final class ZTSConsts {
     public static final String ZTS_PROP_CERT_REQUEST_VERIFY_SUBJECT_OU   = "athenz.zts.cert_request_verify_subject_ou";
     public static final String ZTS_PROP_CERT_REQUEST_TOKEN_TYPE_JWT      = "athenz.zts.cert_request_token_type_jwt";
 
-    public static final String ZTS_PROP_CERT_DNS_SUFFIX                         = "athenz.zts.cert_dns_suffix";
-    public static final String ZTS_PROP_CERT_FILE_STORE_PATH                    = "athenz.zts.cert_file_store_path";
-    public static final String ZTS_PROP_CERT_FILE_STORE_NAME                    = "athenz.zts.cert_file_store_name";
+    public static final String ZTS_PROP_CERT_DNS_SUFFIX      = "athenz.zts.cert_dns_suffix";
+    public static final String ZTS_PROP_CERT_FILE_STORE_PATH = "athenz.zts.cert_file_store_path";
+    public static final String ZTS_PROP_CERT_FILE_STORE_NAME = "athenz.zts.cert_file_store_name";
 
-    public static final String ZTS_PROP_SSH_FILE_STORE_PATH          = "athenz.zts.ssh_file_store_path";
-    public static final String ZTS_PROP_SSH_FILE_STORE_NAME          = "athenz.zts.ssh_file_store_name";
-    public static final String ZTS_PROP_SSH_CERT_VALIDATE_IP         = "athenz.zts.ssh_cert_validate_ip";
+    public static final String ZTS_PROP_SSH_FILE_STORE_PATH  = "athenz.zts.ssh_file_store_path";
+    public static final String ZTS_PROP_SSH_FILE_STORE_NAME  = "athenz.zts.ssh_file_store_name";
+    public static final String ZTS_PROP_SSH_CERT_VALIDATE_IP = "athenz.zts.ssh_cert_validate_ip";
 
     public static final String ZTS_PROP_WORKLOAD_JDBC_STORE               = "athenz.zts.workload_jdbc_store";
     public static final String ZTS_PROP_WORKLOAD_JDBC_USER                = "athenz.zts.workload_jdbc_user";

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -140,6 +140,8 @@ public class ZTSImpl implements ZTSHandler {
     protected int roleTokenMaxTimeout;
     protected int idTokenMaxTimeout;
     protected int idTokenDefaultTimeout;
+    protected int jagTokenUserMaxTimeout;
+    protected int jagTokenServiceMaxTimeout;
     protected DynamicConfigLong x509CertRefreshResetTime;
     protected long signedPolicyTimeout;
     protected static String serverHostName = null;
@@ -670,6 +672,14 @@ public class ZTSImpl implements ZTSHandler {
         timeout = TimeUnit.SECONDS.convert(1, TimeUnit.HOURS);
         idTokenDefaultTimeout = Integer.parseInt(
                 System.getProperty(ZTSConsts.ZTS_PROP_ID_TOKEN_DEFAULT_TIMEOUT, Long.toString(timeout)));
+
+        timeout = TimeUnit.SECONDS.convert(1, TimeUnit.HOURS);
+        jagTokenUserMaxTimeout = Integer.parseInt(
+                System.getProperty(ZTSConsts.ZTS_PROP_JAG_TOKEN_USER_MAX_TIMEOUT, Long.toString(timeout)));
+
+        timeout = TimeUnit.SECONDS.convert(6, TimeUnit.HOURS);
+        jagTokenServiceMaxTimeout = Integer.parseInt(
+                System.getProperty(ZTSConsts.ZTS_PROP_JAG_TOKEN_SERVICE_MAX_TIMEOUT, Long.toString(timeout)));
 
         // signedPolicyTimeout is in milliseconds but the config setting should be in seconds
         // to be consistent with other configuration properties
@@ -2204,7 +2214,7 @@ public class ZTSImpl implements ZTSHandler {
 
         IdToken idToken = new IdToken();
         idToken.setVersion(1);
-        idToken.setAudience(getIdTokenAudience(clientId, roleInAudClaim, idTokenGroups));
+        idToken.setAudience(getOauth2TokenAudience(clientId, roleInAudClaim, idTokenGroups));
         idToken.setSubject(principalName);
         idToken.setIssuer(issuerResolver.getIDTokenIssuer(ctx.request(), null));
         idToken.setNonce(nonce);
@@ -2250,7 +2260,7 @@ public class ZTSImpl implements ZTSHandler {
         }
     }
 
-    String getIdTokenAudience(final String clientId, Boolean includeGroup, List<String> idTokenGroups) {
+    String getOauth2TokenAudience(final String clientId, Boolean includeGroup, List<String> idTokenGroups) {
         return (includeGroup == Boolean.TRUE && idTokenGroups != null && idTokenGroups.size() == 1) ?
                 clientId + ":" + idTokenGroups.get(0) : clientId;
     }
@@ -3321,7 +3331,8 @@ public class ZTSImpl implements ZTSHandler {
 
             final String clientId = dataStore.getServiceClientId(clientPrincipalDomain, clientPrincipalName);
             if (clientId == null || !clientId.equals(jagToken.getClientId())) {
-                LOGGER.error("Invalid jag assertion client_id claim: {}", jagToken.getClientId());
+                LOGGER.error("Invalid jag assertion client_id claim: {}, clientPrincipalDomain {}, clientPrincipalName {}, clientId {}",
+                    jagToken.getClientId(), clientPrincipalDomain, clientPrincipalName, clientId);
                 throw requestError("Invalid jag assertion client_id", caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN, clientPrincipalDomain);
             }
         }
@@ -3372,7 +3383,8 @@ public class ZTSImpl implements ZTSHandler {
         }
 
         if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("processAccessTokenJAGRequest(principal: {}, assertionScope: {}, requestedScope: {}, scope: {})", principalName, jagToken.getScopeStd(), requestedScope, scopeStd);
+            LOGGER.debug("processAccessTokenJAGRequest(principal: {}, assertionScope: {}, requestedScope: {}, scope: {})",
+                principalName, jagToken.getScopeStd(), requestedScope, scopeStd);
         }
 
         // our scopes are space separated list of values
@@ -3405,7 +3417,8 @@ public class ZTSImpl implements ZTSHandler {
         // process our request and retrieve the roles for the principal
 
         Set<String> roles = new HashSet<>();
-        dataStore.getAccessibleRoles(data, domainName, principalName, requestedRoles, false, roles, false);
+        dataStore.getAccessibleRoles(data, domainName, principalName, requestedRoles, false,
+            roles, accessTokenRequest.isFullArn());
 
         // we return failure if we don't have access to any roles
 
@@ -3414,31 +3427,48 @@ public class ZTSImpl implements ZTSHandler {
                     caller, domainName, principalDomain);
         }
 
-        // we're going to issue a token valid only up to the expiry time
-        // of the jag token. However, if the jag token expiry time is too
-        // far in the future we'll limit the access token timeout to our
-        // configured max expiry time
+        // jag tokens are typically issued for a very short period
+        // so we can't base our expiry on the jag token expiry
+        // instead, we need to decide how long to issue an token for
 
-        int tokenTimeout = determineTokenTimeout(data, roles, null, ZTSUtils.getRemainingExpiryTime(jagToken.getExpiryTime()));
+        int tokenTimeout = determineTokenTimeout(data, roles, null,
+            userDomain.equals(principalDomain) ? jagTokenUserMaxTimeout : jagTokenServiceMaxTimeout);
         long iat = System.currentTimeMillis() / 1000;
+
+        // if the client has specified an audience, we'll honor it only
+        // if the full arn is enabled, otherwise we'll just use the
+        // role's domainName as audience as required
+
+        List<String> roleList = new ArrayList<>(roles);
+        final String requestAudience = accessTokenRequest.getAudience();
+        String audience = !StringUtil.isBlank(requestAudience) && accessTokenRequest.isFullArn() ?
+            requestAudience : getOauth2TokenAudience(domainName, accessTokenRequest.isRoleInAudClaim(), roleList);
 
         AccessToken accessToken = new AccessToken();
         accessToken.setVersion(1);
         accessToken.setJwtId(UUID.randomUUID().toString());
-        accessToken.setAudience(domainName);
+        accessToken.setAudience(audience);
         accessToken.setClientId(clientPrincipalName);
         accessToken.setIssueTime(iat);
         accessToken.setAuthTime(iat);
         accessToken.setExpiryTime(iat + tokenTimeout);
         accessToken.setUserId(principalName);
         accessToken.setSubject(principalName);
-        accessToken.setIssuer(jagAudience);
-        accessToken.setScope(new ArrayList<>(roles));
+        accessToken.setIssuer(issuerResolver.getAccessTokenIssuer(ctx.request(), accessTokenRequest.isUseOpenIDIssuer()));
+        accessToken.setScope(roleList);
         accessToken.setPrincipalIssuer(principal.getIssuerIdentity());
 
         if (identityProvider != null && identityProvider.getTokenExchangeClaims() != null) {
             for (String claim : identityProvider.getTokenExchangeClaims()) {
-                accessToken.setCustomClaim(claim, jagToken.getClaim(claim));
+
+                // if we're asked for the group claim, we're going to copy
+                // our scp attribute as groups
+
+                if (IdToken.CLAIM_GROUPS.equals(claim)) {
+                    accessToken.setCustomClaim(claim, accessToken.getScope());
+                } else {
+                    accessToken.setCustomClaim(claim, jagToken.getClaim(claim));
+                }
             }
         }
 

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2214,7 +2214,7 @@ public class ZTSImpl implements ZTSHandler {
 
         IdToken idToken = new IdToken();
         idToken.setVersion(1);
-        idToken.setAudience(getOauth2TokenAudience(clientId, roleInAudClaim, idTokenGroups));
+        idToken.setAudience(getIdTokenAudience(clientId, roleInAudClaim, idTokenGroups));
         idToken.setSubject(principalName);
         idToken.setIssuer(issuerResolver.getIDTokenIssuer(ctx.request(), null));
         idToken.setNonce(nonce);
@@ -2260,7 +2260,7 @@ public class ZTSImpl implements ZTSHandler {
         }
     }
 
-    String getOauth2TokenAudience(final String clientId, Boolean includeGroup, List<String> idTokenGroups) {
+    String getIdTokenAudience(final String clientId, Boolean includeGroup, List<String> idTokenGroups) {
         return (includeGroup == Boolean.TRUE && idTokenGroups != null && idTokenGroups.size() == 1) ?
                 clientId + ":" + idTokenGroups.get(0) : clientId;
     }
@@ -3441,8 +3441,20 @@ public class ZTSImpl implements ZTSHandler {
 
         List<String> roleList = new ArrayList<>(roles);
         final String requestAudience = accessTokenRequest.getAudience();
-        String audience = !StringUtil.isBlank(requestAudience) && accessTokenRequest.isFullArn() ?
-            requestAudience : getOauth2TokenAudience(domainName, accessTokenRequest.isRoleInAudClaim(), roleList);
+        String audience;
+
+        // if we're asked to include role name in the audience claim then
+        // first we should have the full arn requested as well and
+        // our audience value must be a service identity
+
+        if (accessTokenRequest.isRoleInAudClaim() && accessTokenRequest.isFullArn() && roleList.size() == 1) {
+            validate(requestAudience, TYPE_SERVICE_NAME, principalDomain, caller);
+            audience = requestAudience + ":" + roleList.get(0);
+        } else if (accessTokenRequest.isFullArn()) {
+            audience = requestAudience;
+        } else {
+            audience = domainName;
+        }
 
         AccessToken accessToken = new AccessToken();
         accessToken.setVersion(1);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/token/AccessTokenRequest.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/token/AccessTokenRequest.java
@@ -69,6 +69,8 @@ public class AccessTokenRequest {
     private static final String KEY_ACTOR = "actor";
     private static final String KEY_ACTOR_TOKEN = "actor_token";
     private static final String KEY_ACTOR_TOKEN_TYPE = "actor_token_type";
+    private static final String KEY_FULL_ARN = "full_arn";
+    private static final String KEY_ROLE_IN_AUD_CLAIM = "role_in_aud_claim";
 
     private static final String OAUTH_ASSERTION_TYPE_JWT_BEARER = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
@@ -95,6 +97,8 @@ public class AccessTokenRequest {
     Principal principal = null;
     int expiryTime = 0;
     boolean useOpenIDIssuer = false;
+    boolean fullArn = false;
+    boolean roleInAudClaim = false;
     RequestType requestType;
     OAuth2Token actorTokenObj = null;
     OAuth2Token subjectTokenObj = null;
@@ -143,6 +147,12 @@ public class AccessTokenRequest {
                     break;
                 case KEY_OPENID_ISSUER:
                     useOpenIDIssuer = Boolean.parseBoolean(value);
+                    break;
+                case KEY_FULL_ARN:
+                    fullArn = Boolean.parseBoolean(value);
+                    break;
+                case KEY_ROLE_IN_AUD_CLAIM:
+                    roleInAudClaim = Boolean.parseBoolean(value);
                     break;
                 case KEY_CLIENT_ASSERTION_TYPE:
                     clientAssertionType = value.toLowerCase();
@@ -537,6 +547,14 @@ public class AccessTokenRequest {
 
     public boolean isUseOpenIDIssuer() {
         return useOpenIDIssuer;
+    }
+
+    public boolean isFullArn() {
+        return fullArn;
+    }
+
+    public boolean isRoleInAudClaim() {
+        return roleInAudClaim;
     }
 
     public Principal getPrincipal() {

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/token/AccessTokenRequest.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/token/AccessTokenRequest.java
@@ -290,13 +290,13 @@ public class AccessTokenRequest {
         // service and we have no other way of identifying what access the client
         // is looking for, we'll make the scope mandatory.
 
-        if (StringUtil.isEmpty(scope)) {
+        if (StringUtil.isBlank(scope)) {
             throw new IllegalArgumentException("Invalid request: no scope provided");
         }
 
         // we must have audience specified
 
-        if (StringUtil.isEmpty(audience)) {
+        if (StringUtil.isBlank(audience)) {
             throw new IllegalArgumentException("Invalid request: no audience provided");
         }
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -2337,7 +2337,7 @@ public class ZTSImplAccessTokenTest {
                 "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + jagToken
                         + "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
                         + "&client_assertion=" + createClientAssertionToken(privateKey)
-                        + "&role_in_aud_claim=true");
+                        + "&role_in_aud_claim=true&full_arn=true&audience=coretech.oidc");
 
         assertNotNull(resp);
         assertNotNull(resp.getAccess_token());
@@ -2350,7 +2350,7 @@ public class ZTSImplAccessTokenTest {
 
             JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
             // with role_in_aud_claim=true and a single accessible role, audience is domain:roleName
-            assertEquals(claimSet.getAudience().get(0), "coretech:writers");
+            assertEquals(claimSet.getAudience().get(0), "coretech.oidc:coretech:role.writers");
         } catch (ParseException ex) {
             fail(ex.getMessage());
         }

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -2095,7 +2095,6 @@ public class ZTSImplAccessTokenTest {
         System.clearProperty(ZTSConsts.ZTS_PROP_PROVIDER_CONFIG_FILE);
     }
 
-
     @Test
     public void testProcessJAGTokenExchangeRequestSuccessWithOpenIDIssuer() throws JOSEException {
 
@@ -2128,7 +2127,8 @@ public class ZTSImplAccessTokenTest {
         AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
                 "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + jagToken
                 + "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
-                + "&client_assertion=" + createClientAssertionToken(privateKey));
+                + "&client_assertion=" + createClientAssertionToken(privateKey)
+                + "&openid_issuer=true");
 
         assertNotNull(resp);
         assertNotNull(resp.getAccess_token());
@@ -2148,6 +2148,290 @@ public class ZTSImplAccessTokenTest {
 
         System.clearProperty(ZTSConsts.ZTS_PROP_OPENID_ISSUER);
         System.clearProperty(ZTSConsts.ZTS_PROP_OAUTH_ISSUER);
+    }
+
+    @Test
+    public void testProcessJAGTokenExchangeRequestSuccessGroupsClaim() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        TokenExchangeIdentityProvider provider = new TokenExchangeIdentityProvider() {
+            @Override
+            public String getTokenIdentity(OAuth2Token token) {
+                return "user_domain.user";
+            }
+
+            @Override
+            public String getTokenAudience(OAuth2Token token) {
+                return token.getAudience();
+            }
+
+            @Override
+            public List<String> getTokenExchangeClaims() {
+                return List.of("groups");
+            }
+        };
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        ztsImpl.providerConfigManager.putProvider("coretech.jwt", provider);
+        ztsImpl.tokenConfigOptions.setJwtJAGProcessor(createJAGProcessor());
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        File privateKeyFile = new File("src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(privateKeyFile);
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        String jagToken = createJagToken(privateKey, "0", "user_domain.user", "coretech.jwt",
+                "coretech:domain", ztsImpl.ztsOAuthIssuer, expiryTime);
+
+        Principal principal = SimplePrincipal.create("coretech", "jwt",
+                "v=U1;d=coretech;n=jwt;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + jagToken
+                        + "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                        + "&client_assertion=" + createClientAssertionToken(privateKey));
+
+        assertNotNull(resp);
+        assertNotNull(resp.getAccess_token());
+
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(resp.getAccess_token());
+            assertTrue(signedJWT.verify(verifier));
+
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+            // groups claim must equal the scope (scp) list, not a claim from the jagToken
+            List<String> groups = claimSet.getStringListClaim("groups");
+            assertNotNull(groups);
+            assertFalse(groups.isEmpty());
+            assertEquals(groups, claimSet.getStringListClaim("scp"));
+        } catch (ParseException ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testProcessJAGTokenExchangeRequestSuccessFullArnAudience() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        ztsImpl.tokenConfigOptions.setJwtJAGProcessor(createJAGProcessor());
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        File privateKeyFile = new File("src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(privateKeyFile);
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        String jagToken = createJagToken(privateKey, "0", "user_domain.user", "coretech.jwt",
+                "coretech:domain", ztsImpl.ztsOAuthIssuer, expiryTime);
+
+        Principal principal = SimplePrincipal.create("coretech", "jwt",
+                "v=U1;d=coretech;n=jwt;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        final String customAudience = "https://my-service.athenz.io";
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + jagToken
+                        + "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                        + "&client_assertion=" + createClientAssertionToken(privateKey)
+                        + "&full_arn=true&audience=" + customAudience);
+
+        assertNotNull(resp);
+        assertNotNull(resp.getAccess_token());
+
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(resp.getAccess_token());
+            assertTrue(signedJWT.verify(verifier));
+
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+            // with full_arn=true, the custom audience from the request must be used
+            assertEquals(claimSet.getAudience().get(0), customAudience);
+        } catch (ParseException ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testProcessJAGTokenExchangeRequestAudienceIgnoredWithoutFullArn() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        ztsImpl.tokenConfigOptions.setJwtJAGProcessor(createJAGProcessor());
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        File privateKeyFile = new File("src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(privateKeyFile);
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        String jagToken = createJagToken(privateKey, "0", "user_domain.user", "coretech.jwt",
+                "coretech:domain", ztsImpl.ztsOAuthIssuer, expiryTime);
+
+        Principal principal = SimplePrincipal.create("coretech", "jwt",
+                "v=U1;d=coretech;n=jwt;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + jagToken
+                        + "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                        + "&client_assertion=" + createClientAssertionToken(privateKey)
+                        + "&audience=https://my-service.athenz.io");
+
+        assertNotNull(resp);
+        assertNotNull(resp.getAccess_token());
+
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(resp.getAccess_token());
+            assertTrue(signedJWT.verify(verifier));
+
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+            // without full_arn, the custom audience is ignored and the domain name is used
+            assertEquals(claimSet.getAudience().get(0), "coretech");
+        } catch (ParseException ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testProcessJAGTokenExchangeRequestRoleInAudClaim() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        ztsImpl.tokenConfigOptions.setJwtJAGProcessor(createJAGProcessor());
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        File privateKeyFile = new File("src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(privateKeyFile);
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        // scope restricted to a single role so role_in_aud_claim produces domain:role
+        String jagToken = createJagToken(privateKey, "0", "user_domain.user", "coretech.jwt",
+                "coretech:role.writers", ztsImpl.ztsOAuthIssuer, expiryTime);
+
+        Principal principal = SimplePrincipal.create("coretech", "jwt",
+                "v=U1;d=coretech;n=jwt;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + jagToken
+                        + "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                        + "&client_assertion=" + createClientAssertionToken(privateKey)
+                        + "&role_in_aud_claim=true");
+
+        assertNotNull(resp);
+        assertNotNull(resp.getAccess_token());
+
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(resp.getAccess_token());
+            assertTrue(signedJWT.verify(verifier));
+
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+            // with role_in_aud_claim=true and a single accessible role, audience is domain:roleName
+            assertEquals(claimSet.getAudience().get(0), "coretech:writers");
+        } catch (ParseException ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testProcessJAGTokenExchangeRequestUserDomainTimeout() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+        System.setProperty(PROP_USER_DOMAIN, "user_domain");
+        System.setProperty(ZTSConsts.ZTS_PROP_JAG_TOKEN_USER_MAX_TIMEOUT, "500");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        ztsImpl.tokenConfigOptions.setJwtJAGProcessor(createJAGProcessor());
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        File privateKeyFile = new File("src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(privateKeyFile);
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        // principal domain "user_domain" matches userDomain so user max timeout applies
+        String jagToken = createJagToken(privateKey, "0", "user_domain.user", "coretech.jwt",
+                "coretech:domain", ztsImpl.ztsOAuthIssuer, expiryTime);
+
+        Principal principal = SimplePrincipal.create("coretech", "jwt",
+                "v=U1;d=coretech;n=jwt;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + jagToken
+                        + "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                        + "&client_assertion=" + createClientAssertionToken(privateKey));
+
+        assertNotNull(resp);
+        assertNotNull(resp.getAccess_token());
+        assertTrue(resp.getExpires_in() > 0);
+        assertTrue(resp.getExpires_in() <= 500);
+
+        System.clearProperty(PROP_USER_DOMAIN);
+        System.clearProperty(ZTSConsts.ZTS_PROP_JAG_TOKEN_USER_MAX_TIMEOUT);
+    }
+
+    @Test
+    public void testProcessJAGTokenExchangeRequestServiceDomainTimeout() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+        System.setProperty(ZTSConsts.ZTS_PROP_JAG_TOKEN_SERVICE_MAX_TIMEOUT, "600");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        ztsImpl.tokenConfigOptions.setJwtJAGProcessor(createJAGProcessor());
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        File privateKeyFile = new File("src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(privateKeyFile);
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        // principalDomain "user_domain" != userDomain "user" so service max timeout applies
+        String jagToken = createJagToken(privateKey, "0", "user_domain.user", "coretech.jwt",
+                "coretech:domain", ztsImpl.ztsOAuthIssuer, expiryTime);
+
+        Principal principal = SimplePrincipal.create("coretech", "jwt",
+                "v=U1;d=coretech;n=jwt;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" + jagToken
+                        + "&client_assertion_type=urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+                        + "&client_assertion=" + createClientAssertionToken(privateKey));
+
+        assertNotNull(resp);
+        assertNotNull(resp.getAccess_token());
+        assertTrue(resp.getExpires_in() > 0);
+        assertTrue(resp.getExpires_in() <= 600);
+
+        System.clearProperty(ZTSConsts.ZTS_PROP_JAG_TOKEN_SERVICE_MAX_TIMEOUT);
     }
 
     @DataProvider(name = "jagTokenExchangeCases")

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -13828,25 +13828,25 @@ public class ZTSImplTest {
     }
 
     @Test
-    public void testGetIdTokenAudience() {
-        assertEquals(zts.getIdTokenAudience("id", null, null), "id");
-        assertEquals(zts.getIdTokenAudience("id", Boolean.FALSE, null), "id");
-        assertEquals(zts.getIdTokenAudience("id", Boolean.TRUE, null), "id");
+    public void testGetOauth2TokenAudience() {
+        assertEquals(zts.getOauth2TokenAudience("id", null, null), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", Boolean.FALSE, null), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", Boolean.TRUE, null), "id");
 
         List<String> idTokenGroups = new ArrayList<>();
-        assertEquals(zts.getIdTokenAudience("id", null, idTokenGroups), "id");
-        assertEquals(zts.getIdTokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
-        assertEquals(zts.getIdTokenAudience("id", Boolean.TRUE, idTokenGroups), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", null, idTokenGroups), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", Boolean.TRUE, idTokenGroups), "id");
 
         idTokenGroups.add("athenz:role.oidc");
-        assertEquals(zts.getIdTokenAudience("id", null, idTokenGroups), "id");
-        assertEquals(zts.getIdTokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
-        assertEquals(zts.getIdTokenAudience("id", Boolean.TRUE, idTokenGroups), "id:athenz:role.oidc");
+        assertEquals(zts.getOauth2TokenAudience("id", null, idTokenGroups), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", Boolean.TRUE, idTokenGroups), "id:athenz:role.oidc");
 
         idTokenGroups.add("athenz:role.oidc2");
-        assertEquals(zts.getIdTokenAudience("id", null, idTokenGroups), "id");
-        assertEquals(zts.getIdTokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
-        assertEquals(zts.getIdTokenAudience("id", Boolean.TRUE, idTokenGroups), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", null, idTokenGroups), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
+        assertEquals(zts.getOauth2TokenAudience("id", Boolean.TRUE, idTokenGroups), "id");
     }
 
     private ServerPrivateKey getServerPrivateKey(ZTSImpl ztsImpl, final String keyType) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -13828,25 +13828,25 @@ public class ZTSImplTest {
     }
 
     @Test
-    public void testGetOauth2TokenAudience() {
-        assertEquals(zts.getOauth2TokenAudience("id", null, null), "id");
-        assertEquals(zts.getOauth2TokenAudience("id", Boolean.FALSE, null), "id");
-        assertEquals(zts.getOauth2TokenAudience("id", Boolean.TRUE, null), "id");
+    public void testGetIdTokenAudience() {
+        assertEquals(zts.getIdTokenAudience("id", null, null), "id");
+        assertEquals(zts.getIdTokenAudience("id", Boolean.FALSE, null), "id");
+        assertEquals(zts.getIdTokenAudience("id", Boolean.TRUE, null), "id");
 
         List<String> idTokenGroups = new ArrayList<>();
-        assertEquals(zts.getOauth2TokenAudience("id", null, idTokenGroups), "id");
-        assertEquals(zts.getOauth2TokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
-        assertEquals(zts.getOauth2TokenAudience("id", Boolean.TRUE, idTokenGroups), "id");
+        assertEquals(zts.getIdTokenAudience("id", null, idTokenGroups), "id");
+        assertEquals(zts.getIdTokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
+        assertEquals(zts.getIdTokenAudience("id", Boolean.TRUE, idTokenGroups), "id");
 
         idTokenGroups.add("athenz:role.oidc");
-        assertEquals(zts.getOauth2TokenAudience("id", null, idTokenGroups), "id");
-        assertEquals(zts.getOauth2TokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
-        assertEquals(zts.getOauth2TokenAudience("id", Boolean.TRUE, idTokenGroups), "id:athenz:role.oidc");
+        assertEquals(zts.getIdTokenAudience("id", null, idTokenGroups), "id");
+        assertEquals(zts.getIdTokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
+        assertEquals(zts.getIdTokenAudience("id", Boolean.TRUE, idTokenGroups), "id:athenz:role.oidc");
 
         idTokenGroups.add("athenz:role.oidc2");
-        assertEquals(zts.getOauth2TokenAudience("id", null, idTokenGroups), "id");
-        assertEquals(zts.getOauth2TokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
-        assertEquals(zts.getOauth2TokenAudience("id", Boolean.TRUE, idTokenGroups), "id");
+        assertEquals(zts.getIdTokenAudience("id", null, idTokenGroups), "id");
+        assertEquals(zts.getIdTokenAudience("id", Boolean.FALSE, idTokenGroups), "id");
+        assertEquals(zts.getIdTokenAudience("id", Boolean.TRUE, idTokenGroups), "id");
     }
 
     private ServerPrivateKey getServerPrivateKey(ZTSImpl ztsImpl, final String keyType) {

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/token/AccessTokenRequestTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/token/AccessTokenRequestTest.java
@@ -68,8 +68,8 @@ public class AccessTokenRequestTest {
     public void testAccessTokenRequest() {
 
         AccessTokenRequest request = new AccessTokenRequest("grant_type=client_credentials&scope=coretech:role.writers"
-                + "&authorization_details=details&expires_in=100&proxy_principal_spiffe_uris=&actor=athenz.api",
-                defaultConfigOptions);
+                + "&authorization_details=details&expires_in=100&proxy_principal_spiffe_uris=&actor=athenz.api"
+                + "&role_in_aud_claim=true&full_arn=true", defaultConfigOptions);
         assertNotNull(request);
         assertEquals(request.getGrantType(), "client_credentials");
         assertEquals(request.getScope(), "coretech:role.writers");
@@ -77,6 +77,8 @@ public class AccessTokenRequestTest {
         assertEquals(request.getExpiryTime(), 100);
         assertNull(request.getProxyPrincipalsSpiffeUris());
         assertEquals(request.getActor(), "athenz.api");
+        assertTrue(request.isFullArn());
+        assertTrue(request.isRoleInAudClaim());
     }
 
     @Test


### PR DESCRIPTION
# Description

carried out some integration tests with jag tokens issued by okta and requesting access tokens from ZTS. As part of the integration tests, the following changes were implemented.

a) jag token issued by okta always includes the audience as the issuer for the authorization server so we can't just use that value as the issuer in our tokens - it seems like okta issued the token which is not the case. the code is now follows its standard method to generate the issuer for the token so any receiver can fetch the public keys to validate the token

b) okta issues jag tokens valid for 5 minutes so the original idea of relying on jag token expiry means ZTS will always issue tokens value for 5 minutes. This is not going to work, so the logic is now changed where we have 2 new settings - athenz.zts.jag_token_user_max_timeout and athenz.zts.jag_token_service_max_timeout defining the timeout for users and services accordingly.

c) expose full-arn and role-name-in-audience-claim options when requesting tokens based on jag tokens

d) if we're required for the external identity provider support to include the groups claim, then the value will be the same as scp value generated by ZTS. It's wrong to just copy the value from the jag token since we'll be exposing more values that the access token is issued for.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

