### PR TITLE
zts-accesstoken/sia: add openid_issuer flag support

### DIFF
--- a/libs/go/sia/access/config/config.go
+++ b/libs/go/sia/access/config/config.go
@@ -24,6 +24,7 @@ type Role struct {
 	Roles                    []string `json:"roles,omitempty"`                       // the roles in the domain in which principal is a member
 	Expiry                   int      `json:"expires_in,omitempty"`                  // requested expiry time for access token in seconds
 	ProxyPrincipalSpiffeUris string   `json:"proxy_principal_spiffe_uris,omitempty"` // Proxy Principal Spiffe URIs to be included in the token
+	UseOpenIDIssuer          bool     `json:"openid_issuer,omitempty"`               // use OpenID Connect issuer instead of default athenz issuer
 }
 
 // AccessToken is the type that holds information AFTER processing the configuration
@@ -37,6 +38,7 @@ type AccessToken struct {
 	Gid                      int      // Gid of the file on disc
 	Expiry                   int      // Expiry of the access token
 	ProxyPrincipalSpiffeUris string   // Proxy Principal Spiffe URIs to be included in the token
+	UseOpenIDIssuer          bool     // use OpenID Connect issuer instead of default athenz issuer
 }
 
 type StoreTokenOptions int

--- a/libs/go/sia/access/tokens/tokens.go
+++ b/libs/go/sia/access/tokens/tokens.go
@@ -162,7 +162,7 @@ func Fetch(opts *config.TokenOptions) ([]string, []error) {
 		}
 		client.AddCredentials(UserAgent, opts.UserAgent)
 
-		res, err := client.PostAccessTokenRequest(zts.AccessTokenRequest(makeTokenRequest(t.Domain, t.Roles, t.Expiry, t.ProxyPrincipalSpiffeUris)))
+		res, err := client.PostAccessTokenRequest(zts.AccessTokenRequest(makeTokenRequest(t.Domain, t.Roles, t.Expiry, t.ProxyPrincipalSpiffeUris, t.UseOpenIDIssuer)))
 		if err != nil {
 			errs = append(errs, fmt.Errorf("unable to post access token request for domain: %q, roles: %v, err: %v", t.Domain, t.Roles, err))
 			continue
@@ -226,12 +226,15 @@ func TokenDirs(root string, tokens []config.AccessToken) []string {
 	return dirs
 }
 
-func makeTokenRequest(domain string, roles []string, expiryTime int, proxyPrincipalSpiffeUris string) string {
+func makeTokenRequest(domain string, roles []string, expiryTime int, proxyPrincipalSpiffeUris string, useOpenIDIssuer bool) string {
 	params := url.Values{}
 	params.Add("grant_type", "client_credentials")
 	params.Add("expires_in", strconv.Itoa(expiryTime))
 	if proxyPrincipalSpiffeUris != "" {
 		params.Add("proxy_principal_spiffe_uris", proxyPrincipalSpiffeUris)
+	}
+	if useOpenIDIssuer {
+		params.Add("openid_issuer", "true")
 	}
 
 	var scope string

--- a/libs/go/sia/access/tokens/tokens_test.go
+++ b/libs/go/sia/access/tokens/tokens_test.go
@@ -1077,6 +1077,20 @@ func assertParseJwt(a *assert.Assertions, token []byte) jwt.MapClaims {
 	return claims
 }
 
+func TestMakeTokenRequestOpenIDIssuer(t *testing.T) {
+	a := assert.New(t)
+
+	withoutFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false)
+	v, err := url.ParseQuery(withoutFlag)
+	a.NoError(err)
+	a.Empty(v.Get("openid_issuer"), "openid_issuer should be absent when flag is false")
+
+	withFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", true)
+	v, err = url.ParseQuery(withFlag)
+	a.NoError(err)
+	a.Equal("true", v.Get("openid_issuer"), "openid_issuer should be 'true' when flag is set")
+}
+
 // uid returns current user's uid
 func uid(t *testing.T) int {
 	u, err := user.Current()

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -735,6 +735,7 @@ func processAccessTokens(config *sc.Config, processedSvcs []sc.Service) ([]ac.Ac
 			Uid:                      processedSvc.Uid,
 			Gid:                      processedSvc.Gid,
 			ProxyPrincipalSpiffeUris: t.ProxyPrincipalSpiffeUris,
+			UseOpenIDIssuer:          t.UseOpenIDIssuer,
 		})
 	}
 	return accessTokens, nil

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -802,6 +802,7 @@ func processAccessTokens(config *sc.Config, processedSvcs []sc.Service) ([]ac.Ac
 			Uid:                      processedSvc.Uid,
 			Gid:                      processedSvc.Gid,
 			ProxyPrincipalSpiffeUris: t.ProxyPrincipalSpiffeUris,
+			UseOpenIDIssuer:          t.UseOpenIDIssuer,
 		})
 	}
 	return accessTokens, nil

--- a/utils/zts-accesstoken/zts-accesstoken.go
+++ b/utils/zts-accesstoken/zts-accesstoken.go
@@ -46,7 +46,7 @@ func printVersion() {
 func main() {
 	var domain, service, actor, svcKeyFile, svcCertFile, svcCACertFile, roles, ntokenFile, ztsURL, hdr, conf, accessToken, authzDetails, proxyPrincipalSpiffeUris string
 	var expireTime int
-	var proxy, validate, claims, tokenOnly, showVersion bool
+	var proxy, validate, claims, tokenOnly, showVersion, openidIssuer bool
 	flag.StringVar(&domain, "domain", "", "name of provider domain")
 	flag.StringVar(&service, "service", "", "name of provider service")
 	flag.StringVar(&roles, "roles", "", "comma separated list of provider roles")
@@ -67,6 +67,7 @@ func main() {
 	flag.BoolVar(&showVersion, "version", false, "Show version")
 	flag.BoolVar(&tokenOnly, "token-only", false, "Display the access token only")
 	flag.StringVar(&actor, "actor", "", "actor that may request on behalf of the principal")
+	flag.BoolVar(&openidIssuer, "openid-issuer", false, "use OpenID Connect issuer instead of default athenz issuer")
 	flag.Parse()
 
 	if showVersion {
@@ -77,7 +78,7 @@ func main() {
 	if validate {
 		validateAccessToken(accessToken, conf, claims)
 	} else {
-		fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor, proxy, expireTime, tokenOnly)
+		fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor, proxy, expireTime, tokenOnly, openidIssuer)
 	}
 }
 
@@ -123,7 +124,7 @@ func validateAccessToken(accessToken, conf string, showClaims bool) {
 	fmt.Println("Access Token successfully validated")
 }
 
-func fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor string, proxy bool, expireTime int, tokenOnly bool) {
+func fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor string, proxy bool, expireTime int, tokenOnly bool, openidIssuer bool) {
 
 	defaultConfig, _ := athenzutils.ReadDefaultConfig()
 	// check to see if we need to use zts url from our default config file
@@ -169,6 +170,12 @@ func fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, s
 	if actor != "" {
 		params := url.Values{}
 		params.Add("actor", actor)
+		request += "&" + params.Encode()
+	}
+
+	if openidIssuer {
+		params := url.Values{}
+		params.Add("openid_issuer", "true")
 		request += "&" + params.Encode()
 	}
 


### PR DESCRIPTION
The ZTS server supports an `openid_issuer` request parameter on the `/oauth2/token` endpoint that causes it to use the configured OpenID Connect issuer URL in the `iss` claim instead of the default `"athenz"` string. Neither `zts-accesstoken` nor the SIA access token fetcher exposed this option.

## Changes

### `utils/zts-accesstoken`
Adds a `-openid-issuer` boolean flag. When set, `openid_issuer=true` is appended to the token request body, matching the pattern already used by the `-actor` flag.

```
zts-accesstoken ... -openid-issuer
```

### `libs/go/sia`
Adds `openid_issuer` support to the SIA access token configuration:

- `access/config/config.go`: adds `UseOpenIDIssuer bool` to both `Role` (JSON config, key `"openid_issuer"`) and the processed `AccessToken` struct
- `access/tokens/tokens.go`: threads the field through `makeTokenRequest`, appending `openid_issuer=true` to the request body when set
- `options/options.go`, `aws/options/options.go`: maps `Role.UseOpenIDIssuer` → `AccessToken.UseOpenIDIssuer` during config processing

SIA config example (`access_tokens` is a map keyed by `"<domain>/<filename>"`):
```json
{
  "access_tokens": {
    "my.domain/admin": {
      "roles": ["admin"],
      "openid_issuer": true
    }
  }
}
```