### PR TITLE
move db lookup in status response into a separate thread

### DIFF
--- a/servers/zms/conf/zms.properties
+++ b/servers/zms/conf/zms.properties
@@ -420,6 +420,20 @@ athenz.zms.no_auth_uri_list=/zms/v1/schema
 # now report that the server is ready to accept production traffic
 #athenz.zms.health_check_path=
 
+# The frequency in seconds that the ZMS server will run its
+# background database health check task. This task verifies our
+# database connectivity by listing the system (sys.auth) domains
+# and stores the result in a flag. The /zms/v1/status command only
+# reads that flag instead of making a database call on every request,
+# thus keeping the status endpoint as fast as possible.
+#athenz.zms.db_health_check_frequency_seconds=10
+
+# Boolean value indicating whether the ZMS server should disable
+# the background database health check timer task. This is primarily
+# used during unit tests where the periodic task is not required.
+# The initial synchronous check is still carried out during startup.
+#athenz.zms.disable_db_health_check_timer_task=false
+
 # Boolean value indicating whether the ZMS server should
 # call the configured user authority and verify if the given
 # user is valid or not before adding the user to a role. The

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/DBHealthChecker.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/DBHealthChecker.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static com.yahoo.athenz.zms.ZMSConsts.*;
+
+/**
+ * This class creates a background daemon that periodically verifies our
+ * database connectivity by listing the system (sys.auth) domains and stores
+ * the result in a volatile flag. The getStatus handler only needs to read
+ * that flag instead of making a database call on every request, thus keeping
+ * the status endpoint as fast as possible.
+ */
+public class DBHealthChecker {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DBHealthChecker.class);
+
+    private static final String SYS_AUTH = "sys.auth";
+
+    private ScheduledExecutorService scheduledExecutor;
+    private final DBService dbService;
+    private volatile boolean domainsAvailable = false;
+
+    public DBHealthChecker(final DBService dbService) {
+        LOGGER.info("Initializing DBHealthChecker...");
+        this.dbService = dbService;
+
+        // run the check once synchronously so the flag reflects the current
+        // state of the database by the time the server starts serving requests
+
+        checkDomainsAvailability();
+
+        // only in case of test invocation we don't need to start the timer task
+
+        if (shouldDisableTimerTask()) {
+            LOGGER.info("Timer task is not started because {} is set to true",
+                    ZMS_PROP_DB_HEALTH_CHECK_DISABLE_TIMER);
+            return;
+        }
+        init();
+    }
+
+    private boolean shouldDisableTimerTask() {
+        return Boolean.parseBoolean(System.getProperty(ZMS_PROP_DB_HEALTH_CHECK_DISABLE_TIMER, "false"));
+    }
+
+    /**
+     * Create the scheduler that refreshes the domains availability flag
+     */
+    private void init() {
+        scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
+        long frequencySeconds = Long.parseLong(
+                System.getProperty(ZMS_PROP_DB_HEALTH_CHECK_FREQUENCY_SECONDS,
+                        ZMS_PROP_DB_HEALTH_CHECK_FREQUENCY_DEFAULT));
+        scheduledExecutor.scheduleAtFixedRate(this::checkDomainsAvailability, frequencySeconds,
+                frequencySeconds, TimeUnit.SECONDS);
+    }
+
+    /**
+     * Shutdown hook for the scheduler
+     */
+    public void shutdown() {
+        if (scheduledExecutor != null) {
+            scheduledExecutor.shutdownNow();
+        }
+    }
+
+    /**
+     * This method gets called on server start up as well as every configured
+     * time period. It verifies our database connectivity by listing the system
+     * domains and updates the domainsAvailable flag accordingly. Any failure
+     * (empty result or an exception) results in the flag being set to false.
+     */
+    void checkDomainsAvailability() {
+        try {
+            domainsAvailable = !dbService.listDomains(SYS_AUTH, 0, false).isEmpty();
+        } catch (Exception ex) {
+            LOGGER.error("Unable to verify database connectivity: {}", ex.getMessage());
+            domainsAvailable = false;
+        }
+    }
+
+    /**
+     * @return true if the system domains were available as of the last check
+     */
+    public boolean isDomainsAvailable() {
+        return domainsAvailable;
+    }
+}

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSConsts.java
@@ -259,6 +259,10 @@ public final class ZMSConsts {
     public static final String ZMS_PROP_EXTERNAL_MEMBER_VALIDATOR_FREQUENCY_MINUTES = "athenz.zms.external_member_validator_frequency_minutes";
     public static final String ZMS_PROP_EXTERNAL_MEMBER_VALIDATOR_FREQUENCY_DEFAULT = "60";
 
+    public static final String ZMS_PROP_DB_HEALTH_CHECK_FREQUENCY_SECONDS = "athenz.zms.db_health_check_frequency_seconds";
+    public static final String ZMS_PROP_DB_HEALTH_CHECK_FREQUENCY_DEFAULT = "10";
+    public static final String ZMS_PROP_DB_HEALTH_CHECK_DISABLE_TIMER = "athenz.zms.disable_db_health_check_timer_task";
+
     public static final String ZMS_PROP_QUOTA_ASSERTION_CONDITIONS = "athenz.zms.quota_assertion_conditions";
 
     public static final String ZMS_PROP_MAX_POLICY_VERSIONS_DEFAULT = "3";

--- a/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
+++ b/servers/zms/src/main/java/com/yahoo/athenz/zms/ZMSImpl.java
@@ -233,6 +233,7 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
     protected ServiceProviderManager serviceProviderManager;
     protected ServiceProviderClient serviceProviderClient;
     protected ExternalMemberValidatorManager externalMemberValidatorManager;
+    protected DBHealthChecker dbHealthChecker = null;
     protected Info serverInfo = null;
     protected Set<String> domainContactTypes = new HashSet<>();
     protected Set<String> domainEnvironments = new HashSet<>();
@@ -708,6 +709,10 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         initializeExternalMemberValidatorManager();
 
+        // Initialize the DB health checker used by the status endpoint
+
+        initializeDBHealthChecker();
+
         // load the domain change publisher
 
         loadDomainChangePublisher();
@@ -780,6 +785,10 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
     private void initializeExternalMemberValidatorManager() {
         externalMemberValidatorManager = new ExternalMemberValidatorManager(dbService);
+    }
+
+    private void initializeDBHealthChecker() {
+        dbHealthChecker = new DBHealthChecker(dbService);
     }
 
     private void setNotificationManager() {
@@ -10368,11 +10377,13 @@ public class ZMSImpl implements Authorizer, KeyStore, ZMSHandler {
 
         validateRequest(ctx.request(), caller, true);
 
-        // we're going to verify our database connectivity
-        // by listing our system domains. In case of failure
-        // we're going to return not found
+        // we're going to verify our database connectivity by checking the
+        // flag maintained by our background DB health checker. This avoids
+        // making a database call within this handler and keeps the status
+        // endpoint as fast as possible. In case of failure we're going to
+        // return not found
 
-        if (dbService.listDomains(SYS_AUTH, 0, false).isEmpty()) {
+        if (dbHealthChecker != null && !dbHealthChecker.isDomainsAvailable()) {
             throw ZMSUtils.notFoundError("Error - no domains available", caller);
         }
 

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/DBHealthCheckerTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/DBHealthCheckerTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright The Athenz Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.yahoo.athenz.zms;
+
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static org.testng.Assert.*;
+
+public class DBHealthCheckerTest {
+
+    @Mock private DBService dbService;
+
+    @BeforeMethod
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+        System.setProperty(ZMSConsts.ZMS_PROP_DB_HEALTH_CHECK_DISABLE_TIMER, "true");
+    }
+
+    @AfterMethod
+    public void tearDown() {
+        System.clearProperty(ZMSConsts.ZMS_PROP_DB_HEALTH_CHECK_DISABLE_TIMER);
+        System.clearProperty(ZMSConsts.ZMS_PROP_DB_HEALTH_CHECK_FREQUENCY_SECONDS);
+    }
+
+    @Test
+    public void testDomainsAvailable() {
+
+        Mockito.when(dbService.listDomains("sys.auth", 0, false))
+                .thenReturn(Collections.singletonList("sys.auth"));
+
+        DBHealthChecker checker = new DBHealthChecker(dbService);
+        assertTrue(checker.isDomainsAvailable());
+
+        checker.shutdown();
+    }
+
+    @Test
+    public void testDomainsNotAvailableEmptyList() {
+
+        Mockito.when(dbService.listDomains("sys.auth", 0, false))
+                .thenReturn(Collections.emptyList());
+
+        DBHealthChecker checker = new DBHealthChecker(dbService);
+        assertFalse(checker.isDomainsAvailable());
+
+        checker.shutdown();
+    }
+
+    @Test
+    public void testDomainsNotAvailableDbException() {
+
+        Mockito.when(dbService.listDomains("sys.auth", 0, false))
+                .thenThrow(new ResourceException(500, "DB Error"));
+
+        DBHealthChecker checker = new DBHealthChecker(dbService);
+        assertFalse(checker.isDomainsAvailable());
+
+        checker.shutdown();
+    }
+
+    @Test
+    public void testCheckDomainsAvailabilityStateTransition() {
+
+        Mockito.when(dbService.listDomains("sys.auth", 0, false))
+                .thenReturn(Collections.singletonList("sys.auth"))
+                .thenReturn(Collections.emptyList())
+                .thenReturn(Collections.singletonList("sys.auth"));
+
+        DBHealthChecker checker = new DBHealthChecker(dbService);
+        assertTrue(checker.isDomainsAvailable());
+
+        // second check returns empty list - flag should turn false
+
+        checker.checkDomainsAvailability();
+        assertFalse(checker.isDomainsAvailable());
+
+        // third check returns a domain again - flag should turn true
+
+        checker.checkDomainsAvailability();
+        assertTrue(checker.isDomainsAvailable());
+
+        checker.shutdown();
+    }
+
+    @Test
+    public void testTimerTaskEnabled() {
+
+        // enable the timer task with a short frequency to exercise the init path
+
+        System.clearProperty(ZMSConsts.ZMS_PROP_DB_HEALTH_CHECK_DISABLE_TIMER);
+        System.setProperty(ZMSConsts.ZMS_PROP_DB_HEALTH_CHECK_FREQUENCY_SECONDS, "1");
+
+        Mockito.when(dbService.listDomains("sys.auth", 0, false))
+                .thenReturn(Collections.singletonList("sys.auth"));
+
+        DBHealthChecker checker = new DBHealthChecker(dbService);
+        assertTrue(checker.isDomainsAvailable());
+
+        checker.shutdown();
+    }
+
+    @Test
+    public void testShutdownWithoutTimer() {
+
+        Mockito.when(dbService.listDomains("sys.auth", 0, false))
+                .thenReturn(Collections.singletonList("sys.auth"));
+
+        DBHealthChecker checker = new DBHealthChecker(dbService);
+
+        // shutdown should be a no-op when the scheduler was never started
+        // and safe to call multiple times
+
+        checker.shutdown();
+        checker.shutdown();
+    }
+}

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSImplTest.java
@@ -18700,6 +18700,48 @@ public class ZMSImplTest {
     }
 
     @Test
+    public void testGetStatusNoDomainsAvailable() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        zmsImpl.statusPort = 0;
+
+        // simulate the background DB health checker having marked the
+        // database as unavailable - getStatus must return not found
+
+        DBHealthChecker dbHealthChecker = Mockito.mock(DBHealthChecker.class);
+        Mockito.when(dbHealthChecker.isDomainsAvailable()).thenReturn(false);
+        zmsImpl.dbHealthChecker = dbHealthChecker;
+
+        try {
+            zmsImpl.getStatus(ctx);
+            fail();
+        } catch (ResourceException ex) {
+            assertEquals(ex.getCode(), ResourceException.NOT_FOUND);
+        }
+
+        zmsImpl.objectStore.clearConnections();
+    }
+
+    @Test
+    public void testGetStatusNoDBHealthChecker() {
+
+        ZMSImpl zmsImpl = zmsTestInitializer.zmsInit();
+        RsrcCtxWrapper ctx = zmsTestInitializer.getMockDomRsrcCtx();
+        zmsImpl.statusPort = 0;
+
+        // if the DB health checker is not configured we skip the check
+        // and rely on the remaining status verifications
+
+        zmsImpl.dbHealthChecker = null;
+
+        Status status = zmsImpl.getStatus(ctx);
+        assertEquals(status.getCode(), ResourceException.OK);
+
+        zmsImpl.objectStore.clearConnections();
+    }
+
+    @Test
     public void testGetStatusWithStatusFile() throws IOException {
 
         System.setProperty(ZMSConsts.ZMS_PROP_HEALTH_CHECK_PATH, "/tmp/zms-healthcheck");

--- a/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestInitializer.java
+++ b/servers/zms/src/test/java/com/yahoo/athenz/zms/ZMSTestInitializer.java
@@ -159,6 +159,7 @@ public class ZMSTestInitializer {
                 "role,group,policy,service,domain,entity,tenancy,template");
         System.setProperty(ZMSConsts.ZMS_PROP_VALIDATE_ASSERTION_ROLES, "true");
         System.setProperty(ZMSConsts.ZMS_PROP_PRINCIPAL_STATE_UPDATER_DISABLE_TIMER, "true");
+        System.setProperty(ZMSConsts.ZMS_PROP_DB_HEALTH_CHECK_DISABLE_TIMER, "true");
         System.setProperty(ZMSConsts.ZMS_PROP_MAX_POLICY_VERSIONS, "5");
 
         String certPath = Resources.getResource("service.provider.cert.pem").getPath();


### PR DESCRIPTION
# Description

in the status response, we're checking to make sure our DB connection is valid and accessible. In AWS, the status response must come back within 2 secs. So if the DB is under heavy load (e.g. too many simultaneous requests), the response might take a little bit longer than 2 secs. However, Route53 health check assumes the server is not available which is not quite correct. We've now moved the db lookup into its own thread.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**

## Attach Screenshots (Optional) 

