### PR TITLE
Migrate athenzutils and zmscli from gopkg.in/yaml.v3 to go.yaml.in/yaml/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/proto/otlp v1.10.0
+	go.yaml.in/yaml/v3 v3.0.4
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
@@ -45,7 +46,6 @@ require (
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5
@@ -103,7 +103,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.67.0 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
-	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.45.0 // indirect
@@ -117,6 +116,7 @@ require (
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.35.4 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20250910181357-589584f1c912 // indirect

--- a/libs/go/athenzutils/config.go
+++ b/libs/go/athenzutils/config.go
@@ -6,7 +6,7 @@ package athenzutils
 import (
 	"fmt"
 	"github.com/AthenZ/athenz/libs/go/sia/util"
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 	"os"
 	"path/filepath"
 )

--- a/libs/go/zmscli/domain.go
+++ b/libs/go/zmscli/domain.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"gopkg.in/yaml.v3"
+	"go.yaml.in/yaml/v3"
 
 	"github.com/AthenZ/athenz/clients/go/zms"
 )


### PR DESCRIPTION
# Description

The original go-yaml repository (`gopkg.in/yaml.v3`) has been archived and is no longer maintained. `go.yaml.in/yaml/v3` is its community-maintained successor — the module Kubernetes (and others) have migrated to. AthenZ already depends on `go.yaml.in/yaml/v3` (v3.0.4) transitively, so this PR migrates the two remaining direct importers of the archived module onto it:

- `libs/go/athenzutils/config.go`
- `libs/go/zmscli/domain.go`

Both changes are **pure import-path swaps**. The package name (`yaml`) and the API used (`yaml.Unmarshal`, `yaml:"..."` struct tags) are identical between the two modules, so there is **no behavioural change**.

`go.mod` is updated to promote `go.yaml.in/yaml/v3` to a direct dependency and demote `gopkg.in/yaml.v3` to indirect; `go.sum` is unchanged (both modules were already present in the graph). After this change, `gopkg.in/yaml.v3` is no longer in the package import closure of `athenzutils` or `zmscli` — it remains only as an indirect, **test-time** transitive dependency (via `github.com/stretchr/testify`'s `assert/yaml`).

This also helps downstream modules that depend on `athenzutils` (e.g. through `zmssvctoken`) drop the archived `gopkg.in/yaml.v3` from their own dependency graphs.

### Verification
- `go build ./libs/go/athenzutils/... ./libs/go/zmscli/...`
- `go vet ./libs/go/athenzutils/... ./libs/go/zmscli/...`
- `go test ./libs/go/athenzutils/... ./libs/go/zmscli/...`

All pass.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.** — omitted: this is a minimal, no-behaviour-change dependency-hygiene swap; happy to file a tracking issue if maintainers prefer.
