### PR TITLE
Feat: Support Delegation Claims`may_act` in AT=>AT Delegated Token Exchange (RFC 8693)

### DIFF
--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2904,10 +2904,23 @@ public class ZTSImpl implements ZTSHandler {
         // if we have requested authenticated by another principal other than
         // the actor token principal then we'll just do a quick check here
         // to make sure the principals match
-
-        if (!principal.getFullName().equals(actorToken.getSubject())) {
+        
+        final String clientPrincipalName = principal.getFullName();
+        if (!clientPrincipalName.equals(actorToken.getSubject())) {
             throw forbiddenError("Request principal does not match actor token principal",
                     caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN, principalDomain);
+        }
+
+        // Optional actor parameter means: issue this delegated AT with may_act
+        // so that the next actor can perform another delegated token exchange.
+        final String actor = accessTokenRequest.getActor();
+        if (actor != null) {
+            validate(actor, TYPE_SERVICE_NAME, principalDomain, caller);
+
+            if (principal.getX509Certificate() == null) {
+                throw forbiddenError("Actor parameter requires X.509 authenticated principal",
+                        caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN, principalDomain);
+            }
         }
 
         // in the delegation request the subject token is issued with a specific
@@ -2988,6 +3001,14 @@ public class ZTSImpl implements ZTSHandler {
         accessToken.setIssuer(issuerResolver.getAccessTokenIssuer(ctx.request(), accessTokenRequest.isUseOpenIDIssuer()));
         accessToken.setScope(new ArrayList<>(roles));
         accessToken.setPrincipalIssuer(principal.getIssuerIdentity());
+
+        if (actor != null) {
+            // may_act: The service principal that will be delegated the authority
+            accessToken.setMayActEntry(AccessToken.CLAIM_SUBJECT, actor);
+
+            // act: current authenticated client acting on behalf of the subject
+            accessToken.setActEntry(AccessToken.CLAIM_SUBJECT, clientPrincipalName);
+        }
 
         final String spiffeId = extractSpiffeIdFromToken(subjectToken);
         if (spiffeId != null) {

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2915,11 +2915,6 @@ public class ZTSImpl implements ZTSHandler {
         final String actor = accessTokenRequest.getActor();
         if (actor != null) {
             validate(actor, TYPE_SERVICE_NAME, principalDomain, caller);
-
-            if (principal.getX509Certificate() == null) {
-                throw forbiddenError("Actor parameter requires X.509 authenticated principal",
-                        caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN, principalDomain);
-            }
         }
 
         // in the delegation request the subject token is issued with a specific

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2904,9 +2904,8 @@ public class ZTSImpl implements ZTSHandler {
         // if we have requested authenticated by another principal other than
         // the actor token principal then we'll just do a quick check here
         // to make sure the principals match
-        
-        final String clientPrincipalName = principal.getFullName();
-        if (!clientPrincipalName.equals(actorToken.getSubject())) {
+
+        if (!principal.getFullName().equals(actorToken.getSubject())) {
             throw forbiddenError("Request principal does not match actor token principal",
                     caller, ZTSConsts.ZTS_UNKNOWN_DOMAIN, principalDomain);
         }
@@ -3005,9 +3004,6 @@ public class ZTSImpl implements ZTSHandler {
         if (actor != null) {
             // may_act: The service principal that will be delegated the authority
             accessToken.setMayActEntry(AccessToken.CLAIM_SUBJECT, actor);
-
-            // act: current authenticated client acting on behalf of the subject
-            accessToken.setActEntry(AccessToken.CLAIM_SUBJECT, clientPrincipalName);
         }
 
         final String spiffeId = extractSpiffeIdFromToken(subjectToken);

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -4750,6 +4750,9 @@ public class ZTSImplAccessTokenTest {
             assertNotNull(scopes);
             assertEquals(scopes.size(), 1);
             assertEquals(scopes.get(0), "writers");
+
+            // not expecting `may_act` claim with "actor" not defined:
+            assertNull(claimSet.getJSONObjectClaim("may_act"));
         } catch (Exception ex) {
             fail(ex.getMessage());
         }
@@ -5099,8 +5102,179 @@ public class ZTSImplAccessTokenTest {
             assertNotNull(subActMap);
             assertEquals(subActMap.get("sub"), "athenz.actor");
 
+            // not expecting `may_act` claim with "actor" not defined:
+            assertNull(claimSet.getJSONObjectClaim("may_act"));
+
         } catch (Exception ex) {
             fail(ex.getMessage());
+        }
+
+        cloudStore.close();
+    }
+
+    @Test
+    public void testProcessAccessTokenExchangeDelegationRequestWithMayActSuccess() throws JOSEException {
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        // Create source domain
+        SignedDomain sourceDomain = createSignedDomain("sourcedomain", "weather", "storage", true);
+        store.processSignedDomain(sourceDomain, false);
+
+        // Create target domain
+        SignedDomain targetDomain = createSignedDomain("targetdomain", "weather", "storage", true);
+        store.processSignedDomain(targetDomain, false);
+
+        // Add token target exchange policy
+        addTokenTargetExchangePolicy("targetdomain", "sourcedomain", "user_domain.proxy-user1", "writers");
+
+        // Load EC private key for creating tokens
+        final File ecPrivateKey = new File("./src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        KeyStore keyStore = getServerPublicKeyProvider(privateKey);
+
+        // Create subject token (AccessToken) with roles in source domain
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        List<String> subjectRoles = List.of("writers");
+        String subjectTokenStr = createAccessToken(privateKey, "0", "user_domain.user",
+                "sourcedomain", subjectRoles, "user_domain.proxy-user1", null, expiryTime);
+
+        // Create actor token (OAuth2Token)
+        String actorTokenStr = createActorToken(privateKey, "0", "user_domain.proxy-user1",
+                "targetdomain", expiryTime);
+
+        // Create principal for proxy-user1 who will request the token exchange
+        Principal principal = SimplePrincipal.create("user_domain", "proxy-user1",
+                "v=U1;d=user_domain;n=proxy-user1;s=signature", 0, null);
+        assertNotNull(principal);
+        
+        // Delegation with next actor requires mTLS (X.509) principal.
+        java.security.cert.X509Certificate mockCert = org.mockito.Mockito.mock(java.security.cert.X509Certificate.class);
+        ((com.yahoo.athenz.auth.impl.SimplePrincipal) principal).setX509Certificate(mockCert);
+        
+        ResourceContext context = createResourceContext(principal);
+        TokenConfigOptions tokenConfigOptions = createTokenConfigOptions(ztsImpl);
+        tokenConfigOptions.setOauth2Issuers(Set.of("https://athenz.io:4443/zts/v1"));
+        tokenConfigOptions.setPublicKeyProvider(keyStore);
+        ztsImpl.tokenConfigOptions = tokenConfigOptions;
+
+        // Add actor=athenz.next-actor to request may_act
+        final String requestBody = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
+                        + "&requested_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&subject_token=" + subjectTokenStr
+                        + "&subject_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&actor_token=" + actorTokenStr
+                        + "&actor_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&audience=targetdomain"
+                        + "&scope=targetdomain:role.writers"
+                        + "&actor=athenz.next-actor"; // next actor specified
+
+        AccessTokenResponse response = ztsImpl.postAccessTokenRequest(context, requestBody);
+
+        assertNotNull(response);
+        assertNotNull(response.getAccess_token());
+        assertEquals(response.getToken_type(), "Bearer");
+        assertTrue(response.getExpires_in() > 0);
+        assertEquals(response.getScope(), "targetdomain:role.writers");
+
+        // Verify the access token
+        String accessTokenStr = response.getAccess_token();
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(accessTokenStr);
+            assertTrue(signedJWT.verify(verifier));
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+
+            assertNotNull(claimSet);
+            assertNotNull(claimSet.getJWTID());
+            assertEquals(claimSet.getSubject(), "user_domain.user");
+            assertEquals(claimSet.getAudience().get(0), "targetdomain");
+            assertEquals(claimSet.getIssuer(), ztsImpl.ztsOAuthIssuer);
+
+            List<String> scopes = claimSet.getStringListClaim("scp");
+            assertNotNull(scopes);
+            assertEquals(scopes.size(), 1);
+            assertEquals(scopes.get(0), "writers");
+
+            // Verify act claim is constructed
+            Map actMap = (Map) claimSet.getClaim("act");
+            assertNotNull(actMap);
+            assertEquals(actMap.get("sub"), "user_domain.proxy-user1");
+
+            // Verify may_act claim is constructed correctly
+            Map mayActMap = (Map) claimSet.getClaim("may_act");
+            assertNotNull(mayActMap);
+            assertEquals(mayActMap.get("sub"), "athenz.next-actor");
+
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+
+        cloudStore.close();
+    }
+
+    @Test
+    public void testProcessAccessTokenExchangeDelegationRequestWithMayActMissingX509() throws JOSEException {
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain sourceDomain = createSignedDomain("sourcedomain", "weather", "storage", true);
+        store.processSignedDomain(sourceDomain, false);
+
+        SignedDomain targetDomain = createSignedDomain("targetdomain", "weather", "storage", true);
+        store.processSignedDomain(targetDomain, false);
+
+        addTokenTargetExchangePolicy("targetdomain", "sourcedomain", "user_domain.proxy-user1", "writers");
+
+        final File ecPrivateKey = new File("./src/test/resources/unit_test_zts_private_ec.pem");
+        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
+        KeyStore keyStore = getServerPublicKeyProvider(privateKey);
+
+        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
+        List<String> subjectRoles = List.of("writers");
+        String subjectTokenStr = createAccessToken(privateKey, "0", "user_domain.user",
+                "sourcedomain", subjectRoles, "user_domain.proxy-user1", null, expiryTime);
+
+        String actorTokenStr = createActorToken(privateKey, "0", "user_domain.proxy-user1",
+                "targetdomain", expiryTime);
+
+        // Correct actor principal, but NOT X.509 authenticated
+        Principal principal = SimplePrincipal.create("user_domain", "proxy-user1",
+                "v=U1;d=user_domain;n=proxy-user1;s=signature", 0, null);
+        assertNotNull(principal);
+        
+        ResourceContext context = createResourceContext(principal);
+        TokenConfigOptions tokenConfigOptions = createTokenConfigOptions(ztsImpl);
+        tokenConfigOptions.setOauth2Issuers(Set.of("https://athenz.io:4443/zts/v1"));
+        tokenConfigOptions.setPublicKeyProvider(keyStore);
+        ztsImpl.tokenConfigOptions = tokenConfigOptions;
+
+        final String requestBody = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
+                        + "&requested_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&subject_token=" + subjectTokenStr
+                        + "&subject_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&actor_token=" + actorTokenStr
+                        + "&actor_token_type=urn:ietf:params:oauth:token-type:access_token"
+                        + "&audience=targetdomain"
+                        + "&scope=targetdomain:role.writers"
+                        + "&actor=athenz.next-actor";
+
+        try {
+            ztsImpl.postAccessTokenRequest(context, requestBody);
+            fail("Expected ResourceException(403) to be thrown");
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), 403);
+            assertTrue(ex.getMessage().contains("Actor parameter requires X.509 authenticated principal"));
         }
 
         cloudStore.close();

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -5220,67 +5220,6 @@ public class ZTSImplAccessTokenTest {
     }
 
     @Test
-    public void testProcessAccessTokenExchangeDelegationRequestWithMayActMissingX509() throws JOSEException {
-        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
-
-        CloudStore cloudStore = new CloudStore();
-        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
-
-        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
-
-        SignedDomain sourceDomain = createSignedDomain("sourcedomain", "weather", "storage", true);
-        store.processSignedDomain(sourceDomain, false);
-
-        SignedDomain targetDomain = createSignedDomain("targetdomain", "weather", "storage", true);
-        store.processSignedDomain(targetDomain, false);
-
-        addTokenTargetExchangePolicy("targetdomain", "sourcedomain", "user_domain.proxy-user1", "writers");
-
-        final File ecPrivateKey = new File("./src/test/resources/unit_test_zts_private_ec.pem");
-        PrivateKey privateKey = Crypto.loadPrivateKey(ecPrivateKey);
-        KeyStore keyStore = getServerPublicKeyProvider(privateKey);
-
-        long expiryTime = System.currentTimeMillis() / 1000 + 3600;
-        List<String> subjectRoles = List.of("writers");
-        String subjectTokenStr = createAccessToken(privateKey, "0", "user_domain.user",
-                "sourcedomain", subjectRoles, "user_domain.proxy-user1", null, expiryTime);
-
-        String actorTokenStr = createActorToken(privateKey, "0", "user_domain.proxy-user1",
-                "targetdomain", expiryTime);
-
-        // Correct actor principal, but NOT X.509 authenticated
-        Principal principal = SimplePrincipal.create("user_domain", "proxy-user1",
-                "v=U1;d=user_domain;n=proxy-user1;s=signature", 0, null);
-        assertNotNull(principal);
-        
-        ResourceContext context = createResourceContext(principal);
-        TokenConfigOptions tokenConfigOptions = createTokenConfigOptions(ztsImpl);
-        tokenConfigOptions.setOauth2Issuers(Set.of("https://athenz.io:4443/zts/v1"));
-        tokenConfigOptions.setPublicKeyProvider(keyStore);
-        ztsImpl.tokenConfigOptions = tokenConfigOptions;
-
-        final String requestBody = "grant_type=urn:ietf:params:oauth:grant-type:token-exchange"
-                        + "&requested_token_type=urn:ietf:params:oauth:token-type:access_token"
-                        + "&subject_token=" + subjectTokenStr
-                        + "&subject_token_type=urn:ietf:params:oauth:token-type:access_token"
-                        + "&actor_token=" + actorTokenStr
-                        + "&actor_token_type=urn:ietf:params:oauth:token-type:access_token"
-                        + "&audience=targetdomain"
-                        + "&scope=targetdomain:role.writers"
-                        + "&actor=athenz.next-actor";
-
-        try {
-            ztsImpl.postAccessTokenRequest(context, requestBody);
-            fail("Expected ResourceException(403) to be thrown");
-        } catch (ResourceException ex) {
-            assertEquals(ex.getCode(), 403);
-            assertTrue(ex.getMessage().contains("Actor parameter requires X.509 authenticated principal"));
-        }
-
-        cloudStore.close();
-    }
-
-    @Test
     public void testProcessAccessTokenDelegationRequestPrincipalMismatch() {
         System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
 


### PR DESCRIPTION
# Background

Athenz currently supports Delegated Token Exchange. To perform a delegation, the subject token is required to have a `may_act` claim; otherwise, it throws the following error:

```sh
# Invalid subject token: missing may_act claim
```

This behavior itself is fine. According to the `RFC 8693` specification, while enforcing this is not strictly required by development standards, performing this check is entirely valid as the following:

```
... may_act claim in the subject token can be used by the 
authorization server to determine whether the client (or party identified in the actor_token)
is authorized to engage in the requested delegation or impersonation.
```

*[4.4. ](https://datatracker.ietf.org/doc/html/rfc8693#section-4.4)["may_act" (Authorized Actor) Claim](https://datatracker.ietf.org/doc/html/rfc8693#name-may_act-authorized-actor-cl)*

When issuing an Access Token (AT) authenticated by an X.509 certificate, we can pass the actor parameter. Consequently, an AT issued this way can be used to perform a delegated token exchange.

```sh
_role_scope="api:role.docs-getter api:role.mcp-accessor"
_mcp_actor="api.api-mcp"
_cert_path="./keys/idjag-learner.crt"
_key_path="./keys/idjag-learner.key"
_ca_cert="./athenz_dist/certs/ca.cert.pem"
_zts_url="https://localhost:8443/zts/v1/oauth2/token"

_at=$(curl -sS -X POST "$_zts_url" \
  --cert "$_cert_path" \
  --key "$_key_path" \
  --cacert "$_ca_cert" \
  -H "Content-Type: application/x-www-form-urlencoded" \
  --data-urlencode "grant_type=client_credentials" \
  --data-urlencode "scope=$_role_scope" \
  --data-urlencode "actor=$_mcp_actor" \
  --data-urlencode "expires_in=3600" | jq -r .access_token)

echo $_at | jq -R 'split(".") | .[1] | @base64d | fromjson'

# {
#   "sub": "human.idjag-learner",
#   "may_act": {
#     "sub": "api.api-mcp"
#   },
#   ...
# }
```

However, while the initial delegation succeeds, any subsequent delegated exchange fails. This happens because there is currently no implementation to attach the may_act claim to the resulting token in this specific path.

```sh
# {
#   "sub": "human.idjag-learner",
#   "act": {
#     "sub": "api.api-mcp"
#   },
#   ...
# }
```

# What's done?

Enables attaching the `may_act` claim during the AT => AT Delegated Exchange path

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Related Issue

https://github.com/AthenZ/athenz/issues/3100