### PR TITLE
Add opt-in local file cache for S3ChangeLogStore

### DIFF
--- a/kubernetes/charts/athenz-zts/files/conf/zts.properties
+++ b/kubernetes/charts/athenz-zts/files/conf/zts.properties
@@ -160,6 +160,10 @@ athenz.zms.client.keymanager_password=dummy
 # class (athenz.zts.change_log_store_factory_class property)
 athenz.zts.change_log_store_dir=/opt/athenz/zts/var
 
+# Specifies if S3ChangeLogStoreFactory should maintain a local file cache
+# of domain json documents and the last S3 modification timestamp
+#athenz.zts.s3_change_log_store_local_cache=false
+
 # Boolean setting to force users to request role tokens for specific
 # roles rather than for domain which will includes all the roles the
 # given principal has access in that domain

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStore.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStore.java
@@ -254,20 +254,15 @@ public class S3ChangeLogStore implements ChangeLogStore {
 
     SignedDomain getSignedDomainFromS3(String domainName) {
 
-        // make sure we have an aws s3 client for our request
-
-        if (awsS3Client == null) {
-            awsS3Client = getS3Client();
-        }
-
-        SignedDomain signedDomain = getSignedDomain(awsS3Client, domainName);
+        S3Client s3Client = getAwsS3Client();
+        SignedDomain signedDomain = getSignedDomain(s3Client, domainName);
 
         // if we got a failure for any reason, we're going
         // get a new aws s3 client and try again
 
         if (signedDomain == null) {
-            awsS3Client = getS3Client();
-            signedDomain = getSignedDomain(awsS3Client, domainName);
+            s3Client = refreshAwsS3Client(s3Client);
+            signedDomain = getSignedDomain(s3Client, domainName);
         }
 
         return signedDomain;
@@ -275,23 +270,49 @@ public class S3ChangeLogStore implements ChangeLogStore {
 
     JWSDomain getJWSDomainFromS3(String domainName) {
 
-        // make sure we have an aws s3 client for our request
-
-        if (awsS3Client == null) {
-            awsS3Client = getS3Client();
-        }
-
-        JWSDomain jwsDomain = getJWSDomain(awsS3Client, domainName);
+        S3Client s3Client = getAwsS3Client();
+        JWSDomain jwsDomain = getJWSDomain(s3Client, domainName);
 
         // if we got a failure for any reason, we're going
         // get a new aws s3 client and try again
 
         if (jwsDomain == null) {
-            awsS3Client = getS3Client();
-            jwsDomain = getJWSDomain(awsS3Client, domainName);
+            s3Client = refreshAwsS3Client(s3Client);
+            jwsDomain = getJWSDomain(s3Client, domainName);
         }
 
         return jwsDomain;
+    }
+
+    S3Client getAwsS3Client() {
+        synchronized (this) {
+            if (awsS3Client == null) {
+                awsS3Client = getS3Client();
+            }
+            return awsS3Client;
+        }
+    }
+
+    S3Client refreshAwsS3Client(S3Client currentClient) {
+        synchronized (this) {
+            if (awsS3Client == currentClient) {
+                closeS3Client(awsS3Client);
+                awsS3Client = null;
+                awsS3Client = getS3Client();
+            }
+            return awsS3Client;
+        }
+    }
+
+    void closeS3Client(S3Client s3Client) {
+        if (s3Client == null) {
+            return;
+        }
+        try {
+            s3Client.close();
+        } catch (Exception ex) {
+            LOGGER.warn("S3ChangeLogStore: unable to close S3 client", ex);
+        }
     }
 
     SignedDomain getSignedDomain(S3Client s3, String domainName) {
@@ -495,51 +516,47 @@ public class S3ChangeLogStore implements ChangeLogStore {
             return true;
         }
 
-        S3Client s3;
-        Set<String> serverDomains;
-        try {
-            s3 = getS3Client();
+        try (S3Client s3Client = getS3Client()) {
             HashSet<String> domains = new HashSet<>();
-            listObjects(s3, domains, 0);
-            serverDomains = domains;
+            listObjects(s3Client, domains, 0);
+
+            Set<String> localDomainSet = new HashSet<>(localDomains);
+            boolean fetchedAllMissingDomains = true;
+            int fetchedDomains = 0;
+            for (String domainName : domains) {
+                if (localDomainSet.contains(domainName)) {
+                    continue;
+                }
+
+                if (jwsDomainSupport) {
+                    JWSDomain jwsDomain = getJWSDomain(s3Client, domainName);
+                    if (jwsDomain == null) {
+                        fetchedAllMissingDomains = false;
+                        continue;
+                    }
+                    localChangeLogStore.saveLocalDomain(domainName, jwsDomain);
+                } else {
+                    SignedDomain signedDomain = getSignedDomain(s3Client, domainName);
+                    if (signedDomain == null) {
+                        fetchedAllMissingDomains = false;
+                        continue;
+                    }
+                    localChangeLogStore.saveLocalDomain(domainName, signedDomain);
+                }
+
+                localDomains.add(domainName);
+                localDomainSet.add(domainName);
+                fetchedDomains++;
+            }
+
+            if (fetchedDomains > 0) {
+                LOGGER.info("S3ChangeLogStore: fetched {} missing domain(s) into local cache", fetchedDomains);
+            }
+            return fetchedAllMissingDomains;
         } catch (Exception ex) {
             LOGGER.error("S3ChangeLogStore: unable to retrieve domain list from S3", ex);
             return false;
         }
-
-        Set<String> localDomainSet = new HashSet<>(localDomains);
-        boolean fetchedAllMissingDomains = true;
-        int fetchedDomains = 0;
-        for (String domainName : serverDomains) {
-            if (localDomainSet.contains(domainName)) {
-                continue;
-            }
-
-            if (jwsDomainSupport) {
-                JWSDomain jwsDomain = getJWSDomain(s3, domainName);
-                if (jwsDomain == null) {
-                    fetchedAllMissingDomains = false;
-                    continue;
-                }
-                localChangeLogStore.saveLocalDomain(domainName, jwsDomain);
-            } else {
-                SignedDomain signedDomain = getSignedDomain(s3, domainName);
-                if (signedDomain == null) {
-                    fetchedAllMissingDomains = false;
-                    continue;
-                }
-                localChangeLogStore.saveLocalDomain(domainName, signedDomain);
-            }
-
-            localDomains.add(domainName);
-            localDomainSet.add(domainName);
-            fetchedDomains++;
-        }
-
-        if (fetchedDomains > 0) {
-            LOGGER.info("S3ChangeLogStore: fetched {} missing domain(s) into local cache", fetchedDomains);
-        }
-        return fetchedAllMissingDomains;
     }
 
     @Override

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStore.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStore.java
@@ -619,9 +619,9 @@ public class S3ChangeLogStore implements ChangeLogStore {
         // been deleted, we're going to get a new s3 client
         // instead of using our original client
 
-        try {
+        try (S3Client s3Client = getS3Client()) {
             HashSet<String> domains = new HashSet<>();
-            listObjects(getS3Client(), domains, 0);
+            listObjects(s3Client, domains, 0);
             return domains;
         } catch (Exception ex) {
             LOGGER.error("S3ChangeLogStore: unable to retrieve domain list from S3", ex);

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStore.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStore.java
@@ -27,6 +27,8 @@ import software.amazon.awssdk.services.s3.model.*;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yahoo.athenz.common.server.store.ChangeLogStore;
+import com.yahoo.athenz.common.server.store.impl.ZMSFileChangeLogStoreCommon;
+import com.yahoo.athenz.zms.DomainAttributes;
 import com.yahoo.athenz.zms.JWSDomain;
 import com.yahoo.athenz.zms.SignedDomain;
 import com.yahoo.athenz.zms.SignedDomains;
@@ -35,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.TrustManagerFactory;
+import java.io.File;
 import java.net.URI;
 import java.security.KeyStore;
 import java.security.cert.X509Certificate;
@@ -52,6 +55,7 @@ public class S3ChangeLogStore implements ChangeLogStore {
 
     long lastModTime;
     S3Client awsS3Client = null;
+    ZMSFileChangeLogStoreCommon localChangeLogStore = null;
 
     private String s3BucketName;
     private String awsRegion;
@@ -64,22 +68,28 @@ public class S3ChangeLogStore implements ChangeLogStore {
     private static final String ZTS_PROP_AWS_S3_ENDPOINT = "athenz.zts.aws_s3_endpoint";
     private static final String ZTS_PROP_AWS_S3_CA_CERT = "athenz.zts.aws_s3_ca_cert";
     private static final String ZTS_PROP_S3_CHANGE_LOG_STORE_FILTER = "athenz.zts.s3_change_log_store_domain_filter";
+    static final String ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE = "athenz.zts.s3_change_log_store_local_cache";
     private final int nThreads = Integer.parseInt(System.getProperty(NUMBER_OF_THREADS, "10"));
     private final int defaultTimeoutSeconds = Integer.parseInt(System.getProperty(DEFAULT_TIMEOUT_SECONDS, "1800"));
     protected Map<String, SignedDomain> tempSignedDomainMap = new ConcurrentHashMap<>();
     protected Map<String, JWSDomain> tempJWSDomainMap = new ConcurrentHashMap<>();
 
     public S3ChangeLogStore() {
-        init();
+        init(null);
         initAwsRegion();
     }
 
     public S3ChangeLogStore(String awsRegion) {
-        init();
+        init(null);
         this.awsRegion = awsRegion;
     }
 
-    void init() {
+    S3ChangeLogStore(File rootDirectory) {
+        init(rootDirectory == null ? null : rootDirectory.getPath());
+        initAwsRegion();
+    }
+
+    void init(String rootDirectory) {
         s3BucketName = System.getProperty(ZTS_PROP_AWS_BUCKET_NAME);
         if (s3BucketName == null || s3BucketName.isEmpty()) {
             LOGGER.error("S3 Bucket name cannot be null");
@@ -121,6 +131,36 @@ public class S3ChangeLogStore implements ChangeLogStore {
                 domainFilter = null;
             }
         }
+
+        initLocalCache(rootDirectory);
+    }
+
+    void initLocalCache(String rootDirectory) {
+
+        if (!Boolean.parseBoolean(System.getProperty(ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "false"))) {
+            return;
+        }
+
+        if (StringUtil.isEmpty(rootDirectory)) {
+            LOGGER.error("S3 local cache root directory cannot be null");
+            throw new RuntimeException("S3ChangeLogStore: local cache root directory cannot be null");
+        }
+
+        localChangeLogStore = new ZMSFileChangeLogStoreCommon(rootDirectory);
+        if (localChangeLogStore.lastModTime == null) {
+            return;
+        }
+
+        try {
+            lastModTime = Long.parseLong(localChangeLogStore.lastModTime);
+        } catch (NumberFormatException ex) {
+            LOGGER.error("S3ChangeLogStore: invalid local cache lastModTime: {}", localChangeLogStore.lastModTime);
+            lastModTime = 0;
+        }
+    }
+
+    boolean isDomainAllowed(String domainName) {
+        return domainFilter == null || domainFilter.contains(domainName);
     }
 
     void initAwsRegion() {
@@ -147,6 +187,17 @@ public class S3ChangeLogStore implements ChangeLogStore {
             LOGGER.debug("getLocalSignedDomain: {}", domainName);
         }
 
+        if (localChangeLogStore != null) {
+            SignedDomain signedDomain = localChangeLogStore.getLocalSignedDomain(domainName);
+            if (signedDomain == null) {
+                signedDomain = getSignedDomainFromS3(domainName);
+                if (signedDomain != null) {
+                    localChangeLogStore.saveLocalDomain(domainName, signedDomain);
+                }
+            }
+            return signedDomain;
+        }
+
         // clear the mapping if present and value is stored else null is returned
 
         SignedDomain signedDomain = tempSignedDomainMap.remove(domainName);
@@ -160,21 +211,7 @@ public class S3ChangeLogStore implements ChangeLogStore {
                 LOGGER.info("getLocalSignedDomain: not present in cache, fetching from S3...");
             }
 
-            // make sure we have an aws s3 client for our request
-
-            if (awsS3Client == null) {
-                awsS3Client = getS3Client();
-            }
-
-            signedDomain = getSignedDomain(awsS3Client, domainName);
-
-            // if we got a failure for any reason, we're going
-            // get a new aws s3 client and try again
-
-            if (signedDomain == null) {
-                awsS3Client = getS3Client();
-                signedDomain = getSignedDomain(awsS3Client, domainName);
-            }
+            signedDomain = getSignedDomainFromS3(domainName);
         }
         return signedDomain;
     }
@@ -184,6 +221,17 @@ public class S3ChangeLogStore implements ChangeLogStore {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("getLocalJWSDomain: {}", domainName);
+        }
+
+        if (localChangeLogStore != null) {
+            JWSDomain jwsDomain = localChangeLogStore.getLocalJWSDomain(domainName);
+            if (jwsDomain == null) {
+                jwsDomain = getJWSDomainFromS3(domainName);
+                if (jwsDomain != null) {
+                    localChangeLogStore.saveLocalDomain(domainName, jwsDomain);
+                }
+            }
+            return jwsDomain;
         }
 
         // clear the mapping if present and value is stored else null is returned
@@ -199,22 +247,50 @@ public class S3ChangeLogStore implements ChangeLogStore {
                 LOGGER.info("getLocalJWSDomain: not present in cache, fetching from S3...");
             }
 
-            // make sure we have an aws s3 client for our request
-
-            if (awsS3Client == null) {
-                awsS3Client = getS3Client();
-            }
-
-            jwsDomain = getJWSDomain(awsS3Client, domainName);
-
-            // if we got a failure for any reason, we're going
-            // get a new aws s3 client and try again
-
-            if (jwsDomain == null) {
-                awsS3Client = getS3Client();
-                jwsDomain = getJWSDomain(awsS3Client, domainName);
-            }
+            jwsDomain = getJWSDomainFromS3(domainName);
         }
+        return jwsDomain;
+    }
+
+    SignedDomain getSignedDomainFromS3(String domainName) {
+
+        // make sure we have an aws s3 client for our request
+
+        if (awsS3Client == null) {
+            awsS3Client = getS3Client();
+        }
+
+        SignedDomain signedDomain = getSignedDomain(awsS3Client, domainName);
+
+        // if we got a failure for any reason, we're going
+        // get a new aws s3 client and try again
+
+        if (signedDomain == null) {
+            awsS3Client = getS3Client();
+            signedDomain = getSignedDomain(awsS3Client, domainName);
+        }
+
+        return signedDomain;
+    }
+
+    JWSDomain getJWSDomainFromS3(String domainName) {
+
+        // make sure we have an aws s3 client for our request
+
+        if (awsS3Client == null) {
+            awsS3Client = getS3Client();
+        }
+
+        JWSDomain jwsDomain = getJWSDomain(awsS3Client, domainName);
+
+        // if we got a failure for any reason, we're going
+        // get a new aws s3 client and try again
+
+        if (jwsDomain == null) {
+            awsS3Client = getS3Client();
+            jwsDomain = getJWSDomain(awsS3Client, domainName);
+        }
+
         return jwsDomain;
     }
 
@@ -260,19 +336,36 @@ public class S3ChangeLogStore implements ChangeLogStore {
     public void removeLocalDomain(String domainName) {
         // in AWS our Athenz syncer is responsible for pushing new
         // changes including removing deleted domain to S3 so this
-        // api is just a no-op
+        // api is just a no-op unless local file cache is enabled
+
+        if (localChangeLogStore == null) {
+            return;
+        }
+        localChangeLogStore.removeLocalDomain(domainName);
     }
 
     @Override
     public void saveLocalDomain(String domainName, SignedDomain signedDomain) {
         // in AWS our Athenz syncer is responsible for pushing new
-        // changes into S3 so this api is just a no-op
+        // changes into S3 so this api is just a no-op unless local
+        // file cache is enabled
+
+        if (localChangeLogStore == null) {
+            return;
+        }
+        localChangeLogStore.saveLocalDomain(domainName, signedDomain);
     }
 
     @Override
     public void saveLocalDomain(String domainName, JWSDomain jwsDomain) {
         // in AWS our Athenz syncer is responsible for pushing new
-        // changes into S3 so this api is just a no-op
+        // changes into S3 so this api is just a no-op unless local
+        // file cache is enabled
+
+        if (localChangeLogStore == null) {
+            return;
+        }
+        localChangeLogStore.saveLocalDomain(domainName, jwsDomain);
     }
 
     /**
@@ -352,6 +445,15 @@ public class S3ChangeLogStore implements ChangeLogStore {
     @Override
     public List<String> getLocalDomainList() {
 
+        if (localChangeLogStore != null) {
+            List<String> localDomains = localChangeLogStore.getLocalDomainList();
+            localDomains.removeIf(domain -> !isDomainAllowed(domain));
+            if (!fetchMissingLocalDomains(localDomains)) {
+                setLastModificationTimestamp(null);
+            }
+            return localDomains;
+        }
+
         // check to see if we need to maintain our last modification time.
         // this will be necessary if our last mod time field is null. We need
         // to save the timestamp at the beginning just in case we end up getting
@@ -382,6 +484,72 @@ public class S3ChangeLogStore implements ChangeLogStore {
         }
 
         return domains;
+    }
+
+    boolean fetchMissingLocalDomains(List<String> localDomains) {
+
+        // Without a last modification timestamp, startup will already fetch
+        // all domains from S3 through the regular update path.
+
+        if (localChangeLogStore.lastModTime == null) {
+            return true;
+        }
+
+        S3Client s3;
+        Set<String> serverDomains;
+        try {
+            s3 = getS3Client();
+            HashSet<String> domains = new HashSet<>();
+            listObjects(s3, domains, 0);
+            serverDomains = domains;
+        } catch (Exception ex) {
+            LOGGER.error("S3ChangeLogStore: unable to retrieve domain list from S3", ex);
+            return false;
+        }
+
+        Set<String> localDomainSet = new HashSet<>(localDomains);
+        boolean fetchedAllMissingDomains = true;
+        int fetchedDomains = 0;
+        for (String domainName : serverDomains) {
+            if (localDomainSet.contains(domainName)) {
+                continue;
+            }
+
+            if (jwsDomainSupport) {
+                JWSDomain jwsDomain = getJWSDomain(s3, domainName);
+                if (jwsDomain == null) {
+                    fetchedAllMissingDomains = false;
+                    continue;
+                }
+                localChangeLogStore.saveLocalDomain(domainName, jwsDomain);
+            } else {
+                SignedDomain signedDomain = getSignedDomain(s3, domainName);
+                if (signedDomain == null) {
+                    fetchedAllMissingDomains = false;
+                    continue;
+                }
+                localChangeLogStore.saveLocalDomain(domainName, signedDomain);
+            }
+
+            localDomains.add(domainName);
+            localDomainSet.add(domainName);
+            fetchedDomains++;
+        }
+
+        if (fetchedDomains > 0) {
+            LOGGER.info("S3ChangeLogStore: fetched {} missing domain(s) into local cache", fetchedDomains);
+        }
+        return fetchedAllMissingDomains;
+    }
+
+    @Override
+    public Map<String, DomainAttributes> getLocalDomainAttributeList() {
+        if (localChangeLogStore == null) {
+            return null;
+        }
+        Map<String, DomainAttributes> domainAttributes = localChangeLogStore.getLocalDomainAttributeList();
+        domainAttributes.entrySet().removeIf(entry -> !isDomainAllowed(entry.getKey()));
+        return domainAttributes;
     }
 
     public boolean getAllDomains(List<String> domains) {
@@ -434,9 +602,14 @@ public class S3ChangeLogStore implements ChangeLogStore {
         // been deleted, we're going to get a new s3 client
         // instead of using our original client
 
-        HashSet<String> domains = new HashSet<>();
-        listObjects(getS3Client(), domains, 0);
-        return domains;
+        try {
+            HashSet<String> domains = new HashSet<>();
+            listObjects(getS3Client(), domains, 0);
+            return domains;
+        } catch (Exception ex) {
+            LOGGER.error("S3ChangeLogStore: unable to retrieve domain list from S3", ex);
+            return null;
+        }
     }
 
     /**
@@ -535,6 +708,9 @@ public class S3ChangeLogStore implements ChangeLogStore {
             lastModTime = 0;
         } else {
             lastModTime = Long.parseLong(newLastModTime);
+        }
+        if (localChangeLogStore != null) {
+            localChangeLogStore.setLastModificationTimestamp(newLastModTime);
         }
     }
 

--- a/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreFactory.java
+++ b/libs/java/server_aws_common/src/main/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreFactory.java
@@ -19,13 +19,18 @@ package io.athenz.server.aws.common.store.impl;
 import com.yahoo.athenz.common.server.store.ChangeLogStore;
 import com.yahoo.athenz.common.server.store.ChangeLogStoreFactory;
 
+import java.io.File;
 import java.security.PrivateKey;
+
+import static com.yahoo.athenz.common.ServerCommonConsts.PROP_DATA_STORE_SUBDIR;
 
 public class S3ChangeLogStoreFactory implements ChangeLogStoreFactory {
 
     @Override
     public ChangeLogStore create(String ztsHomeDir, PrivateKey privateKey, String privateKeyId) {
-        return new S3ChangeLogStore();
+        final File rootDirectory = ztsHomeDir == null ? null :
+                new File(ztsHomeDir, System.getProperty(PROP_DATA_STORE_SUBDIR, "zts_store"));
+        return new S3ChangeLogStore(rootDirectory);
     }
 
 }

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/MockS3ChangeLogStore.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/MockS3ChangeLogStore.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.mock;
 import org.mockito.Mockito;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.io.File;
 import java.util.concurrent.ExecutorService;
 
 class MockS3ChangeLogStore extends S3ChangeLogStore {
@@ -36,6 +37,11 @@ class MockS3ChangeLogStore extends S3ChangeLogStore {
         super();
         awsS3Client = mock(S3Client.class);
         this.execService = executorService;
+    }
+
+    public MockS3ChangeLogStore(File rootDirectory) {
+        super(rootDirectory);
+        awsS3Client = mock(S3Client.class);
     }
 
     void resetAWSS3Client() {

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreFactoryTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreFactoryTest.java
@@ -18,6 +18,10 @@ package io.athenz.server.aws.common.store.impl;
 import com.yahoo.athenz.common.server.store.ChangeLogStore;
 import org.testng.annotations.Test;
 
+import java.io.File;
+import java.nio.file.Files;
+
+import static com.yahoo.athenz.common.ServerCommonConsts.PROP_DATA_STORE_SUBDIR;
 import static com.yahoo.athenz.common.ServerCommonConsts.ZTS_PROP_AWS_BUCKET_NAME;
 import static com.yahoo.athenz.common.ServerCommonConsts.ZTS_PROP_AWS_REGION_NAME;
 import static org.testng.Assert.*;
@@ -35,5 +39,38 @@ public class S3ChangeLogStoreFactoryTest {
 
         System.clearProperty(ZTS_PROP_AWS_BUCKET_NAME);
         System.clearProperty(ZTS_PROP_AWS_REGION_NAME);
+    }
+
+    @Test
+    public void testCreateStoreWithLocalFileCache() throws Exception {
+        System.setProperty(ZTS_PROP_AWS_BUCKET_NAME, "s3-unit-test-bucket-name");
+        System.setProperty(ZTS_PROP_AWS_REGION_NAME, "us-west-1");
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-factory-test").toFile();
+        try {
+            S3ChangeLogStoreFactory factory = new S3ChangeLogStoreFactory();
+            ChangeLogStore store = factory.create(rootDirectory.getPath(), null, null);
+            assertNotNull(store);
+            assertTrue(new File(rootDirectory, System.getProperty(PROP_DATA_STORE_SUBDIR, "zts_store")).isDirectory());
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(ZTS_PROP_AWS_BUCKET_NAME);
+            System.clearProperty(ZTS_PROP_AWS_REGION_NAME);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    private void deleteDirectory(File directory) {
+        if (directory == null || !directory.exists()) {
+            return;
+        }
+        File[] files = directory.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                deleteDirectory(file);
+            }
+        }
+        assertTrue(directory.delete());
     }
 }

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreTest.java
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.*;
 import static org.testng.Assert.*;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.net.URI;
 import java.security.cert.X509Certificate;
 import java.util.*;
@@ -43,6 +45,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.*;
+import com.yahoo.athenz.zms.DomainAttributes;
 import com.yahoo.athenz.zms.DomainData;
 import com.yahoo.athenz.zms.SignedDomain;
 import com.yahoo.athenz.zms.SignedDomains;
@@ -57,6 +60,7 @@ public class S3ChangeLogStoreTest {
         System.setProperty(ZTS_PROP_AWS_BUCKET_NAME, "s3-unit-test-bucket-name");
         System.setProperty(ZTS_PROP_AWS_REGION_NAME, "test-region");
         System.clearProperty("athenz.zts.s3_change_log_store_domain_filter");
+        System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
     }
 
     @Test
@@ -105,6 +109,321 @@ public class S3ChangeLogStoreTest {
 
         store.setLastModificationTimestamp(null);
         assertEquals(store.lastModTime, 0);
+    }
+
+    @Test
+    public void testLocalFileCacheRequiresRootDirectory() {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        try {
+            new S3ChangeLogStore();
+            fail();
+        } catch (RuntimeException ex) {
+            assertTrue(ex.getMessage().contains("local cache root directory cannot be null"));
+        } finally {
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheSignedDomain() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            SignedDomain signedDomain = new SignedDomain().setDomain(new DomainData().setName("iaas"));
+            store.saveLocalDomain("iaas", signedDomain);
+            store.setLastModificationTimestamp("12345");
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            mockS3DomainList(cachedStore, "iaas");
+            assertEquals(cachedStore.lastModTime, 12345);
+            List<String> domains = cachedStore.getLocalDomainList();
+            assertEquals(domains.size(), 1);
+            assertEquals(domains.get(0), "iaas");
+
+            SignedDomain cachedDomain = cachedStore.getLocalSignedDomain("iaas");
+            assertNotNull(cachedDomain);
+            assertEquals(cachedDomain.getDomain().getName(), "iaas");
+            verify(cachedStore.awsS3Client, times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+            verify(cachedStore.awsS3Client, never()).getObject(any(GetObjectRequest.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheFallbackForCorruptSignedDomain() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            store.saveLocalDomain("iaas", new SignedDomain().setDomain(new DomainData().setName("iaas")));
+            store.setLastModificationTimestamp("12345");
+            Files.write(new File(rootDirectory, "iaas").toPath(), "invalid".getBytes(StandardCharsets.UTF_8));
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            mockS3Object(cachedStore, "iaas", "src/test/resources/iaas.json");
+
+            SignedDomain cachedDomain = cachedStore.getLocalSignedDomain("iaas");
+            assertNotNull(cachedDomain);
+            assertEquals(cachedDomain.getDomain().getName(), "iaas");
+
+            cachedDomain = cachedStore.getLocalSignedDomain("iaas");
+            assertNotNull(cachedDomain);
+            assertEquals(cachedDomain.getDomain().getName(), "iaas");
+            verify(cachedStore.awsS3Client, times(1)).getObject(any(GetObjectRequest.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheServerDomainListUsesS3ObjectNamesOnly() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            store.saveLocalDomain("iaas", new SignedDomain().setDomain(new DomainData().setName("iaas")));
+            store.setLastModificationTimestamp("12345");
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            mockS3DomainList(cachedStore, "iaas");
+            assertFalse(cachedStore.getLocalDomainList().isEmpty());
+            verify(cachedStore.awsS3Client, times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+
+            ListObjectsV2Response mockListObjectsV2Response = mock(ListObjectsV2Response.class);
+            ArrayList<S3Object> objectList = new ArrayList<>();
+            objectList.add(S3Object.builder().key("iaas").build());
+            when(mockListObjectsV2Response.contents()).thenReturn(objectList);
+            when(mockListObjectsV2Response.isTruncated()).thenReturn(false);
+            when(cachedStore.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(mockListObjectsV2Response);
+
+            Set<String> domains = cachedStore.getServerDomainList();
+            assertEquals(domains.size(), 1);
+            assertTrue(domains.contains("iaas"));
+            verify(cachedStore.awsS3Client, times(2)).listObjectsV2(any(ListObjectsV2Request.class));
+            verify(cachedStore.awsS3Client, never()).getObject(any(GetObjectRequest.class));
+
+            cachedStore.getLocalDomainList();
+            domains = cachedStore.getServerDomainList();
+            assertEquals(domains.size(), 1);
+            assertTrue(domains.contains("iaas"));
+            verify(cachedStore.awsS3Client, times(4)).listObjectsV2(any(ListObjectsV2Request.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheAppliesDomainFilter() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        System.setProperty("athenz.zts.s3_change_log_store_domain_filter", "athenz");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            store.saveLocalDomain("iaas", new SignedDomain().setDomain(new DomainData().setName("iaas")));
+            store.saveLocalDomain("athenz", new SignedDomain().setDomain(new DomainData().setName("athenz")));
+            store.setLastModificationTimestamp("12345");
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            mockS3DomainList(cachedStore, "iaas", "athenz");
+            List<String> domains = cachedStore.getLocalDomainList();
+            assertEquals(domains.size(), 1);
+            assertEquals(domains.get(0), "athenz");
+
+            Map<String, DomainAttributes> domainAttributes = cachedStore.getLocalDomainAttributeList();
+            assertEquals(domainAttributes.size(), 1);
+            assertTrue(domainAttributes.containsKey("athenz"));
+            assertFalse(domainAttributes.containsKey("iaas"));
+            verify(cachedStore.awsS3Client, times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+            verify(cachedStore.awsS3Client, never()).getObject(any(GetObjectRequest.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+            System.clearProperty("athenz.zts.s3_change_log_store_domain_filter");
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheJWSDomain() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            JWSDomain jwsDomain = new JWSDomain().setPayload("payload").setProtectedHeader("header").setSignature("signature");
+            store.saveLocalDomain("iaas", jwsDomain);
+            store.setLastModificationTimestamp("12345");
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            JWSDomain cachedDomain = cachedStore.getLocalJWSDomain("iaas");
+            assertNotNull(cachedDomain);
+            assertEquals(cachedDomain.getPayload(), "payload");
+            verify(cachedStore.awsS3Client, never()).listObjectsV2(any(ListObjectsV2Request.class));
+            verify(cachedStore.awsS3Client, never()).getObject(any(GetObjectRequest.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheFallbackForCorruptJWSDomain() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            store.saveLocalDomain("iaas", new JWSDomain().setPayload("payload"));
+            store.setLastModificationTimestamp("12345");
+            Files.write(new File(rootDirectory, "iaas").toPath(), "invalid".getBytes(StandardCharsets.UTF_8));
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            cachedStore.setJWSDomainSupport(true);
+            mockS3Object(cachedStore, "iaas", "src/test/resources/iaas.jws");
+
+            JWSDomain cachedDomain = cachedStore.getLocalJWSDomain("iaas");
+            assertNotNull(cachedDomain);
+            assertNotNull(cachedDomain.getPayload());
+
+            cachedDomain = cachedStore.getLocalJWSDomain("iaas");
+            assertNotNull(cachedDomain);
+            assertNotNull(cachedDomain.getPayload());
+            verify(cachedStore.awsS3Client, times(1)).getObject(any(GetObjectRequest.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheFetchesMissingSignedDomainFromS3() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            store.saveLocalDomain("athenz", new SignedDomain().setDomain(new DomainData().setName("athenz")));
+            store.setLastModificationTimestamp("12345");
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            mockS3DomainList(cachedStore, "athenz", "iaas");
+            mockS3Object(cachedStore, "iaas", "src/test/resources/iaas.json");
+
+            List<String> domains = cachedStore.getLocalDomainList();
+            assertEquals(new HashSet<>(domains), new HashSet<>(Arrays.asList("athenz", "iaas")));
+            assertTrue(new File(rootDirectory, "iaas").exists());
+
+            SignedDomain cachedDomain = cachedStore.getLocalSignedDomain("iaas");
+            assertNotNull(cachedDomain);
+            assertEquals(cachedDomain.getDomain().getName(), "iaas");
+            verify(cachedStore.awsS3Client, times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+            verify(cachedStore.awsS3Client, times(1)).getObject(any(GetObjectRequest.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheResetsLastModTimeWhenMissingDomainListFails() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            store.saveLocalDomain("athenz", new SignedDomain().setDomain(new DomainData().setName("athenz")));
+            store.setLastModificationTimestamp("12345");
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            S3Exception s3Exception = Mockito.mock(S3Exception.class);
+            when(s3Exception.getMessage()).thenReturn("failed list operation");
+            when(cachedStore.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenThrow(s3Exception);
+
+            List<String> domains = cachedStore.getLocalDomainList();
+            assertEquals(domains.size(), 1);
+            assertEquals(domains.get(0), "athenz");
+            assertEquals(cachedStore.lastModTime, 0);
+            assertNull(cachedStore.localChangeLogStore.lastModTime);
+            verify(cachedStore.awsS3Client, times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+            verify(cachedStore.awsS3Client, never()).getObject(any(GetObjectRequest.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheResetsLastModTimeWhenMissingSignedDomainFetchFails() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            store.saveLocalDomain("athenz", new SignedDomain().setDomain(new DomainData().setName("athenz")));
+            store.setLastModificationTimestamp("12345");
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            mockS3DomainList(cachedStore, "athenz", "iaas");
+
+            List<String> domains = cachedStore.getLocalDomainList();
+            assertEquals(domains.size(), 1);
+            assertEquals(domains.get(0), "athenz");
+            assertEquals(cachedStore.lastModTime, 0);
+            assertNull(cachedStore.localChangeLogStore.lastModTime);
+            assertFalse(new File(rootDirectory, "iaas").exists());
+            verify(cachedStore.awsS3Client, times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+            verify(cachedStore.awsS3Client, times(1)).getObject(any(GetObjectRequest.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheFetchesMissingJWSDomainFromS3() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            store.saveLocalDomain("athenz", new JWSDomain().setPayload("payload"));
+            store.setLastModificationTimestamp("12345");
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            cachedStore.setJWSDomainSupport(true);
+            mockS3DomainList(cachedStore, "athenz", "iaas");
+            mockS3Object(cachedStore, "iaas", "src/test/resources/iaas.jws");
+
+            List<String> domains = cachedStore.getLocalDomainList();
+            assertEquals(new HashSet<>(domains), new HashSet<>(Arrays.asList("athenz", "iaas")));
+            assertTrue(new File(rootDirectory, "iaas").exists());
+
+            JWSDomain cachedDomain = cachedStore.getLocalJWSDomain("iaas");
+            assertNotNull(cachedDomain);
+            assertNotNull(cachedDomain.getPayload());
+            verify(cachedStore.awsS3Client, times(1)).listObjectsV2(any(ListObjectsV2Request.class));
+            verify(cachedStore.awsS3Client, times(1)).getObject(any(GetObjectRequest.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
+    }
+
+    @Test
+    public void testLocalFileCacheMissingLastModTimeDeletesDomains() throws IOException {
+        System.setProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE, "true");
+        File rootDirectory = Files.createTempDirectory("s3-change-log-store-test").toFile();
+        try {
+            MockS3ChangeLogStore store = new MockS3ChangeLogStore(rootDirectory);
+            store.saveLocalDomain("iaas", new SignedDomain().setDomain(new DomainData().setName("iaas")));
+            assertTrue(new File(rootDirectory, "iaas").exists());
+
+            MockS3ChangeLogStore cachedStore = new MockS3ChangeLogStore(rootDirectory);
+            assertFalse(new File(rootDirectory, "iaas").exists());
+            assertTrue(cachedStore.getLocalDomainList().isEmpty());
+            verify(cachedStore.awsS3Client, never()).listObjectsV2(any(ListObjectsV2Request.class));
+        } finally {
+            deleteDirectory(rootDirectory);
+            System.clearProperty(S3ChangeLogStore.ZTS_PROP_S3_CHANGE_LOG_STORE_LOCAL_CACHE);
+        }
     }
 
     @Test
@@ -705,7 +1024,7 @@ public class S3ChangeLogStoreTest {
     @Test
     public void initNoRegionException() {
         System.clearProperty(ZTS_PROP_AWS_REGION_NAME);
-        S3ChangeLogStore store = new S3ChangeLogStore(null);
+        S3ChangeLogStore store = new S3ChangeLogStore((String) null);
         try {
             store.getS3Client();
             fail();
@@ -1281,5 +1600,37 @@ public class S3ChangeLogStoreTest {
         assertEquals(domains.size(), 2);
         assertTrue(domains.contains("iaas"));
         assertTrue(domains.contains("iaas.athenz"));
+    }
+
+    private void deleteDirectory(File directory) {
+        if (directory == null || !directory.exists()) {
+            return;
+        }
+        File[] files = directory.listFiles();
+        if (files != null) {
+            for (File file : files) {
+                deleteDirectory(file);
+            }
+        }
+        assertTrue(directory.delete());
+    }
+
+    private void mockS3DomainList(MockS3ChangeLogStore store, String... domainNames) {
+        ListObjectsV2Response mockListObjectsV2Response = mock(ListObjectsV2Response.class);
+        ArrayList<S3Object> objectList = new ArrayList<>();
+        for (String domainName : domainNames) {
+            objectList.add(S3Object.builder().key(domainName).build());
+        }
+        when(mockListObjectsV2Response.contents()).thenReturn(objectList);
+        when(mockListObjectsV2Response.isTruncated()).thenReturn(false);
+        when(store.awsS3Client.listObjectsV2(any(ListObjectsV2Request.class))).thenReturn(mockListObjectsV2Response);
+    }
+
+    private void mockS3Object(MockS3ChangeLogStore store, String domainName, String resourcePath) throws FileNotFoundException {
+        GetObjectResponse response = Mockito.mock(GetObjectResponse.class);
+        ResponseInputStream<GetObjectResponse> s3Is = new ResponseInputStream<>(response, new FileInputStream(resourcePath));
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket("s3-unit-test-bucket-name")
+                .key(domainName).build();
+        when(store.awsS3Client.getObject(getObjectRequest)).thenReturn(s3Is);
     }
 }

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreTest.java
@@ -762,6 +762,7 @@ public class S3ChangeLogStoreTest {
         // also verify that last mod time is not updated
         
         assertEquals(store.lastModTime, 0);
+        verify(store.awsS3Client).close();
     }
     
     @Test

--- a/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreTest.java
+++ b/libs/java/server_aws_common/src/test/java/io/athenz/server/aws/common/store/impl/S3ChangeLogStoreTest.java
@@ -851,6 +851,57 @@ public class S3ChangeLogStoreTest {
     }
 
     @Test
+    public void testGetSignedDomainFromS3RefreshesAndClosesClientOnFailure() throws IOException {
+        ClientRefreshingS3ChangeLogStore store = new ClientRefreshingS3ChangeLogStore();
+        S3Client oldClient = mock(S3Client.class);
+        S3Client newClient = mock(S3Client.class);
+        store.addS3Client(oldClient);
+        store.addS3Client(newClient);
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket("s3-unit-test-bucket-name")
+                .key("iaas").build();
+        when(oldClient.getObject(getObjectRequest)).thenReturn(null);
+
+        GetObjectResponse response = Mockito.mock(GetObjectResponse.class);
+        ResponseInputStream<GetObjectResponse> s3Is = new ResponseInputStream<>(response,
+                new FileInputStream("src/test/resources/iaas.json"));
+        when(newClient.getObject(getObjectRequest)).thenReturn(s3Is);
+
+        SignedDomain signedDomain = store.getSignedDomainFromS3("iaas");
+        assertNotNull(signedDomain);
+        assertSame(store.getAwsS3Client(), newClient);
+        assertEquals(store.clientCreationCount, 2);
+        verify(oldClient).close();
+        verify(oldClient).getObject(getObjectRequest);
+        verify(newClient).getObject(getObjectRequest);
+        verify(newClient, never()).close();
+    }
+
+    @Test
+    public void testRefreshAwsS3ClientDoesNotCloseStaleClient() {
+        ClientRefreshingS3ChangeLogStore store = new ClientRefreshingS3ChangeLogStore();
+        S3Client staleClient = mock(S3Client.class);
+        S3Client currentClient = mock(S3Client.class);
+        store.awsS3Client = currentClient;
+
+        assertSame(store.refreshAwsS3Client(staleClient), currentClient);
+        assertEquals(store.clientCreationCount, 0);
+        verify(staleClient, never()).close();
+        verify(currentClient, never()).close();
+    }
+
+    @Test
+    public void testCloseS3ClientIgnoresCloseException() {
+        S3ChangeLogStore store = new S3ChangeLogStore("test-region");
+        S3Client s3Client = mock(S3Client.class);
+        doThrow(new RuntimeException("close failed")).when(s3Client).close();
+
+        store.closeS3Client(s3Client);
+
+        verify(s3Client).close();
+    }
+
+    @Test
     public void testGetServerSignedDomain() {
         MockS3ChangeLogStore store = new MockS3ChangeLogStore();
         assertNull(store.getServerSignedDomain("iaas"));
@@ -1279,6 +1330,33 @@ public class S3ChangeLogStoreTest {
     }
 
     @Test
+    public void testGetJWSDomainFromS3RefreshesAndClosesClientOnFailure() throws IOException {
+        ClientRefreshingS3ChangeLogStore store = new ClientRefreshingS3ChangeLogStore();
+        S3Client oldClient = mock(S3Client.class);
+        S3Client newClient = mock(S3Client.class);
+        store.addS3Client(oldClient);
+        store.addS3Client(newClient);
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket("s3-unit-test-bucket-name")
+                .key("iaas").build();
+        when(oldClient.getObject(getObjectRequest)).thenReturn(null);
+
+        GetObjectResponse response = Mockito.mock(GetObjectResponse.class);
+        ResponseInputStream<GetObjectResponse> s3Is = new ResponseInputStream<>(response,
+                new FileInputStream("src/test/resources/iaas.jws"));
+        when(newClient.getObject(getObjectRequest)).thenReturn(s3Is);
+
+        JWSDomain jwsDomain = store.getJWSDomainFromS3("iaas");
+        assertNotNull(jwsDomain);
+        assertSame(store.getAwsS3Client(), newClient);
+        assertEquals(store.clientCreationCount, 2);
+        verify(oldClient).close();
+        verify(oldClient).getObject(getObjectRequest);
+        verify(newClient).getObject(getObjectRequest);
+        verify(newClient, never()).close();
+    }
+
+    @Test
     public void testGetJWSDomainNotFound() {
         MockS3ChangeLogStore store = new MockS3ChangeLogStore();
         when(store.awsS3Client.getObject(any(GetObjectRequest.class))).thenReturn(null);
@@ -1632,5 +1710,24 @@ public class S3ChangeLogStoreTest {
         GetObjectRequest getObjectRequest = GetObjectRequest.builder().bucket("s3-unit-test-bucket-name")
                 .key(domainName).build();
         when(store.awsS3Client.getObject(getObjectRequest)).thenReturn(s3Is);
+    }
+
+    static class ClientRefreshingS3ChangeLogStore extends S3ChangeLogStore {
+        final Queue<S3Client> s3Clients = new ArrayDeque<>();
+        int clientCreationCount = 0;
+
+        ClientRefreshingS3ChangeLogStore() {
+            super("test-region");
+        }
+
+        void addS3Client(S3Client s3Client) {
+            s3Clients.add(s3Client);
+        }
+
+        @Override
+        S3Client getS3Client() {
+            clientCreationCount++;
+            return s3Clients.remove();
+        }
     }
 }

--- a/servers/zts/conf/zts.properties
+++ b/servers/zts/conf/zts.properties
@@ -155,6 +155,10 @@ athenz.zts.cert_signer_factory_class=com.yahoo.athenz.zts.cert.impl.SelfCertSign
 # class (athenz.zts.data_change_log_store_factory_class property)
 #athenz.zts.change_log_store_dir=/home/athenz/var/zts_server
 
+# Specifies if S3ChangeLogStoreFactory should maintain a local file cache
+# of domain json documents and the last S3 modification timestamp
+#athenz.zts.s3_change_log_store_local_cache=false
+
 # Boolean setting to force users to request role tokens for specific
 # roles rather than for domain which will includes all the roles the
 # given principal has access in that domain


### PR DESCRIPTION
# Description
This PR adds an opt-in local file cache to `S3ChangeLogStore`, similar to the cache used by `ZMSFileChangeLogStore`.

`S3ChangeLogStore` currently loads all domains from S3 during startup. In our environment, where the number of domains is large, this significantly slows down ZTS startup because every domain document must be fetched from S3. With this change, S3 domain documents and the last S3 modification timestamp can be cached locally, reducing the amount of S3 data that must be fetched on restart.

The cache is disabled by default and is enabled only when the new property is set:

```properties
athenz.zts.s3_change_log_store_local_cache=true
```

# Changes

- Added local file cache support to S3ChangeLogStore using ZMSFileChangeLogStoreCommon.
- Added the new property athenz.zts.s3_change_log_store_local_cache, defaulting to false.
- Updated S3ChangeLogStoreFactory to initialize the cache under the configured ZTS data store directory.
- Persisted signed/JWS domain documents and the last modification timestamp when local cache is enabled.
- Added fallback behavior to fetch missing or invalid cached domains from S3.
- Reset the cached last modification timestamp when missing-domain synchronization from S3 fails, so the next startup/update does not incorrectly skip data.
- Preserved domain filter behavior for cached domain lists and domain attributes.
- Added unit tests for local cache initialization, signed/JWS domain cache behavior, fallback from S3, domain filtering, missing domains, and failure handling.
- Documented the new property in ZTS configuration files.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

