### PR TITLE
Fix: UI no longer returns an error for the valid external identity during the group member add

### DIFF
--- a/ui/src/__tests__/components/constants/constants.test.js
+++ b/ui/src/__tests__/components/constants/constants.test.js
@@ -13,9 +13,51 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { StaticWorkloadType } from '../../../components/constants/constants';
+import {
+    GROUP_MEMBER_NAME_REGEX,
+    StaticWorkloadType,
+} from '../../../components/constants/constants';
 import IPTestUtils from '../../../tests_utils/IPTestUtils';
 import { forEach } from 'async';
+import RegexUtils from '../../../components/utils/RegexUtils';
+
+describe('Group member name regex', () => {
+    it('allows compound and external member names', () => {
+        expect(
+            RegexUtils.validate('user.jane', GROUP_MEMBER_NAME_REGEX)
+        ).toBeTruthy();
+        expect(
+            RegexUtils.validate('weather.storage', GROUP_MEMBER_NAME_REGEX)
+        ).toBeTruthy();
+        expect(
+            RegexUtils.validate(
+                'email:ext.idjag-learner@athenz.io',
+                GROUP_MEMBER_NAME_REGEX
+            )
+        ).toBeTruthy();
+        expect(
+            RegexUtils.validate(
+                'partner.identity:ext.alice@example.com',
+                GROUP_MEMBER_NAME_REGEX
+            )
+        ).toBeTruthy();
+    });
+
+    it('rejects invalid group member names', () => {
+        expect(
+            RegexUtils.validate('home.test:group.test', GROUP_MEMBER_NAME_REGEX)
+        ).toBeFalsy();
+        expect(
+            RegexUtils.validate('user.test1.', GROUP_MEMBER_NAME_REGEX)
+        ).toBeFalsy();
+        expect(
+            RegexUtils.validate(
+                'email:external.user@example.com',
+                GROUP_MEMBER_NAME_REGEX
+            )
+        ).toBeFalsy();
+    });
+});
 
 describe('StaticWorkloadType', () => {
     it('StaticWorkloadType should match the regex pattern based on types', () => {

--- a/ui/src/__tests__/components/constants/constants.test.js
+++ b/ui/src/__tests__/components/constants/constants.test.js
@@ -41,14 +41,24 @@ describe('Group member name regex', () => {
                 GROUP_MEMBER_NAME_REGEX
             )
         ).toBeTruthy();
+        expect(
+            RegexUtils.validate(
+                'athenz:ext.oidc/group/my-group',
+                GROUP_MEMBER_NAME_REGEX
+            )
+        ).toBeTruthy();
     });
 
     it('rejects invalid group member names', () => {
+        expect(RegexUtils.validate('*', GROUP_MEMBER_NAME_REGEX)).toBeFalsy();
         expect(
             RegexUtils.validate('home.test:group.test', GROUP_MEMBER_NAME_REGEX)
         ).toBeFalsy();
         expect(
             RegexUtils.validate('user.test1.', GROUP_MEMBER_NAME_REGEX)
+        ).toBeFalsy();
+        expect(
+            RegexUtils.validate('athenz:ext.', GROUP_MEMBER_NAME_REGEX)
         ).toBeFalsy();
         expect(
             RegexUtils.validate(

--- a/ui/src/components/constants/constants.js
+++ b/ui/src/components/constants/constants.js
@@ -25,8 +25,7 @@ export const EXTERNAL_MEMBER_NAME_REGEX =
     '([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*:ext\\..+';
 // Keep the external pattern first because RegexUtils.validate compares the
 // first regex match to the full input, and GROUP_NAME_REGEX matches the prefix.
-export const GROUP_MEMBER_NAME_REGEX =
-    `${EXTERNAL_MEMBER_NAME_REGEX}|${GROUP_NAME_REGEX}`;
+export const GROUP_MEMBER_NAME_REGEX = `${EXTERNAL_MEMBER_NAME_REGEX}|${GROUP_NAME_REGEX}`;
 export const MICROSEGMENTATION_SERVICE_NAME_REGEX =
     '\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*';
 export const POLICY_ENFORCEMENT_REGEX =

--- a/ui/src/components/constants/constants.js
+++ b/ui/src/components/constants/constants.js
@@ -21,8 +21,10 @@ import {
 export const MODAL_TIME_OUT = 2000;
 export const GROUP_NAME_REGEX =
     '([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*';
+export const EXTERNAL_MEMBER_NAME_REGEX =
+    '([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*:ext\\..+';
 export const GROUP_MEMBER_NAME_REGEX =
-    '([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*';
+    `${GROUP_NAME_REGEX}|${EXTERNAL_MEMBER_NAME_REGEX}`;
 export const MICROSEGMENTATION_SERVICE_NAME_REGEX =
     '\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*';
 export const POLICY_ENFORCEMENT_REGEX =

--- a/ui/src/components/constants/constants.js
+++ b/ui/src/components/constants/constants.js
@@ -23,8 +23,10 @@ export const GROUP_NAME_REGEX =
     '([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*';
 export const EXTERNAL_MEMBER_NAME_REGEX =
     '([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*:ext\\..+';
+// Keep the external pattern first because RegexUtils.validate compares the
+// first regex match to the full input, and GROUP_NAME_REGEX matches the prefix.
 export const GROUP_MEMBER_NAME_REGEX =
-    `${GROUP_NAME_REGEX}|${EXTERNAL_MEMBER_NAME_REGEX}`;
+    `${EXTERNAL_MEMBER_NAME_REGEX}|${GROUP_NAME_REGEX}`;
 export const MICROSEGMENTATION_SERVICE_NAME_REGEX =
     '\\*|([a-zA-Z0-9_][a-zA-Z0-9_-]*\\.)*[a-zA-Z0-9_][a-zA-Z0-9_-]*';
 export const POLICY_ENFORCEMENT_REGEX =


### PR DESCRIPTION
# Description

UI Does not accept the external identity naming format:

<img width="2557" height="1133" alt="image" src="https://github.com/user-attachments/assets/c97a63b7-28c2-48bd-b845-6391663481da" />

When I can add the member with direct API access:

```sh
domain="api"
group_name="external-partners"
member_name="email:ext.idjag-learner@athenz.io"

curl -i -s -k -X PUT "https://localhost:4443/zms/v1/domain/${domain}/group/${group_name}/member/${member_name}" \
    --cert ./athenz_dist/certs/athenz_admin.cert.pem \
    --key ./athenz_dist/keys/athenz_admin.private.pem \
    -H "Content-Type: application/json" \
    -H "Y-Audit-Ref: local group member test" \
    -d '{
      "memberName": "'"${member_name}"'",
      "groupName": "'"${group_name}"'",
      "isMember": true
    }'
```

✅ 204: 

```sh
# HTTP/1.1 204 No Content
# Strict-Transport-Security: max-age=31536000; includeSubDomains
# Host: athenz-zms-server-8469448966-5lrc4
```

## What's done?

Add `EXTERNAL_MEMBER_NAME_REGEX` for both group and role

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**


