### PR TITLE
Support role name in access token audience claim (role_in_aud_claim)

### DIFF
--- a/libs/go/sia/access/config/config.go
+++ b/libs/go/sia/access/config/config.go
@@ -24,6 +24,7 @@ type Role struct {
 	Roles                    []string `json:"roles,omitempty"`                       // the roles in the domain in which principal is a member
 	Expiry                   int      `json:"expires_in,omitempty"`                  // requested expiry time for access token in seconds
 	ProxyPrincipalSpiffeUris string   `json:"proxy_principal_spiffe_uris,omitempty"` // Proxy Principal Spiffe URIs to be included in the token
+	RoleInAudClaim           bool     `json:"role_in_aud_claim,omitempty"`           // include the role name in the audience claim when a single role is returned
 }
 
 // AccessToken is the type that holds information AFTER processing the configuration
@@ -37,6 +38,7 @@ type AccessToken struct {
 	Gid                      int      // Gid of the file on disc
 	Expiry                   int      // Expiry of the access token
 	ProxyPrincipalSpiffeUris string   // Proxy Principal Spiffe URIs to be included in the token
+	RoleInAudClaim           bool     // include the role name in the audience claim when a single role is returned
 }
 
 type StoreTokenOptions int

--- a/libs/go/sia/access/tokens/tokens.go
+++ b/libs/go/sia/access/tokens/tokens.go
@@ -162,7 +162,7 @@ func Fetch(opts *config.TokenOptions) ([]string, []error) {
 		}
 		client.AddCredentials(UserAgent, opts.UserAgent)
 
-		res, err := client.PostAccessTokenRequest(zts.AccessTokenRequest(makeTokenRequest(t.Domain, t.Roles, t.Expiry, t.ProxyPrincipalSpiffeUris)))
+		res, err := client.PostAccessTokenRequest(zts.AccessTokenRequest(makeTokenRequest(t.Domain, t.Roles, t.Expiry, t.ProxyPrincipalSpiffeUris, t.RoleInAudClaim)))
 		if err != nil {
 			errs = append(errs, fmt.Errorf("unable to post access token request for domain: %q, roles: %v, err: %v", t.Domain, t.Roles, err))
 			continue
@@ -226,12 +226,15 @@ func TokenDirs(root string, tokens []config.AccessToken) []string {
 	return dirs
 }
 
-func makeTokenRequest(domain string, roles []string, expiryTime int, proxyPrincipalSpiffeUris string) string {
+func makeTokenRequest(domain string, roles []string, expiryTime int, proxyPrincipalSpiffeUris string, roleInAudClaim bool) string {
 	params := url.Values{}
 	params.Add("grant_type", "client_credentials")
 	params.Add("expires_in", strconv.Itoa(expiryTime))
 	if proxyPrincipalSpiffeUris != "" {
 		params.Add("proxy_principal_spiffe_uris", proxyPrincipalSpiffeUris)
+	}
+	if roleInAudClaim {
+		params.Add("role_in_aud_claim", "true")
 	}
 
 	var scope string

--- a/libs/go/sia/access/tokens/tokens_test.go
+++ b/libs/go/sia/access/tokens/tokens_test.go
@@ -1077,6 +1077,20 @@ func assertParseJwt(a *assert.Assertions, token []byte) jwt.MapClaims {
 	return claims
 }
 
+func TestMakeTokenRequestRoleInAudClaim(t *testing.T) {
+	a := assert.New(t)
+
+	withoutFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", false)
+	v, err := url.ParseQuery(withoutFlag)
+	a.NoError(err)
+	a.Empty(v.Get("role_in_aud_claim"), "role_in_aud_claim should be absent when flag is false")
+
+	withFlag := makeTokenRequest("athenz.demo", []string{"role1"}, 3600, "", true)
+	v, err = url.ParseQuery(withFlag)
+	a.NoError(err)
+	a.Equal("true", v.Get("role_in_aud_claim"), "role_in_aud_claim should be 'true' when flag is set")
+}
+
 // uid returns current user's uid
 func uid(t *testing.T) int {
 	u, err := user.Current()

--- a/libs/go/sia/aws/options/options.go
+++ b/libs/go/sia/aws/options/options.go
@@ -735,6 +735,7 @@ func processAccessTokens(config *sc.Config, processedSvcs []sc.Service) ([]ac.Ac
 			Uid:                      processedSvc.Uid,
 			Gid:                      processedSvc.Gid,
 			ProxyPrincipalSpiffeUris: t.ProxyPrincipalSpiffeUris,
+			RoleInAudClaim:           t.RoleInAudClaim,
 		})
 	}
 	return accessTokens, nil

--- a/libs/go/sia/options/options.go
+++ b/libs/go/sia/options/options.go
@@ -802,6 +802,7 @@ func processAccessTokens(config *sc.Config, processedSvcs []sc.Service) ([]ac.Ac
 			Uid:                      processedSvc.Uid,
 			Gid:                      processedSvc.Gid,
 			ProxyPrincipalSpiffeUris: t.ProxyPrincipalSpiffeUris,
+			RoleInAudClaim:           t.RoleInAudClaim,
 		})
 	}
 	return accessTokens, nil

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -2273,6 +2273,11 @@ public class ZTSImpl implements ZTSHandler {
                 clientId + ":" + idTokenGroups.get(0) : clientId;
     }
 
+    String getAccessTokenAudience(final String domainName, boolean roleInAudClaim, List<String> roles) {
+        return (roleInAudClaim && roles != null && roles.size() == 1) ?
+                domainName + ":" + roles.get(0) : domainName;
+    }
+
     List<String> processIdTokenGroups(final String principalName, IdTokenScope tokenRequest,
                                       final String clientIdDomainName, Boolean allScopePresent,
                                       final String principalDomain, final String caller) {
@@ -3755,7 +3760,8 @@ public class ZTSImpl implements ZTSHandler {
         AccessToken accessToken = new AccessToken();
         accessToken.setVersion(1);
         accessToken.setJwtId(UUID.randomUUID().toString());
-        accessToken.setAudience(domainName);
+        accessToken.setAudience(getAccessTokenAudience(domainName, accessTokenRequest.isRoleInAudClaim(),
+                new ArrayList<>(roles)));
         accessToken.setClientId(principalName);
         accessToken.setIssueTime(iat);
         accessToken.setAuthTime(iat);

--- a/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
+++ b/servers/zts/src/main/java/com/yahoo/athenz/zts/ZTSImpl.java
@@ -3754,14 +3754,14 @@ public class ZTSImpl implements ZTSHandler {
                     caller, domainName, principalDomain);
         }
 
+        List<String> roleList = new ArrayList<>(roles);
         int tokenTimeout = determineTokenTimeout(data, roles, null, accessTokenRequest.getExpiryTime());
         long iat = System.currentTimeMillis() / 1000;
 
         AccessToken accessToken = new AccessToken();
         accessToken.setVersion(1);
         accessToken.setJwtId(UUID.randomUUID().toString());
-        accessToken.setAudience(getAccessTokenAudience(domainName, accessTokenRequest.isRoleInAudClaim(),
-                new ArrayList<>(roles)));
+        accessToken.setAudience(getAccessTokenAudience(domainName, accessTokenRequest.isRoleInAudClaim(), roleList));
         accessToken.setClientId(principalName);
         accessToken.setIssueTime(iat);
         accessToken.setAuthTime(iat);
@@ -3770,7 +3770,7 @@ public class ZTSImpl implements ZTSHandler {
         accessToken.setSubject(principalName);
         accessToken.setIssuer(issuerResolver.getAccessTokenIssuer(ctx.request(), accessTokenRequest.isUseOpenIDIssuer()));
         accessToken.setProxyPrincipal(proxyUser);
-        accessToken.setScope(new ArrayList<>(roles));
+        accessToken.setScope(roleList);
         accessToken.setAuthorizationDetails(accessTokenRequest.getAuthzDetails());
         accessToken.setPrincipalIssuer(principal.getIssuerIdentity());
 

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplAccessTokenTest.java
@@ -2460,6 +2460,42 @@ public class ZTSImplAccessTokenTest {
     }
 
     @Test
+    public void testPostAccessTokenRequestRoleInAudClaim() throws JOSEException {
+
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");
+
+        CloudStore cloudStore = new CloudStore();
+        ZTSImpl ztsImpl = new ZTSImpl(cloudStore, store);
+        // set back to our zts rsa private key
+        System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_private.pem");
+
+        SignedDomain signedDomain = createSignedDomain("coretech", "weather", "storage", true);
+        store.processSignedDomain(signedDomain, false);
+
+        Principal principal = SimplePrincipal.create("user_domain", "user",
+                "v=U1;d=user_domain;n=user;s=signature", 0, null);
+        ResourceContext context = createResourceContext(principal);
+
+        // request a single role with role_in_aud_claim=true; audience becomes domain:roleName
+        AccessTokenResponse resp = ztsImpl.postAccessTokenRequest(context,
+                "grant_type=client_credentials&scope=coretech:role.writers&role_in_aud_claim=true");
+        assertNotNull(resp);
+        assertNotNull(resp.getAccess_token());
+
+        ServerPrivateKey serverPrivateKey = getServerPrivateKey(ztsImpl, ztsImpl.keyAlgoForJsonWebObjects);
+        JWSVerifier verifier = JwtsHelper.getJWSVerifier(Crypto.extractPublicKey(serverPrivateKey.getKey()));
+        try {
+            SignedJWT signedJWT = SignedJWT.parse(resp.getAccess_token());
+            assertTrue(signedJWT.verify(verifier));
+
+            JWTClaimsSet claimSet = signedJWT.getJWTClaimsSet();
+            assertEquals(claimSet.getAudience().get(0), "coretech:writers");
+        } catch (ParseException ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
     public void testProcessJAGTokenExchangeRequestUserDomainTimeout() throws JOSEException {
 
         System.setProperty(FilePrivateKeyStore.ATHENZ_PROP_PRIVATE_KEY, "src/test/resources/unit_test_zts_at_private.pem");

--- a/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
+++ b/servers/zts/src/test/java/com/yahoo/athenz/zts/ZTSImplTest.java
@@ -13851,6 +13851,24 @@ public class ZTSImplTest {
         assertEquals(zts.getIdTokenAudience("id", Boolean.TRUE, idTokenGroups), "id");
     }
 
+    @Test
+    public void testGetAccessTokenAudience() {
+        assertEquals(zts.getAccessTokenAudience("sports", false, null), "sports");
+        assertEquals(zts.getAccessTokenAudience("sports", true, null), "sports");
+
+        List<String> roles = new ArrayList<>();
+        assertEquals(zts.getAccessTokenAudience("sports", false, roles), "sports");
+        assertEquals(zts.getAccessTokenAudience("sports", true, roles), "sports");
+
+        roles.add("writers");
+        assertEquals(zts.getAccessTokenAudience("sports", false, roles), "sports");
+        assertEquals(zts.getAccessTokenAudience("sports", true, roles), "sports:writers");
+
+        roles.add("readers");
+        assertEquals(zts.getAccessTokenAudience("sports", false, roles), "sports");
+        assertEquals(zts.getAccessTokenAudience("sports", true, roles), "sports");
+    }
+
     private ServerPrivateKey getServerPrivateKey(ZTSImpl ztsImpl, final String keyType) {
 
         // look for the preferred key type - RSA or EC.

--- a/utils/zts-accesstoken/zts-accesstoken.go
+++ b/utils/zts-accesstoken/zts-accesstoken.go
@@ -46,7 +46,7 @@ func printVersion() {
 func main() {
 	var domain, service, actor, svcKeyFile, svcCertFile, svcCACertFile, roles, ntokenFile, ztsURL, hdr, conf, accessToken, authzDetails, proxyPrincipalSpiffeUris string
 	var expireTime int
-	var proxy, validate, claims, tokenOnly, showVersion bool
+	var proxy, validate, claims, tokenOnly, showVersion, roleInAudClaim bool
 	flag.StringVar(&domain, "domain", "", "name of provider domain")
 	flag.StringVar(&service, "service", "", "name of provider service")
 	flag.StringVar(&roles, "roles", "", "comma separated list of provider roles")
@@ -67,6 +67,7 @@ func main() {
 	flag.BoolVar(&showVersion, "version", false, "Show version")
 	flag.BoolVar(&tokenOnly, "token-only", false, "Display the access token only")
 	flag.StringVar(&actor, "actor", "", "actor that may request on behalf of the principal")
+	flag.BoolVar(&roleInAudClaim, "role-in-aud-claim", false, "include the role name in the audience claim when a single role is returned")
 	flag.Parse()
 
 	if showVersion {
@@ -77,7 +78,7 @@ func main() {
 	if validate {
 		validateAccessToken(accessToken, conf, claims)
 	} else {
-		fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor, proxy, expireTime, tokenOnly)
+		fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor, proxy, expireTime, tokenOnly, roleInAudClaim)
 	}
 }
 
@@ -123,7 +124,7 @@ func validateAccessToken(accessToken, conf string, showClaims bool) {
 	fmt.Println("Access Token successfully validated")
 }
 
-func fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor string, proxy bool, expireTime int, tokenOnly bool) {
+func fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, svcCACertFile, ntokenFile, hdr, authzDetails, proxyPrincipalSpiffeUris, actor string, proxy bool, expireTime int, tokenOnly bool, roleInAudClaim bool) {
 
 	defaultConfig, _ := athenzutils.ReadDefaultConfig()
 	// check to see if we need to use zts url from our default config file
@@ -169,6 +170,12 @@ func fetchAccessToken(domain, service, roles, ztsURL, svcKeyFile, svcCertFile, s
 	if actor != "" {
 		params := url.Values{}
 		params.Add("actor", actor)
+		request += "&" + params.Encode()
+	}
+
+	if roleInAudClaim {
+		params := url.Values{}
+		params.Add("role_in_aud_claim", "true")
 		request += "&" + params.Encode()
 	}
 


### PR DESCRIPTION
# Description

Adds an option to place the role name in the `aud` claim of ZTS **access
tokens**, mirroring the existing `-role-in-aud-claim` support for OIDC id
tokens (added in #2190).

Today a standard (`client_credentials`) access token always uses the domain as
its audience (`aud=<domain>`), with roles carried only in the `scp`/`scope`
claim. A resource server that authorizes purely on the `aud` claim can
therefore only gate at "holds any role in the domain". This change lets such a
server enforce a tighter per-role gate using an access token — the same gating
`-role-in-aud-claim` already enables for id tokens.

The ZTS access-token endpoint already parsed the `role_in_aud_claim` request
parameter, but only the JAG token-exchange path honored it. This wires it into
the standard flow and exposes it through the `zts-accesstoken` CLI and SIA.

## Server (ZTS)
- `processAccessTokenStandardRequest` now sets the audience via a new
  `getAccessTokenAudience(...)` helper that mirrors `getIdTokenAudience`: when
  `role_in_aud_claim` is set and exactly one role is returned, the audience
  becomes `<domain>:<role>` instead of `<domain>`. Otherwise the audience is
  unchanged.
- No RDL / schema / generated-client change is needed — `role_in_aud_claim` is
  a form-body parameter already parsed by `AccessTokenRequest`.

## zts-accesstoken CLI
- New `-role-in-aud-claim` flag that adds `role_in_aud_claim=true` to the token
  request.

## SIA
- New `role_in_aud_claim` per-role option under `access_tokens`, threaded
  through the access-token request the SIA agent builds.

# Contribution Checklist:
- [x] **The pull request does not introduce any breaking changes**
- [x] **I have read the [contribution guidelines](https://github.com/AthenZ/athenz/blob/master/CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request.**
