### PR TITLE
Use ON DUPLICATE KEY UPDATE for X.509 cert record insert to avoid spurious errors in DB audit logs

### DIFF
--- a/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreConnection.java
+++ b/libs/java/server_common/src/main/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreConnection.java
@@ -30,8 +30,6 @@ public class JDBCCertRecordStoreConnection implements CertRecordStoreConnection 
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JDBCCertRecordStoreConnection.class);
 
-    private static final int MYSQL_ER_OPTION_DUPLICATE_ENTRY = 1062;
-
     public static final String ZTS_PROP_NOTIFICATION_GRACE_PERIOD_HOURS = "athenz.zts.notification_cert_fail_grace_hours";
 
     // Default grace period - 2 weeks (336 hours)
@@ -42,7 +40,12 @@ public class JDBCCertRecordStoreConnection implements CertRecordStoreConnection 
     private static final String SQL_INSERT_X509_RECORD = "INSERT INTO certificates " +
             "(provider, instanceId, service, currentSerial, currentTime, currentIP, prevSerial, prevTime, prevIP, clientCert, " +
             "expiryTime, hostName, siaProvider) " +
-            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?);";
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?) " +
+            "ON DUPLICATE KEY UPDATE " +
+            "currentSerial=VALUES(currentSerial), currentTime=VALUES(currentTime), currentIP=VALUES(currentIP), " +
+            "prevSerial=VALUES(prevSerial), prevTime=VALUES(prevTime), prevIP=VALUES(prevIP), " +
+            "clientCert=VALUES(clientCert), expiryTime=VALUES(expiryTime), hostName=VALUES(hostName), " +
+            "siaProvider=VALUES(siaProvider);";
     private static final String SQL_UPDATE_X509_RECORD = "UPDATE certificates SET " +
             "currentSerial=?, currentTime=?, currentIP=?, prevSerial=?, prevTime=?, prevIP=?, " +
             "expiryTime=?, hostName=?, clientCert=?, siaProvider=? " +
@@ -242,20 +245,8 @@ public class JDBCCertRecordStoreConnection implements CertRecordStoreConnection 
             ps.setString(13, certRecord.getSiaProvider());
 
             affectedRows = executeUpdate(ps, caller);
-            
+
         } catch (SQLException ex) {
-            
-            // if the record already exists, we're going to reset
-            // the state and convert this into an update operation
-            
-            if (ex.getErrorCode() == MYSQL_ER_OPTION_DUPLICATE_ENTRY) {
-                if (LOGGER.isDebugEnabled()) {
-                    LOGGER.debug("{}: Resetting state for instance {} - {}",
-                            caller, certRecord.getProvider(), certRecord.getInstanceId());
-                }
-                return updateX509CertRecord(certRecord);
-            }
-            
             throw sqlError(ex, caller);
         }
         return (affectedRows > 0);

--- a/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreConnectionTest.java
+++ b/libs/java/server_common/src/test/java/com/yahoo/athenz/common/server/cert/impl/JDBCCertRecordStoreConnectionTest.java
@@ -185,7 +185,7 @@ public class JDBCCertRecordStoreConnectionTest {
 
     @Test
     public void testInsertX509RecordAlreadyExists() throws Exception {
-        
+
         JDBCCertRecordStoreConnection jdbcConn = new JDBCCertRecordStoreConnection(mockConn);
 
         Date now = new Date();
@@ -195,18 +195,20 @@ public class JDBCCertRecordStoreConnectionTest {
         certRecord.setExpiryTime(now);
         certRecord.setHostName("hostname");
 
-        Mockito.doThrow(new SQLException("entry already exits", "state", 1062))
-            .doReturn(1).when(mockPrepStmt).executeUpdate();
-        
+        // With ON DUPLICATE KEY UPDATE, MySQL returns 2 affected rows when an existing
+        // row is updated via the UPSERT path. The statement is executed only once.
+        Mockito.doReturn(2).when(mockPrepStmt).executeUpdate();
+
         boolean requestSuccess = jdbcConn.insertX509CertRecord(certRecord);
         assertTrue(requestSuccess);
-        
-        // we should have all operation done once for insert and one for update
+
+        // single UPSERT execution - all insert parameters bound once
 
         Mockito.verify(mockPrepStmt, times(1)).setString(1, "ostk");
         Mockito.verify(mockPrepStmt, times(1)).setString(2, "instance-id");
         Mockito.verify(mockPrepStmt, times(1)).setString(3, "cn");
         Mockito.verify(mockPrepStmt, times(1)).setString(4, "current-serial");
+        Mockito.verify(mockPrepStmt, times(1)).setTimestamp(5, new java.sql.Timestamp(now.getTime()));
         Mockito.verify(mockPrepStmt, times(1)).setString(6, "current-ip");
         Mockito.verify(mockPrepStmt, times(1)).setString(7, "prev-serial");
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(8, new java.sql.Timestamp(now.getTime()));
@@ -215,22 +217,6 @@ public class JDBCCertRecordStoreConnectionTest {
         Mockito.verify(mockPrepStmt, times(1)).setTimestamp(11, new java.sql.Timestamp(now.getTime()));
         Mockito.verify(mockPrepStmt, times(1)).setString(12, "hostname");
 
-        Mockito.verify(mockPrepStmt, times(1)).setString(1, "current-serial");
-        Mockito.verify(mockPrepStmt, times(1)).setTimestamp(2, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(3, "current-ip");
-        Mockito.verify(mockPrepStmt, times(1)).setString(4, "prev-serial");
-        Mockito.verify(mockPrepStmt, times(1)).setString(6, "prev-ip");
-        Mockito.verify(mockPrepStmt, times(1)).setTimestamp(7, new java.sql.Timestamp(now.getTime()));
-        Mockito.verify(mockPrepStmt, times(1)).setString(8, "hostname");
-        Mockito.verify(mockPrepStmt, times(1)).setBoolean(9, false);
-        Mockito.verify(mockPrepStmt, times(1)).setString(10, null);
-        Mockito.verify(mockPrepStmt, times(1)).setString(11, "ostk");
-        Mockito.verify(mockPrepStmt, times(1)).setString(12, "instance-id");
-        Mockito.verify(mockPrepStmt, times(1)).setString(13, "cn");
-
-        // common between insert/update so count is 2 times
-        Mockito.verify(mockPrepStmt, times(2)).setTimestamp(5, new java.sql.Timestamp(now.getTime()));
-        
         jdbcConn.close();
     }
 


### PR DESCRIPTION
# Description
## Summary

Refactors `JDBCCertRecordStoreConnection#insertX509CertRecord` to use MySQL's `INSERT ... ON DUPLICATE KEY UPDATE` (UPSERT) instead of issuing an `INSERT`, catching the duplicate-key `SQLException` (error code `1062`), and then falling back to a separate `UPDATE`.

## Motivation

The existing implementation relies on catching a duplicate-key error as part of its normal control flow when a certificate record already exists (e.g. on re-registration of the same `provider` / `instanceId`).

The main problem with this approach is **observability on the database side**:

- Every duplicate-key case is recorded as a failed `INSERT` in the DB audit log / error log. From the audit log alone, there is no way to distinguish "expected, benign duplicate that the application recovers from" vs. "real insert failure that should be investigated".
- This makes it very difficult to alert on / triage genuine SQL errors on the `certificates` table, because the log is constantly polluted with error 1062 entries produced by normal traffic.
- It also inflates DB error metrics and complicates any audit-log-based monitoring or compliance review.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**


